### PR TITLE
Rs token

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub mod token;
+
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, String, Symbol};
 
 #[contracttype]

--- a/contracts/src/token.rs
+++ b/contracts/src/token.rs
@@ -1,0 +1,109 @@
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env};
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    CertificateContract,
+    Balance(Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TokenError {
+    AlreadyInitialized = 1,
+    NotAuthorized = 2,
+    InvalidAmount = 3,
+}
+
+#[contract]
+pub struct RsTokenContract;
+
+#[contractimpl]
+impl RsTokenContract {
+    /// Stores the certificate contract address allowed to mint RS-Tokens.
+    pub fn init(env: Env, certificate_contract: Address) {
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::CertificateContract)
+        {
+            panic_with_error!(&env, TokenError::AlreadyInitialized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CertificateContract, &certificate_contract);
+    }
+
+    /// Mints non-transferable RS-Tokens to a student.
+    /// Only the configured certificate contract address may call this.
+    pub fn mint(env: Env, caller: Address, student: Address, amount: i128) {
+        caller.require_auth();
+
+        let certificate_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::CertificateContract)
+            .unwrap();
+
+        if caller != certificate_contract {
+            panic_with_error!(&env, TokenError::NotAuthorized);
+        }
+
+        if amount <= 0 {
+            panic_with_error!(&env, TokenError::InvalidAmount);
+        }
+
+        let balance_key = DataKey::Balance(student);
+        let current_balance: i128 = env.storage().instance().get(&balance_key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&balance_key, &(current_balance + amount));
+    }
+
+    pub fn get_balance(env: Env, student: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Balance(student))
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    #[test]
+    fn mints_balance_for_student_when_called_by_certificate_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let certificate_contract = Address::generate(&env);
+        let student = Address::generate(&env);
+
+        RsTokenContract::init(env.clone(), certificate_contract.clone());
+        RsTokenContract::mint(
+            env.clone(),
+            certificate_contract,
+            student.clone(),
+            25,
+        );
+
+        assert_eq!(RsTokenContract::get_balance(env, student), 25);
+    }
+
+    #[test]
+    #[should_panic]
+    fn rejects_mint_from_non_certificate_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let certificate_contract = Address::generate(&env);
+        let unauthorized = Address::generate(&env);
+        let student = Address::generate(&env);
+
+        RsTokenContract::init(env.clone(), certificate_contract);
+        RsTokenContract::mint(env, unauthorized, student, 10);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the certificate system and adds a new non-transferable token contract. The certificate contract now supports issuing and retrieving certificates by a custom symbol, enabling multiple certificates to be managed. Additionally, a new `RsTokenContract` is introduced to mint non-transferable tokens, with strict authorization to ensure only the certificate contract can mint tokens for students.

**Certificate Contract Improvements:**
- Added a `symbol` field to the `Certificate` struct and updated the `issue` and `get_certificate` methods to use this symbol, allowing management of multiple certificates by unique symbols.
- Updated storage logic to use the symbol as the key, enabling retrieval of certificates by their unique symbol.
- Added unit tests to verify issuing and retrieving certificates with custom symbols.

**New Token Contract:**
- Introduced `RsTokenContract` in `token.rs`, a non-transferable token contract that allows only the configured certificate contract to mint tokens for students.
- Implemented strict authorization checks and error handling to prevent unauthorized minting and invalid token amounts.
- Added unit tests to ensure correct minting behavior and authorization enforcement.

Closes #13 