### PR TITLE
feat: Aggregation Layer to Optimize Frontend Dashboard API Payloads

### DIFF
--- a/backend/src/dashboard/dashboard.routes.ts
+++ b/backend/src/dashboard/dashboard.routes.ts
@@ -1,5 +1,8 @@
 import { Request, Response, Router } from 'express';
+import { authenticate } from '../auth/auth.middleware.js';
 import { getStudentDashboard, getStats } from './dashboard.service.js';
+import { getAggregatedDashboardData } from '../services/bff.service.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 
@@ -14,6 +17,24 @@ router.get('/stats', async (req: Request, res: Response) => {
     res.json(stats);
   } catch {
     res.status(500).json({ error: 'Failed to fetch platform stats' });
+  }
+});
+
+/**
+ * @route   GET /api/dashboard/me
+ * @desc    BFF aggregation endpoint: returns all dashboard data the frontend needs in one request.
+ *          Runs data fetchers concurrently (Promise.all), uses 30s in-memory cache, and
+ *          returns partial data if one module fails (graceful degradation).
+ * @access  Private
+ */
+router.get('/me', authenticate, async (req: Request, res: Response) => {
+  try {
+    const studentId = req.user!.id;
+    const aggregatedData = await getAggregatedDashboardData(studentId);
+    res.json(aggregatedData);
+  } catch (error) {
+    logger.error('BFF /me endpoint failed:', error);
+    res.status(500).json({ error: 'Failed to load dashboard data' });
   }
 });
 

--- a/backend/src/services/bff.service.ts
+++ b/backend/src/services/bff.service.ts
@@ -1,0 +1,55 @@
+import { getStudentDashboard } from '../dashboard/dashboard.service.js';
+import prisma from '../db/index.js';
+import logger from '../utils/logger.js';
+
+// Simple in-memory cache
+const cache = new Map<string, { data: any, timestamp: number }>();
+const CACHE_TTL = 30 * 1000; // 30 seconds
+
+export const getAggregatedDashboardData = async (studentId: string) => {
+  const cacheKey = `dashboard:${studentId}`;
+  const cached = cache.get(cacheKey);
+
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    logger.debug(`Returning cached dashboard data for ${studentId}`);
+    return cached.data;
+  }
+
+  // Define concurrent resolvers with individual error handling
+  const [dashboard, studentInfo, recentAuditLogs] = await Promise.all([
+    getStudentDashboard(studentId).catch(err => {
+      logger.error('BFF: Failed to fetch student dashboard:', err);
+      return null;
+    }),
+    prisma.student.findUnique({
+      where: { id: studentId },
+      select: { email: true, firstName: true, lastName: true, createdAt: true }
+    }).catch(err => {
+      logger.error('BFF: Failed to fetch student info:', err);
+      return null;
+    }),
+    prisma.auditLog.findMany({
+      where: { userId: studentId },
+      orderBy: { timestamp: 'desc' },
+      take: 5
+    }).catch(err => {
+      logger.error('BFF: Failed to fetch audit logs:', err);
+      return [];
+    })
+  ]);
+
+  const aggregatedData = {
+    profile: studentInfo,
+    dashboard: dashboard,
+    recentActivity: recentAuditLogs,
+    meta: {
+      generatedAt: new Date().toISOString(),
+      cacheTtl: CACHE_TTL / 1000
+    }
+  };
+
+  // Cache the result
+  cache.set(cacheKey, { data: aggregatedData, timestamp: Date.now() });
+
+  return aggregatedData;
+};


### PR DESCRIPTION
## Closes #213

## Summary
Implements a **Backend-For-Frontend (BFF) aggregation layer** that resolves all dashboard data concurrently and returns a single unified JSON payload — eliminating the N-request waterfall on the frontend dashboard.

## Changes

### New Files
- `backend/src/services/bff.service.ts` — Core aggregation service: runs Auth, Dashboard, and AuditLog resolvers concurrently via `Promise.all`, applies 30-second in-memory cache, and returns partial results if individual modules fail.

### Modified Files
- `backend/src/dashboard/dashboard.routes.ts` — Added the new `GET /api/v1/dashboard/me` endpoint (private, uses `authenticate` middleware) that calls the BFF service.

## Implementation Details

### Phase 1 — Unified JSON Payload Schema
The `/api/v1/dashboard/me` endpoint returns a single object:
```json
{
  "profile": { ... },
  "dashboard": { "progress": ..., "certificates": ..., "tokenBalance": ... },
  "recentActivity": [ ... ],
  "meta": { "generatedAt": "...", "cacheTtl": 30 }
}
```

### Phase 2 — Concurrent Resolvers (`Promise.all`)
Three data sources are fetched **simultaneously**:
1. `getStudentDashboard` — learning progress, blockchain achievements, token balance.
2. `prisma.student.findUnique` — profile info.
3. `prisma.auditLog.findMany` — last 5 activity entries.

### Phase 3 — Short-Lived In-Memory Cache (30s)
Results are stored in a `Map<string, { data, timestamp }>` keyed by `dashboard:<studentId>`. A cache hit bypasses all DB/service calls entirely, drastically reducing load for high-frequency dashboard polls.

### Phase 4 — Graceful Partial Failure Handling
Each resolver is wrapped in `.catch()` — if one module (e.g. blockchain service) fails, the other two still return data. The consumer receives partial but usable data rather than a 500 error.