### PR TITLE
fix: route GET reads to replica with primary lag fallback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -129,7 +129,7 @@
   "breadcrumbs.enabled": true,
   "workbench.editor.enablePreview": false,
   "workbench.editor.showTabs": "multiple",
-  "workbench.colorTheme": "Default Dark Modern",
+  "workbench.colorTheme": "Dark Modern",
   "workbench.iconTheme": "vs-seti",
   "terminal.integrated.shell.osx": "/bin/zsh",
   "terminal.integrated.fontSize": 14,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,14 @@ REFRESH_TOKEN_SECRET="refresh-secret-change-in-production"
 # PostgreSQL connection string
 # Format: postgresql://[user][:password]@[host]:[port]/[database][?schema=public]
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/web3-student-lab?schema=public"
+# Optional read-replica connection string. Falls back to DATABASE_URL when not provided.
+READ_DATABASE_URL=""
+# Native PostgreSQL pool controls used by Prisma's pg adapter
+DB_POOL_MAX=20
+DB_POOL_IDLE_TIMEOUT_MS=10000
+DB_POOL_CONNECTION_TIMEOUT_MS=5000
+# Keep reads on primary briefly after writes for replica lag tolerance
+DB_REPLICATION_LAG_WINDOW_MS=1000
 REDIS_URL="redis://localhost:6379"
 
 # For production, use a secure password and connection string

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1822,6 +1822,84 @@
         "node": ">=16"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3186,6 +3264,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3784,6 +3863,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmmirror.com/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4043,6 +4123,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4055,6 +4136,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -4279,15 +4361,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmmirror.com/dedent/-/dedent-1.7.2.tgz",
@@ -4425,12 +4498,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dijkstrajs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
-      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -4612,6 +4679,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/error-ex": {
@@ -5466,6 +5554,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5990,6 +6079,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7711,6 +7801,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmmirror.com/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7755,6 +7846,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8092,15 +8184,6 @@
         "pathe": "^2.0.3"
       }
     },
-    "node_modules/pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8326,182 +8409,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qrcode": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
-      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "dijkstrajs": "^1.0.1",
-        "pngjs": "^5.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/qrcode/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/qrcode/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.0.tgz",
@@ -8670,16 +8577,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "license": "ISC"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -8841,12 +8743,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9045,6 +8941,27 @@
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/socket.io-parser": {
@@ -9746,9 +9663,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -10056,12 +9971,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "license": "ISC"
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -10252,10 +10161,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10418,6 +10328,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
       "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },

--- a/backend/src/auth/auth.middleware.ts
+++ b/backend/src/auth/auth.middleware.ts
@@ -1,5 +1,6 @@
-import { Request, Response, NextFunction } from 'express';
-import { verifyToken, getStudentById } from './auth.service.js';
+import { NextFunction, Request, Response } from 'express';
+import { setDbRoutingUserId } from '../db/requestContext.js';
+import { getStudentById, verifyToken } from './auth.service.js';
 import { isAccessTokenBlacklisted } from './token.service.js';
 import { User } from './types.js';
 
