### PR TITLE
test: add comprehensive unit tests for get_certificate and fix token …

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -35,43 +35,10 @@ impl CertificateContract {
     }
 
     /// Retrieve a certificate by its symbol.
-    pub fn get_certificate(env: Env, symbol: Symbol) -> Certificate {
-        env.storage().instance().get(&symbol).unwrap()
+    pub fn get_certificate(env: Env, symbol: Symbol) -> Option<Certificate> {
+        env.storage().instance().get(&symbol)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use soroban_sdk::{symbol_short, testutils::Ledger, Env};
-
-    #[test]
-    fn issues_and_loads_certificate_with_custom_symbol() {
-        let env = Env::default();
-        env.ledger().with_mut(|ledger| ledger.timestamp = 1_234);
-
-        let symbol = symbol_short!("SOLID");
-        let student = String::from_str(&env, "Ada Lovelace");
-        let course_name = String::from_str(&env, "Rust 101");
-
-        let issued = CertificateContract::issue(
-            env.clone(),
-            symbol.clone(),
-            student.clone(),
-            course_name.clone(),
-        );
-
-        assert_eq!(
-            issued,
-            Certificate {
-                symbol: symbol.clone(),
-                student,
-                course_name,
-                issue_date: 1_234,
-            }
-        );
-
-        let stored = CertificateContract::get_certificate(env, symbol);
-        assert_eq!(stored, issued);
-    }
-}
+mod tests;

--- a/contracts/src/tests.rs
+++ b/contracts/src/tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+use soroban_sdk::{symbol_short, testutils::Ledger, Env, String};
+
+#[test]
+fn issues_and_loads_certificate_successfully() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_234);
+
+    let symbol = symbol_short!("SOLID");
+    let student = String::from_str(&env, "Ada Lovelace");
+    let course_name = String::from_str(&env, "Rust 101");
+
+    let issued = client.issue(
+        &symbol,
+        &student,
+        &course_name,
+    );
+
+    assert_eq!(
+        issued,
+        Certificate {
+            symbol: symbol.clone(),
+            student,
+            course_name,
+            issue_date: 1_234,
+        }
+    );
+
+    let stored = client.get_certificate(&symbol);
+    assert_eq!(stored, Some(issued));
+}
+
+#[test]
+fn returns_none_for_non_existent_certificate() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let symbol = symbol_short!("MISSIN");
+
+    let stored = client.get_certificate(&symbol);
+    assert!(stored.is_none());
+}

--- a/contracts/src/token.rs
+++ b/contracts/src/token.rs
@@ -75,13 +75,16 @@ mod tests {
         let env = Env::default();
         env.mock_all_auths();
 
+        let contract_id = env.register_contract(None, RsTokenContract);
+        let client = RsTokenContractClient::new(&env, &contract_id);
+
         let certificate_contract = Address::generate(&env);
         let student = Address::generate(&env);
 
-        RsTokenContract::init(env.clone(), certificate_contract.clone());
-        RsTokenContract::mint(env.clone(), certificate_contract, student.clone(), 25);
+        client.init(&certificate_contract);
+        client.mint(&certificate_contract, &student, &25);
 
-        assert_eq!(RsTokenContract::get_balance(env, student), 25);
+        assert_eq!(client.get_balance(&student), 25);
     }
 
     #[test]
@@ -90,11 +93,14 @@ mod tests {
         let env = Env::default();
         env.mock_all_auths();
 
+        let contract_id = env.register_contract(None, RsTokenContract);
+        let client = RsTokenContractClient::new(&env, &contract_id);
+
         let certificate_contract = Address::generate(&env);
         let unauthorized = Address::generate(&env);
         let student = Address::generate(&env);
 
-        RsTokenContract::init(env.clone(), certificate_contract);
-        RsTokenContract::mint(env, unauthorized, student, 10);
+        client.init(&certificate_contract);
+        client.mint(&unauthorized, &student, &10);
     }
 }

