### PR TITLE
chore: add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  # Root npm dependencies (husky, lint-staged, concurrently)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # Backend npm dependencies (Express, Prisma, TypeScript)
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # Frontend npm dependencies (Next.js, React, Tailwind)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # Soroban smart contract Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # GitHub Actions workflow versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Closes #41

Adds `.github/dependabot.yml` to automate dependency update PRs. Covers all the ecosystems in this monorepo:

- **npm** — `/` (root), `/backend`, `/frontend`
- **cargo** — `/contracts` (Soroban smart contract)
- **github-actions** — keeps workflow action versions up to date

All set to run weekly on Mondays. PR limits are capped at 10 for npm and 5 for cargo/actions so it doesn't flood the repo. Each PR gets a `dependencies` label for easy filtering.