### PR TITLE
fix: add SSE export status stream for user sessions

### DIFF
--- a/backend/src/jobs/export.worker.ts
+++ b/backend/src/jobs/export.worker.ts
@@ -24,11 +24,30 @@ interface ExportJobData {
   userId: string;
 }
 
+const publishExportProgress = async (
+  job: Job<ExportJobData>,
+  progress: number,
+  stage: string
+): Promise<void> => {
+  await job.updateProgress(progress);
+
+  await broadcastEvent('user_metrics_updated', {
+    userId: job.data.userId,
+    type: 'EXPORT_PROGRESS',
+    jobId: job.id,
+    progress,
+    stage,
+    timestamp: new Date().toISOString(),
+  });
+};
+
 const worker = new Worker(
   EXPORT_QUEUE_NAME,
   async (job: Job<ExportJobData>) => {
     const { type, format, userId } = job.data;
     logger.info(`Starting export job ${job.id} for user ${userId}, type: ${type}, format: ${format}`);
+
+    await publishExportProgress(job, 5, 'started');
 
     let data: unknown[] = [];
 
@@ -42,6 +61,8 @@ const worker = new Worker(
     } else if (type === 'courses') {
       data = await prisma.course.findMany();
     }
+
+    await publishExportProgress(job, 40, 'data_loaded');
 
     // Simulate processing time
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -57,7 +78,10 @@ const worker = new Worker(
       content = JSON.stringify(data, null, 2);
     }
 
+    await publishExportProgress(job, 75, 'file_prepared');
+
     await fs.writeFile(filePath, content);
+    await publishExportProgress(job, 95, 'file_written');
 
     logger.info(`Export job ${job.id} completed. File saved to ${filePath}`);
 
@@ -72,7 +96,9 @@ const worker = new Worker(
       userId,
       type: 'EXPORT_COMPLETED',
       jobId: job.id,
+      progress: 100,
       result,
+      timestamp: new Date().toISOString(),
     });
 
     return result;
@@ -116,6 +142,16 @@ worker.on('completed', (job) => {
 
 worker.on('failed', (job, err) => {
   logger.error(`Job ${job?.id} failed: ${err.message}`);
+
+  if (job?.data?.userId) {
+    void broadcastEvent('user_metrics_updated', {
+      userId: job.data.userId,
+      type: 'EXPORT_FAILED',
+      jobId: job.id,
+      error: err.message,
+      timestamp: new Date().toISOString(),
+    });
+  }
 });
 
 export default worker;

--- a/backend/src/routes/export.routes.ts
+++ b/backend/src/routes/export.routes.ts
@@ -2,7 +2,9 @@ import { Job } from 'bullmq';
 import { Router } from 'express';
 import fs from 'fs';
 import path from 'path';
+import { verifyToken } from '../auth/auth.service.js';
 import { exportQueue } from '../jobs/export.queue.js';
+import { sseSessionManager } from '../sse/SseSessionManager.js';
 
 const EXPORTS_DIR = path.join(process.cwd(), 'exports');
 
@@ -28,6 +30,45 @@ router.post('/', async (req, res) => {
   });
 
   res.json({ jobId: job.id });
+});
+
+// GET /api/v1/export/events - Open SSE stream for export status updates
+router.get('/events', (req, res) => {
+  const authHeader = req.headers.authorization;
+  const headerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+  const queryToken = typeof req.query.access_token === 'string' ? req.query.access_token : undefined;
+  const token = headerToken || queryToken;
+
+  if (!token) {
+    return res.status(401).json({ error: 'Authorization token required' });
+  }
+
+  let userId: string;
+
+  try {
+    userId = verifyToken(token).userId;
+  } catch {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  if (typeof res.flushHeaders === 'function') {
+    res.flushHeaders();
+  }
+
+  res.write('retry: 5000\n\n');
+  const clientId = sseSessionManager.addClient(userId, res);
+  sseSessionManager.emitToUser(userId, 'sse_connected', {
+    connected: true,
+    timestamp: new Date().toISOString(),
+  });
+
+  req.on('close', () => {
+    sseSessionManager.removeClient(userId, clientId);
+  });
 });
 
 // GET /api/v1/export/:id/status - Get job status

--- a/backend/src/sse/SseSessionManager.ts
+++ b/backend/src/sse/SseSessionManager.ts
@@ -1,0 +1,82 @@
+import { Response } from 'express';
+
+interface SseClient {
+  id: string;
+  res: Response;
+  heartbeat: NodeJS.Timeout;
+}
+
+export class SseSessionManager {
+  private sessions = new Map<string, Map<string, SseClient>>();
+  private clientCounter = 0;
+
+  constructor(private readonly heartbeatIntervalMs = 25000) {}
+
+  addClient(sessionId: string, res: Response): string {
+    const clientId = `${Date.now()}-${this.clientCounter++}`;
+    const heartbeat = setInterval(() => {
+      this.writeRaw(res, ': keep-alive\n\n');
+    }, this.heartbeatIntervalMs);
+
+    const client: SseClient = { id: clientId, res, heartbeat };
+    const existing = this.sessions.get(sessionId);
+
+    if (existing) {
+      existing.set(clientId, client);
+    } else {
+      this.sessions.set(sessionId, new Map([[clientId, client]]));
+    }
+
+    return clientId;
+  }
+
+  removeClient(sessionId: string, clientId: string): void {
+    const clients = this.sessions.get(sessionId);
+    if (!clients) {
+      return;
+    }
+
+    const client = clients.get(clientId);
+    if (!client) {
+      return;
+    }
+
+    clearInterval(client.heartbeat);
+    clients.delete(clientId);
+
+    if (clients.size === 0) {
+      this.sessions.delete(sessionId);
+    }
+  }
+
+  emitToUser(userId: string, event: string, payload: unknown): void {
+    const clients = this.sessions.get(userId);
+    if (!clients || clients.size === 0) {
+      return;
+    }
+
+    const message = this.formatEvent(event, payload);
+
+    for (const [clientId, client] of clients.entries()) {
+      const success = this.writeRaw(client.res, message);
+      if (!success) {
+        this.removeClient(userId, clientId);
+      }
+    }
+  }
+
+  private formatEvent(event: string, payload: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+  }
+
+  private writeRaw(res: Response, chunk: string): boolean {
+    try {
+      res.write(chunk);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const sseSessionManager = new SseSessionManager();

--- a/backend/src/websocket/gateway.ts
+++ b/backend/src/websocket/gateway.ts
@@ -1,5 +1,6 @@
 import { Server, Socket } from 'socket.io';
 import { verifyToken } from '../auth/auth.service.js';
+import { sseSessionManager } from '../sse/SseSessionManager.js';
 import logger from '../utils/logger.js';
 import { pubClient, subClient } from '../utils/redis.js';
 
@@ -68,6 +69,7 @@ export const initWebSocketGateway = (io: Server) => {
     } else if (channel === 'user_metrics_updated') {
       if (data.userId) {
         io.to(`user:${data.userId}`).emit('user_metrics_updated', data);
+        sseSessionManager.emitToUser(String(data.userId), 'user_metrics_updated', data);
       }
     }
   });

--- a/backend/tests/sseSessionManager.test.ts
+++ b/backend/tests/sseSessionManager.test.ts
@@ -1,0 +1,50 @@
+import { Response } from 'express';
+import { SseSessionManager } from '../src/sse/SseSessionManager.js';
+
+const createMockResponse = (): Response => {
+  return {
+    write: jest.fn(),
+  } as unknown as Response;
+};
+
+describe('SseSessionManager', () => {
+  it('emits events to all clients in a user session', () => {
+    const manager = new SseSessionManager(60000);
+    const responseA = createMockResponse();
+    const responseB = createMockResponse();
+
+    const clientA = manager.addClient('user-1', responseA);
+    const clientB = manager.addClient('user-1', responseB);
+
+    manager.emitToUser('user-1', 'user_metrics_updated', {
+      type: 'EXPORT_PROGRESS',
+      progress: 40,
+    });
+
+    expect(responseA.write).toHaveBeenCalledWith(
+      expect.stringContaining('event: user_metrics_updated')
+    );
+    expect(responseA.write).toHaveBeenCalledWith(
+      expect.stringContaining('"progress":40')
+    );
+    expect(responseB.write).toHaveBeenCalledWith(
+      expect.stringContaining('event: user_metrics_updated')
+    );
+
+    manager.removeClient('user-1', clientA);
+    manager.removeClient('user-1', clientB);
+  });
+
+  it('stops emitting after a client disconnects', () => {
+    const manager = new SseSessionManager(60000);
+    const response = createMockResponse();
+
+    const clientId = manager.addClient('user-2', response);
+    manager.removeClient('user-2', clientId);
+    manager.emitToUser('user-2', 'user_metrics_updated', {
+      type: 'EXPORT_COMPLETED',
+    });
+
+    expect(response.write).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,8 @@
 import apiClient from "./api-client";
 
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
+
 export interface User {
   id: string;
   email: string;
@@ -64,6 +67,30 @@ export interface Feedback {
   updatedAt: string;
   student?: User;
   course?: Course;
+}
+
+export interface ExportJobResult {
+  fileName: string;
+  downloadUrl: string;
+  expiresAt: string;
+}
+
+export interface ExportJobStatus {
+  id: string;
+  state: string;
+  progress: number;
+  result?: ExportJobResult;
+}
+
+export interface ExportSseMessage {
+  userId?: string;
+  type?: "EXPORT_PROGRESS" | "EXPORT_COMPLETED" | "EXPORT_FAILED";
+  jobId?: string;
+  progress?: number;
+  stage?: string;
+  result?: ExportJobResult;
+  error?: string;
+  timestamp?: string;
 }
 
 // Authentication APIs
@@ -235,5 +262,33 @@ export const analyticsAPI = {
   getGlobalStats: async (): Promise<any> => {
     const response = await apiClient.get("/analytics/global-stats");
     return response.data;
+  },
+};
+
+export const exportAPI = {
+  start: async (data: {
+    type: "students" | "audit" | "courses";
+    format: "csv" | "json";
+  }): Promise<{ jobId: string }> => {
+    const response = await apiClient.post("/export", data);
+    return response.data;
+  },
+
+  getStatus: async (jobId: string): Promise<ExportJobStatus> => {
+    const response = await apiClient.get(`/export/${jobId}/status`);
+    return response.data;
+  },
+
+  openStatusStream: (): EventSource => {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+      throw new Error("Missing auth token for SSE connection");
+    }
+
+    const streamUrl = new URL(`${API_BASE_URL}/export/events`);
+    streamUrl.searchParams.set("access_token", token);
+
+    return new EventSource(streamUrl.toString());
   },
 };


### PR DESCRIPTION
## Closes #226

## Summary
Adds Server-Sent Events support for real-time export status updates with a reusable user-session SSE manager, wired to existing pub/sub events and extended export worker progress emission.

## Root Cause
- Backend had only WebSocket fanout for user metrics and polling for export status
- No SSE endpoint or user-session SSE utility existed
- Export worker did not emit progressive status updates suitable for SSE consumers

## Changes

| File | Change |
|---|---|
| `SseSessionManager.ts` | New user-scoped SSE utility |
| `export.routes.ts` | New authenticated SSE endpoint for export status streaming |
| `gateway.ts` | Dual fanout to WebSocket + SSE for user metrics |
| `export.worker.ts` | Progress, failure, and completion event emission |
| `api.ts` | Frontend SSE consumption utility and export API methods |
| `sseSessionManager.test.ts` | SSE manager unit tests |

## Testing
- ✅ Backend SSE session manager unit tests pass
- ✅ ESLint passes for all changed backend files