--- a/contracts/test_output.txt
+++ b/contracts/test_output.txt
@@ -1,0 +1,45 @@
+   Compiling soroban-certificate-contract v0.0.0 (/home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts)
+warning: use of deprecated method `soroban_sdk::Env::register_contract`: use `register`
+  --> src/token.rs:78:31
+   |
+78 |         let contract_id = env.register_contract(None, RsTokenContract);
+   |                               ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated method `soroban_sdk::Env::register_contract`: use `register`
+  --> src/token.rs:96:31
+   |
+96 |         let contract_id = env.register_contract(None, RsTokenContract);
+   |                               ^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::Env::register_contract`: use `register`
+ --> src/tests.rs:7:27
+  |
+7 |     let contract_id = env.register_contract(None, CertificateContract);
+  |                           ^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated method `soroban_sdk::Env::register_contract`: use `register`
+  --> src/tests.rs:39:27
+   |
+39 |     let contract_id = env.register_contract(None, CertificateContract);
+   |                           ^^^^^^^^^^^^^^^^^
+
+warning: `soroban-certificate-contract` (lib test) generated 4 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.06s
+     Running unittests src/lib.rs (target/debug/deps/soroban_certificate_contract-727423dd3195a6cc)
+
+running 4 tests
+test tests::returns_none_for_non_existent_certificate ... ok
+test token::tests::rejects_mint_from_non_certificate_contract - should panic ... ok
+test tests::issues_and_loads_certificate_successfully ... ok
+test token::tests::mints_balance_for_student_when_called_by_certificate_contract ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+   Doc-tests soroban_certificate_contract
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+

--- a/contracts/test_snapshots/tests/issues_and_loads_certificate_successfully.1.json
+++ b/contracts/test_snapshots/tests/issues_and_loads_certificate_successfully.1.json
@@ -1,0 +1,119 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1234,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "SOLID"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "course_name"
+                              },
+                              "val": {
+                                "string": "Rust 101"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "issue_date"
+                              },
+                              "val": {
+                                "u64": 1234
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "student"
+                              },
+                              "val": {
+                                "string": "Ada Lovelace"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "symbol": "SOLID"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/tests/returns_none_for_non_existent_certificate.1.json
+++ b/contracts/test_snapshots/tests/returns_none_for_non_existent_certificate.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/token/tests/mints_balance_for_student_when_called_by_certificate_contract.1.json
+++ b/contracts/test_snapshots/token/tests/mints_balance_for_student_when_called_by_certificate_contract.1.json
@@ -1,0 +1,169 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 25
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Balance"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 25
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CertificateContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/test_snapshots/token/tests/rejects_mint_from_non_certificate_contract.1.json
+++ b/contracts/test_snapshots/token/tests/rejects_mint_from_non_certificate_contract.1.json
@@ -1,0 +1,90 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CertificateContract"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Description
This PR adds comprehensive unit tests for the [get_certificate](cci:1://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:36:4-39:5) function in the [CertificateContract](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:16:0-16:31) and improves the function's safety by returning an `Option` type instead of panicking on missing records.

## Key Changes
- **Refined Signature**: Updated [get_certificate](cci:1://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:36:4-39:5) in [lib.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:0:0-0:0) to return `Option<Certificate>`, providing safer data retrieval for non-existent certificates.
- **New Test Suite**: Created [contracts/src/tests.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/tests.rs:0:0-0:0) with detailed unit tests for:
    - Successful certificate issuance and loading.
    - Retrieval cases where no certificate exists (returning `None`).
- **Test Infrastructure**: Fixed pre-existing failing tests in [token.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/token.rs:0:0-0:0) by transitioning them to use the `CertificateContractClient` for proper contract context in the Soroban environment.

## Requirements Covered
- [x] Update [contracts/src/lib.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:0:0-0:0) and create [contracts/src/tests.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/tests.rs:0:0-0:0).
- [x] Tests cover successful retrieval and cases where no certificate exists.
- [x] Passing tests via `cargo test`.

## Testing Instructions
1. Navigate to the `contracts` directory.
2. Run `cargo test` to execute the full suite of unit tests.
3. Observe that both [CertificateContract](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/lib.rs:16:0-16:31) and [RsTokenContract](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/Web3-Student-Lab/contracts/src/token.rs:18:0-18:27) tests now pass successfully.

Closes #36 