@@ -57,6 +58,7 @@ export const authenticate = async (
 
     // Attach user to request object
     req.user = user;
+    setDbRoutingUserId(user.id);
 
     next();
   } catch (error) {
@@ -104,6 +106,7 @@ export const optionalAuth = async (
 
     if (user) {
       req.user = user;
+      setDbRoutingUserId(user.id);
     }
 
     next();

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,20 +1,155 @@
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
 import pg from 'pg';
+import { getDatabaseRoleForOperation } from './requestContext.js';
 
-const connectionString =
-  process.env.DATABASE_URL ||
+const DEFAULT_DATABASE_URL =
   'postgresql://postgres:postgres@localhost:5432/web3-student-lab?schema=public';
 
-const pool = new pg.Pool({ connectionString });
-const adapter = new PrismaPg(pool);
+const writeConnectionString =
+  process.env.DATABASE_URL ||
+  DEFAULT_DATABASE_URL;
+const readConnectionString = process.env.READ_DATABASE_URL || writeConnectionString;
+
+const parsePoolOption = (value: string | undefined, fallback: number): number => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+};
+
+const poolConfig: pg.PoolConfig = {
+  max: parsePoolOption(process.env.DB_POOL_MAX, 20),
+  idleTimeoutMillis: parsePoolOption(process.env.DB_POOL_IDLE_TIMEOUT_MS, 10000),
+  connectionTimeoutMillis: parsePoolOption(process.env.DB_POOL_CONNECTION_TIMEOUT_MS, 5000),
+};
+
+const hasDedicatedReadReplica = readConnectionString !== writeConnectionString;
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
+  prismaWrite: PrismaClient | undefined;
+  prismaRead: PrismaClient | undefined;
+  writePool: pg.Pool | undefined;
+  readPool: pg.Pool | undefined;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+const writePool =
+  globalForPrisma.writePool ??
+  new pg.Pool({
+    connectionString: writeConnectionString,
+    ...poolConfig,
+  });
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+const readPool = hasDedicatedReadReplica
+  ? globalForPrisma.readPool ??
+    new pg.Pool({
+      connectionString: readConnectionString,
+      ...poolConfig,
+    })
+  : writePool;
+
+const writeAdapter = new PrismaPg(writePool);
+const readAdapter = hasDedicatedReadReplica ? new PrismaPg(readPool) : writeAdapter;
+
+const prismaWrite = globalForPrisma.prismaWrite ?? new PrismaClient({ adapter: writeAdapter });
+const prismaRead = hasDedicatedReadReplica
+  ? globalForPrisma.prismaRead ?? new PrismaClient({ adapter: readAdapter })
+  : prismaWrite;
+
+const getClientForOperation = (operation: string): PrismaClient => {
+  if (!hasDedicatedReadReplica) {
+    return prismaWrite;
+  }
+
+  const role = getDatabaseRoleForOperation(operation);
+  return role === 'read' ? prismaRead : prismaWrite;
+};
+
+const isModelDelegate = (value: unknown): value is Record<string, unknown> => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return 'findUnique' in value && 'create' in value;
+};
+
+const createModelDelegateProxy = (modelName: string): object => {
+  return new Proxy(
+    {},
+    {
+      get(_target, operationKey: string | symbol) {
+        const operationName = String(operationKey);
+        const client = getClientForOperation(operationName);
+        const delegate = (client as unknown as Record<string, unknown>)[modelName] as
+          | Record<string, unknown>
+          | undefined;
+        const operation = delegate?.[operationKey as keyof typeof delegate];
+
+        if (typeof operation === 'function') {
+          return operation.bind(delegate);
+        }
+
+        return operation;
+      },
+    }
+  );
+};
+
+const prismaProxy = new Proxy(prismaWrite as PrismaClient, {
+  get(target, property, receiver) {
+    if (property === '$connect') {
+      return () => prismaWrite.$connect();
+    }
+
+    if (property === '$disconnect') {
+      return async () => {
+        await prismaWrite.$disconnect();
+        if (hasDedicatedReadReplica) {
+          await prismaRead.$disconnect();
+        }
+
+        await writePool.end();
+        if (hasDedicatedReadReplica) {
+          await readPool.end();
+        }
+      };
+    }
+
+    if (property === '$queryRaw' || property === '$queryRawUnsafe') {
+      const client = getClientForOperation('findMany');
+      const operation = (client as unknown as Record<string, unknown>)[property as string];
+      if (typeof operation === 'function') {
+        return operation.bind(client);
+      }
+
+      return operation;
+    }
+
+    const value = Reflect.get(target as object, property, receiver);
+
+    if (typeof value === 'function') {
+      return value.bind(prismaWrite);
+    }
+
+    if (typeof property === 'string' && isModelDelegate(value)) {
+      return createModelDelegateProxy(property);
+    }
+
+    return value;
+  },
+});
+
+export const prisma = globalForPrisma.prisma ?? prismaProxy;
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+  globalForPrisma.prismaWrite = prismaWrite;
+  globalForPrisma.prismaRead = prismaRead;
+  globalForPrisma.writePool = writePool;
+  globalForPrisma.readPool = readPool;
+}
 
 export default prisma;

--- a/backend/src/db/requestContext.ts
+++ b/backend/src/db/requestContext.ts
@@ -1,0 +1,97 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface DbRoutingContext {
+  method: string;
+  userId?: string;
+}
+
+type DatabaseRole = 'primary' | 'read';
+
+const READ_OPERATIONS = new Set<string>([
+  'findFirst',
+  'findFirstOrThrow',
+  'findMany',
+  'findUnique',
+  'findUniqueOrThrow',
+  'count',
+  'aggregate',
+  'groupBy',
+]);
+
+const DEFAULT_LAG_WINDOW_MS = 1000;
+
+const getLagWindowMs = (): number => {
+  const parsed = Number.parseInt(process.env.DB_REPLICATION_LAG_WINDOW_MS ?? '', 10);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_LAG_WINDOW_MS;
+  }
+
+  return parsed;
+};
+
+const routingContextStorage = new AsyncLocalStorage<DbRoutingContext>();
+const recentPrimaryReadUsers = new Map<string, number>();
+
+const pruneExpiredEntries = (now: number): void => {
+  const lagWindowMs = getLagWindowMs();
+
+  for (const [userId, timestamp] of recentPrimaryReadUsers.entries()) {
+    if (now - timestamp > lagWindowMs) {
+      recentPrimaryReadUsers.delete(userId);
+    }
+  }
+};
+
+const shouldForcePrimaryReadForUser = (userId: string): boolean => {
+  const now = Date.now();
+  pruneExpiredEntries(now);
+
+  const lastWriteAt = recentPrimaryReadUsers.get(userId);
+  if (lastWriteAt === undefined) {
+    return false;
+  }
+
+  return now - lastWriteAt <= getLagWindowMs();
+};
+
+export const runWithDbRoutingContext = (method: string, callback: () => void): void => {
+  routingContextStorage.run({ method }, callback);
+};
+
+export const setDbRoutingUserId = (userId: string): void => {
+  const store = routingContextStorage.getStore();
+  if (!store) {
+    return;
+  }
+
+  store.userId = userId;
+};
+
+export const markUserWriteToPrimary = (userId: string): void => {
+  const now = Date.now();
+  recentPrimaryReadUsers.set(userId, now);
+  pruneExpiredEntries(now);
+};
+
+export const getDatabaseRoleForOperation = (operation: string): DatabaseRole => {
+  const store = routingContextStorage.getStore();
+
+  if (!store || store.method !== 'GET') {
+    return 'primary';
+  }
+
+  if (!READ_OPERATIONS.has(operation)) {
+    return 'primary';
+  }
+
+  if (store.userId && shouldForcePrimaryReadForUser(store.userId)) {
+    return 'primary';
+  }
+
+  return 'read';
+};
+
+export const clearDbRoutingStateForTests = (): void => {
+  recentPrimaryReadUsers.clear();
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { rateLimit } from 'express-rate-limit';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import prisma from './db/index.js';
+import { dbRoutingMiddleware } from './middleware/dbRouting.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import routes from './routes/index.js';
 import { validateEnvironment } from './utils/checkEnv.js';
@@ -43,6 +44,7 @@ const port = process.env.PORT || 8080;
 app.use(cors());
 app.use(express.json());
 app.use(decryptionMiddleware);
+app.use(dbRoutingMiddleware);
 
 // Initialize WebSocket Gateway
 initWebSocketGateway(io);

--- a/backend/src/middleware/dbRouting.ts
+++ b/backend/src/middleware/dbRouting.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from 'express';
+import { runWithDbRoutingContext } from '../db/requestContext.js';
+
+export const dbRoutingMiddleware = (req: Request, _res: Response, next: NextFunction): void => {
+  runWithDbRoutingContext(req.method, () => {
+    next();
+  });
+};

--- a/backend/src/user/routes.ts
+++ b/backend/src/user/routes.ts
@@ -3,6 +3,7 @@ import { Request, Response, Router } from 'express';
 import { authenticate } from '../auth/auth.middleware.js';
 import { normalizeSorobanDid } from '../auth/auth.service.js';
 import prisma from '../db/index.js';
+import { markUserWriteToPrimary } from '../db/requestContext.js';
 import { linkDidToCertificates } from '../routes/certificates.js';
 
 const router = Router();
@@ -101,6 +102,8 @@ router.put('/profile', authenticate, async (req: Request, res: Response) => {
       });
       linkDidToCertificates(req.user.id, student.did ?? null);
     }
+
+    markUserWriteToPrimary(req.user.id);
 
     res.json({
       id: student.id,

--- a/backend/tests/dbRouting.test.ts
+++ b/backend/tests/dbRouting.test.ts
@@ -1,0 +1,61 @@
+import {
+    clearDbRoutingStateForTests,
+    getDatabaseRoleForOperation,
+    markUserWriteToPrimary,
+    runWithDbRoutingContext,
+    setDbRoutingUserId,
+} from '../src/db/requestContext.js';
+
+describe('DB routing context', () => {
+  const originalLagWindow = process.env.DB_REPLICATION_LAG_WINDOW_MS;
+
+  beforeEach(() => {
+    process.env.DB_REPLICATION_LAG_WINDOW_MS = '1000';
+    clearDbRoutingStateForTests();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clearDbRoutingStateForTests();
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    process.env.DB_REPLICATION_LAG_WINDOW_MS = originalLagWindow;
+  });
+
+  it('uses read role for GET read operations', () => {
+    runWithDbRoutingContext('GET', () => {
+      expect(getDatabaseRoleForOperation('findMany')).toBe('read');
+    });
+  });
+
+  it('keeps write operations on primary even during GET requests', () => {
+    runWithDbRoutingContext('GET', () => {
+      expect(getDatabaseRoleForOperation('update')).toBe('primary');
+    });
+  });
+
+  it('keeps reads on primary for non-GET requests', () => {
+    runWithDbRoutingContext('POST', () => {
+      expect(getDatabaseRoleForOperation('findUnique')).toBe('primary');
+    });
+  });
+
+  it('forces primary reads immediately after a user write and releases after lag window', () => {
+    runWithDbRoutingContext('GET', () => {
+      setDbRoutingUserId('student-1');
+      markUserWriteToPrimary('student-1');
+
+      expect(getDatabaseRoleForOperation('findUnique')).toBe('primary');
+
+      jest.advanceTimersByTime(1001);
+
+      expect(getDatabaseRoleForOperation('findUnique')).toBe('read');
+    });
+  });
+
+  it('defaults to primary outside request context', () => {
+    expect(getDatabaseRoleForOperation('findMany')).toBe('primary');
+  });
+});


### PR DESCRIPTION
 Closes #227

## Summary
Adds robust DB pooling controls and read-replica support for backend reads, with automatic GET routing to replica at the shared Prisma access layer and replication-lag protection to keep reads consistent immediately after profile updates.

## Root Cause
A single Prisma client/pool in `index.ts` handled all reads and writes with no request-aware routing, causing frontend GET traffic to saturate the primary.

## Changes
- Added request-scoped routing context in `requestContext.ts`
- Added primary/read pooled Prisma clients and operation-level routing proxy in `index.ts`
- Added global routing middleware in `dbRouting.ts` and registered in `index.ts`
- Added authenticated user context propagation in `auth.middleware.ts`
- Added post-profile-update lag fallback trigger in `routes.ts`
- Added tests in `dbRouting.test.ts`
- Documented env configuration in `.env.example`

## Testing
- ✅ `npx jest --runInBand tests/dbRouting.test.ts` passes
- ✅ New DB routing env variables documented
