### PR TITLE
feat: implement custom workspace layout with dnd-kit

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,17 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import AuditLogList from "@/components/dashboard/AuditLogList";
+import LayoutGrid from "@/components/dashboard/LayoutGrid";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLayoutPersistence } from "@/hooks/useLayoutPersistence";
 import {
-  coursesAPI,
-  certificatesAPI,
-  enrollmentsAPI,
-  Course,
-  Certificate,
-  Enrollment,
+    Certificate,
+    certificatesAPI,
+    Course,
+    coursesAPI,
+    Enrollment,
+    enrollmentsAPI,
 } from "@/lib/api";
 import Link from "next/link";
-import AuditLogList from "@/components/dashboard/AuditLogList";
+import { useEffect, useState } from "react";
 
 export default function DashboardPage() {
   const { user, logout } = useAuth();
@@ -19,12 +21,15 @@ export default function DashboardPage() {
   const [certificates, setCertificates] = useState<Certificate[]>([]);
   const [_enrollments, setEnrollments] = useState<Enrollment[]>([]); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [isLoading, setIsLoading] = useState(true);
+  const [editMode, setEditMode] = useState(false);
   const [stats, setStats] = useState({
     totalCourses: 0,
     enrolledCourses: 0,
     completedCourses: 0,
     certificates: 0,
   });
+
+  const { layout, saveLayout, resetLayout } = useLayoutPersistence(user?.id);
 
   useEffect(() => {
     async function loadDashboard() {
@@ -71,25 +76,185 @@ export default function DashboardPage() {
     );
   }
 
+  // --- Panel content definitions ---
+
+  const statsPanel = (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
+      {[
+        { label: "Available Nodes", value: stats.totalCourses },
+        { label: "Active Uplinks", value: stats.enrolledCourses },
+        { label: "Executed Modules", value: stats.completedCourses },
+        { label: "Cryptographic Tokens", value: stats.certificates },
+      ].map(({ label, value }) => (
+        <div
+          key={label}
+          className="bg-zinc-950 border border-white/10 rounded-2xl p-6 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.1)] transition-all group relative overflow-hidden"
+        >
+          <div className="absolute top-0 right-0 w-16 h-16 bg-white/5 rounded-bl-3xl group-hover:bg-red-500/10 transition-colors"></div>
+          <p className="text-3xl font-black text-white font-mono">{value}</p>
+          <p className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-2">
+            {label}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+
+  const coursesPanel = (
+    <div>
+      <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
+        <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
+          <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>
+          Directory Nodes
+        </h3>
+        <Link
+          href="/courses"
+          className="text-gray-400 hover:text-white uppercase text-xs font-bold tracking-widest transition-colors flex items-center gap-1 group"
+        >
+          Scan All{" "}
+          <span className="transform group-hover:translate-x-1 transition-transform">
+            →
+          </span>
+        </Link>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {courses.slice(0, 4).map((course) => (
+          <Link
+            key={course.id}
+            href={`/courses/${course.id}`}
+            className="bg-zinc-950 border border-white/5 p-8 hover:border-red-500/30 hover:bg-zinc-900 transition-all block group relative"
+          >
+            <div className="absolute left-0 top-0 bottom-0 w-1 bg-transparent group-hover:bg-red-600 transition-colors"></div>
+            <h4 className="text-xl font-black text-white mb-3 uppercase tracking-tight group-hover:text-red-50">
+              {course.title}
+            </h4>
+            <p className="text-gray-400 font-light text-sm mb-6 line-clamp-2">
+              {course.description || "System metadata missing"}
+            </p>
+            <div className="flex justify-between items-center pt-6 border-t border-white/5">
+              <span className="text-xs font-mono text-gray-500 px-2 py-1 bg-black border border-white/10 rounded">
+                {course.credits} UNIT
+              </span>
+              <span className="text-xs font-bold text-red-500 uppercase tracking-widest group-hover:text-red-400">
+                Connect
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+
+  const certificatesPanel = (
+    <div>
+      <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
+        <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
+          <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>
+          Issued Credentials
+        </h3>
+        <Link
+          href="/certificates"
+          className="text-gray-400 hover:text-white uppercase text-xs font-bold tracking-widest transition-colors flex items-center gap-1 group"
+        >
+          Vault{" "}
+          <span className="transform group-hover:translate-x-1 transition-transform">
+            →
+          </span>
+        </Link>
+      </div>
+      <div className="flex flex-col gap-4">
+        {certificates.length === 0 ? (
+          <p className="text-gray-600 text-sm font-mono">No credentials issued yet.</p>
+        ) : (
+          certificates.slice(0, 3).map((cert) => (
+            <Link
+              key={cert.id}
+              href={`/certificates/${cert.id}`}
+              className="bg-black border border-red-500/20 rounded-xl p-6 hover:border-red-500/60 transition-all block group"
+            >
+              <h4 className="text-base font-bold text-white uppercase tracking-wide group-hover:text-red-100">
+                {cert.course?.title || "Soroban Protocol"}
+              </h4>
+              <p className="text-xs font-light text-red-500/80 mt-1">
+                {new Date(cert.issuedAt).toLocaleDateString()}
+              </p>
+            </Link>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  const auditPanel = (
+    <div>
+      <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
+        <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
+          <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>
+          Audit Trails{" "}
+          <span className="text-gray-600">[Admin Only]</span>
+        </h3>
+        <span className="px-3 py-1 bg-red-500/10 border border-red-500/20 text-red-500 text-[10px] font-black uppercase tracking-widest rounded-full">
+          Live Monitoring
+        </span>
+      </div>
+      <div className="bg-zinc-950/50 backdrop-blur-sm border border-white/5 rounded-2xl p-8">
+        <AuditLogList />
+      </div>
+    </div>
+  );
+
+  const panelDefs = [
+    { id: "stats", content: statsPanel },
+    { id: "courses", content: coursesPanel },
+    { id: "certificates", content: certificatesPanel },
+    { id: "audit", content: auditPanel },
+  ];
+
   return (
     <div className="min-h-screen bg-black text-white selection:bg-red-600 selection:text-white pb-20 relative overflow-hidden">
-      {/* Abstract Background Glow */}
+      {/* Background glows */}
       <div className="absolute top-0 right-0 w-[800px] h-[800px] bg-red-600/5 rounded-full blur-[150px] pointer-events-none"></div>
       <div className="absolute bottom-0 left-0 w-[600px] h-[600px] bg-red-600/5 rounded-full blur-[120px] pointer-events-none"></div>
 
-      {/* Navigation Layer */}
+      {/* Nav */}
       <nav className="relative z-20 bg-zinc-950/80 backdrop-blur-md border-b border-white/10 sticky top-0">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-20">
             <div className="flex items-center gap-4">
-              <div className="flex flex-col">
-                <span className="text-2xl font-black text-white tracking-tighter uppercase flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse"></span>
-                  Control <span className="text-red-600">Center</span>
-                </span>
-              </div>
+              <span className="text-2xl font-black text-white tracking-tighter uppercase flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse"></span>
+                Control <span className="text-red-600">Center</span>
+              </span>
             </div>
-            <div className="flex items-center gap-6">
+            <div className="flex items-center gap-4">
+              {/* Layout edit controls */}
+              {editMode ? (
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={resetLayout}
+                    className="px-4 py-2 text-xs font-bold text-gray-400 bg-zinc-900 border border-white/10 rounded-lg hover:border-white/30 transition-all uppercase tracking-widest"
+                  >
+                    Reset
+                  </button>
+                  <button
+                    onClick={() => setEditMode(false)}
+                    className="px-4 py-2 text-xs font-bold text-white bg-red-600 border border-red-600 rounded-lg hover:bg-red-700 transition-all uppercase tracking-widest"
+                  >
+                    Done
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setEditMode(true)}
+                  className="px-4 py-2 text-xs font-bold text-gray-400 bg-zinc-900 border border-white/10 rounded-lg hover:border-red-500/50 hover:text-white transition-all uppercase tracking-widest flex items-center gap-2"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+                  </svg>
+                  Edit Layout
+                </button>
+              )}
+
               <div className="hidden md:flex flex-col items-end">
                 <span className="text-xs font-bold text-gray-500 uppercase tracking-widest">
                   Active Operator
@@ -109,9 +274,17 @@ export default function DashboardPage() {
         </div>
       </nav>
 
-      {/* Main Content */}
+      {/* Edit mode banner */}
+      {editMode && (
+        <div className="relative z-10 bg-red-600/10 border-b border-red-500/30 px-4 py-2 text-center">
+          <p className="text-xs font-bold text-red-400 uppercase tracking-widest">
+            Layout Edit Mode — Drag panels to reorder · Click 1/2/3 to resize columns · Changes are saved automatically
+          </p>
+        </div>
+      )}
+
+      {/* Main */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 relative z-10">
-        {/* Welcome Section */}
         <div className="mb-12 border-l-4 border-red-600 pl-6 py-2">
           <h2 className="text-4xl md:text-5xl font-black text-white mb-3 uppercase tracking-tight">
             Terminal <span className="text-gray-500">Access Granted</span>
@@ -125,234 +298,12 @@ export default function DashboardPage() {
           </p>
         </div>
 
-        {/* Stats Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
-          <div className="bg-zinc-950 border border-white/10 rounded-2xl p-6 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.1)] transition-all group relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-16 h-16 bg-white/5 rounded-bl-3xl group-hover:bg-red-500/10 transition-colors"></div>
-            <div className="flex items-center justify-between mb-4">
-              <div className="w-12 h-12 bg-black border border-white/10 rounded-xl flex items-center justify-center group-hover:border-white/30 transition-colors">
-                <svg
-                  className="w-6 h-6 text-white group-hover:text-red-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                  />
-                </svg>
-              </div>
-              <p className="text-3xl font-black text-white font-mono">
-                {stats.totalCourses}
-              </p>
-            </div>
-            <p className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-2">
-              Available Nodes
-            </p>
-          </div>
-
-          <div className="bg-zinc-950 border border-white/10 rounded-2xl p-6 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.1)] transition-all group relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-16 h-16 bg-white/5 rounded-bl-3xl group-hover:bg-red-500/10 transition-colors"></div>
-            <div className="flex items-center justify-between mb-4">
-              <div className="w-12 h-12 bg-black border border-white/10 rounded-xl flex items-center justify-center group-hover:border-white/30 transition-colors">
-                <svg
-                  className="w-6 h-6 text-white group-hover:text-red-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <p className="text-3xl font-black text-white font-mono">
-                {stats.enrolledCourses}
-              </p>
-            </div>
-            <p className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-2">
-              Active Uplinks
-            </p>
-          </div>
-
-          <div className="bg-zinc-950 border border-white/10 rounded-2xl p-6 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.1)] transition-all group relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-16 h-16 bg-white/5 rounded-bl-3xl group-hover:bg-red-500/10 transition-colors"></div>
-            <div className="flex items-center justify-between mb-4">
-              <div className="w-12 h-12 bg-black border border-white/10 rounded-xl flex items-center justify-center group-hover:border-white/30 transition-colors">
-                <svg
-                  className="w-6 h-6 text-white group-hover:text-red-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
-                  />
-                </svg>
-              </div>
-              <p className="text-3xl font-black text-white font-mono">
-                {stats.completedCourses}
-              </p>
-            </div>
-            <p className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-2">
-              Executed Modules
-            </p>
-          </div>
-
-          <div className="bg-zinc-950 border border-white/10 rounded-2xl p-6 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.1)] transition-all group relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-16 h-16 bg-white/5 rounded-bl-3xl group-hover:bg-red-500/10 transition-colors"></div>
-            <div className="flex items-center justify-between mb-4">
-              <div className="w-12 h-12 bg-black border border-white/10 rounded-xl flex items-center justify-center group-hover:border-white/30 transition-colors">
-                <svg
-                  className="w-6 h-6 text-white group-hover:text-red-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
-                  />
-                </svg>
-              </div>
-              <p className="text-3xl font-black text-white font-mono">
-                {stats.certificates}
-              </p>
-            </div>
-            <p className="text-xs font-bold text-gray-500 uppercase tracking-widest mt-2">
-              Cryptographic Tokens
-            </p>
-          </div>
-        </div>
-
-        {/* Recent Courses */}
-        <div className="mb-16">
-          <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
-            <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
-              <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>{" "}
-              Directory Nodes
-            </h3>
-            <Link
-              href="/courses"
-              className="text-gray-400 hover:text-white uppercase text-xs font-bold tracking-widest transition-colors flex items-center gap-1 group"
-            >
-              Scan All{" "}
-              <span className="transform group-hover:translate-x-1 transition-transform">
-                →
-              </span>
-            </Link>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {courses.slice(0, 3).map((course) => (
-              <Link
-                key={course.id}
-                href={`/courses/${course.id}`}
-                className="bg-zinc-950 border border-white/5 p-8 hover:border-red-500/30 hover:bg-zinc-900 transition-all block group relative"
-              >
-                <div className="absolute left-0 top-0 bottom-0 w-1 bg-transparent group-hover:bg-red-600 transition-colors"></div>
-                <h4 className="text-xl font-black text-white mb-3 uppercase tracking-tight group-hover:text-red-50">
-                  {course.title}
-                </h4>
-                <p className="text-gray-400 font-light text-sm mb-6 line-clamp-2">
-                  {course.description || "System metadata missing"}
-                </p>
-                <div className="flex justify-between items-center pt-6 border-t border-white/5">
-                  <span className="text-xs font-mono text-gray-500 px-2 py-1 bg-black border border-white/10 rounded">
-                    {course.credits} UNIT
-                  </span>
-                  <span className="text-xs font-bold text-red-500 uppercase tracking-widest group-hover:text-red-400">
-                    Connect
-                  </span>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </div>
-
-        {/* My Certificates */}
-        {certificates.length > 0 && (
-          <div className="mb-16">
-            <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
-              <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
-                <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>{" "}
-                Issued Credentials
-              </h3>
-              <Link
-                href="/certificates"
-                className="text-gray-400 hover:text-white uppercase text-xs font-bold tracking-widest transition-colors flex items-center gap-1 group"
-              >
-                Vault{" "}
-                <span className="transform group-hover:translate-x-1 transition-transform">
-                  →
-                </span>
-              </Link>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {certificates.slice(0, 3).map((cert) => (
-                <Link
-                  key={cert.id}
-                  href={`/certificates/${cert.id}`}
-                  className="bg-black border border-red-500/20 rounded-xl p-8 hover:border-red-500/60 shadow-[0_0_20px_rgba(220,38,38,0.05)] hover:shadow-[0_0_30px_rgba(220,38,38,0.2)] transition-all block relative group overflow-hidden"
-                >
-                  <div className="absolute top-0 right-0 w-32 h-32 bg-red-900/10 rounded-bl-full pointer-events-none group-hover:bg-red-900/20 transition-colors"></div>
-                  <div className="flex items-start justify-between mb-6 relative z-10">
-                    <div className="w-12 h-12 bg-zinc-950 border border-red-500/30 rounded-xl flex items-center justify-center">
-                      <svg
-                        className="w-6 h-6 text-red-500"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
-                        />
-                      </svg>
-                    </div>
-                    <span className="text-xs font-mono bg-zinc-950 border border-white/10 text-gray-400 px-3 py-1 rounded">
-                      {new Date(cert.issuedAt).toLocaleDateString()}
-                    </span>
-                  </div>
-                  <h4 className="text-xl font-bold text-white mb-2 uppercase tracking-wide group-hover:text-red-100">
-                    {cert.course?.title || "Soroban Protocol"}
-                  </h4>
-                  <p className="text-sm font-light text-red-500/80">
-                    On-Chain Certification
-                  </p>
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Audit Logs Section */}
-        <div className="mt-20">
-          <div className="flex justify-between items-center mb-8 border-b border-white/10 pb-4">
-            <h3 className="text-xl font-black text-white uppercase tracking-widest flex items-center gap-3">
-              <span className="w-4 h-4 bg-red-600 rounded-sm inline-block"></span>{" "}
-              Audit Trails <span className="text-gray-600">[Admin Only]</span>
-            </h3>
-            <span className="px-3 py-1 bg-red-500/10 border border-red-500/20 text-red-500 text-[10px] font-black uppercase tracking-widest rounded-full">
-              Live Monitoring
-            </span>
-          </div>
-          <div className="bg-zinc-950/50 backdrop-blur-sm border border-white/5 rounded-2xl p-8">
-            <AuditLogList />
-          </div>
-        </div>
+        <LayoutGrid
+          layout={layout}
+          editMode={editMode}
+          panels={panelDefs}
+          onLayoutChange={saveLayout}
+        />
       </main>
     </div>
   );

--- a/frontend/src/components/dashboard/DraggablePanel.tsx
+++ b/frontend/src/components/dashboard/DraggablePanel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { PanelLayout } from "@/hooks/useLayoutPersistence";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ReactNode } from "react";
+
+interface Props {
+  panel: PanelLayout;
+  editMode: boolean;
+  onResizeCol: (id: string, colSpan: number) => void;
+  children: ReactNode;
+}
+
+const colSpanClass: Record<number, string> = {
+  1: "col-span-1",
+  2: "col-span-1 md:col-span-2",
+  3: "col-span-1 md:col-span-3",
+};
+
+export default function DraggablePanel({
+  panel,
+  editMode,
+  onResizeCol,
+  children,
+}: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: panel.id, disabled: !editMode });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`${colSpanClass[panel.colSpan] ?? "col-span-1 md:col-span-3"} relative ${
+        editMode
+          ? "ring-2 ring-red-500/50 ring-offset-2 ring-offset-black rounded-2xl"
+          : ""
+      }`}
+    >
+      {editMode && (
+        <div className="absolute -top-3 left-0 right-0 z-30 flex items-center justify-between px-3">
+          {/* drag handle */}
+          <button
+            {...listeners}
+            {...attributes}
+            className="cursor-grab active:cursor-grabbing bg-red-600 text-white text-[10px] font-black uppercase tracking-widest px-3 py-1 rounded-full select-none"
+          >
+            ⠿ drag
+          </button>
+
+          {/* col-span controls */}
+          <div className="flex gap-1">
+            {[1, 2, 3].map((n) => (
+              <button
+                key={n}
+                onClick={() => onResizeCol(panel.id, n)}
+                className={`w-6 h-6 text-[10px] font-black rounded border transition-colors ${
+                  panel.colSpan === n
+                    ? "bg-red-600 border-red-600 text-white"
+                    : "bg-zinc-900 border-white/20 text-gray-400 hover:border-red-500"
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={editMode ? "pt-4" : ""}>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/LayoutGrid.tsx
+++ b/frontend/src/components/dashboard/LayoutGrid.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { WorkspaceLayout } from "@/hooks/useLayoutPersistence";
+import {
+    DndContext,
+    DragEndEvent,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    SortableContext,
+    arrayMove,
+    rectSortingStrategy,
+} from "@dnd-kit/sortable";
+import { ReactNode } from "react";
+import DraggablePanel from "./DraggablePanel";
+
+// Snap-to-grid modifier — snaps drag delta to 8px grid
+function snapToGrid(args: { transform: { x: number; y: number; scaleX: number; scaleY: number } }) {
+  const GRID = 8;
+  return {
+    ...args.transform,
+    x: Math.round(args.transform.x / GRID) * GRID,
+    y: Math.round(args.transform.y / GRID) * GRID,
+  };
+}
+
+interface PanelDef {
+  id: string;
+  content: ReactNode;
+}
+
+interface Props {
+  layout: WorkspaceLayout;
+  editMode: boolean;
+  panels: PanelDef[];
+  onLayoutChange: (layout: WorkspaceLayout) => void;
+}
+
+export default function LayoutGrid({ layout, editMode, panels, onLayoutChange }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const orderedPanels = [...layout.panels].sort((a, b) => a.order - b.order);
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedPanels.findIndex((p) => p.id === active.id);
+    const newIndex = orderedPanels.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(orderedPanels, oldIndex, newIndex).map(
+      (p, i) => ({ ...p, order: i }),
+    );
+
+    onLayoutChange({ panels: reordered });
+  }
+
+  function handleResizeCol(id: string, colSpan: number) {
+    onLayoutChange({
+      panels: layout.panels.map((p) => (p.id === id ? { ...p, colSpan } : p)),
+    });
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[snapToGrid]}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={orderedPanels.map((p) => p.id)}
+        strategy={rectSortingStrategy}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {orderedPanels.map((panel) => {
+            const def = panels.find((p) => p.id === panel.id);
+            if (!def) return null;
+            return (
+              <DraggablePanel
+                key={panel.id}
+                panel={panel}
+                editMode={editMode}
+                onResizeCol={handleResizeCol}
+              >
+                {def.content}
+              </DraggablePanel>
+            );
+          })}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/frontend/src/hooks/useLayoutPersistence.ts
+++ b/frontend/src/hooks/useLayoutPersistence.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface PanelLayout {
+  id: string;
+  order: number;
+  colSpan: number; // 1-3 columns
+}
+
+export interface WorkspaceLayout {
+  panels: PanelLayout[];
+}
+
+const DEFAULT_LAYOUT: WorkspaceLayout = {
+  panels: [
+    { id: "stats", order: 0, colSpan: 3 },
+    { id: "courses", order: 1, colSpan: 2 },
+    { id: "certificates", order: 2, colSpan: 1 },
+    { id: "audit", order: 3, colSpan: 3 },
+  ],
+};
+
+function getStorageKey(userId?: string) {
+  return `workspace_layout_${userId ?? "guest"}`;
+}
+
+export function useLayoutPersistence(userId?: string) {
+  const [layout, setLayout] = useState<WorkspaceLayout>(DEFAULT_LAYOUT);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(getStorageKey(userId));
+      if (stored) {
+        setLayout(JSON.parse(stored));
+      } else {
+        setLayout(DEFAULT_LAYOUT);
+      }
+    } catch {
+      setLayout(DEFAULT_LAYOUT);
+    }
+  }, [userId]);
+
+  const saveLayout = useCallback(
+    (newLayout: WorkspaceLayout) => {
+      setLayout(newLayout);
+      try {
+        localStorage.setItem(getStorageKey(userId), JSON.stringify(newLayout));
+      } catch {
+        // storage unavailable
+      }
+    },
+    [userId],
+  );
+
+  const resetLayout = useCallback(() => {
+    saveLayout(DEFAULT_LAYOUT);
+  }, [saveLayout]);
+
+  return { layout, saveLayout, resetLayout };
+}


### PR DESCRIPTION
## Summary

Implements a fully customizable workspace layout for the dashboard, allowing users to reorder and resize panels via drag-and-drop. Layout is persisted to `localStorage` and restored across sessions.

Closes #[issue-number]

## Changes

### New Files
- `frontend/src/hooks/useLayoutPersistence.ts` — hook that reads/writes panel layout (order + col spans) to `localStorage`, keyed per user ID
- `frontend/src/components/dashboard/DraggablePanel.tsx` — sortable panel wrapper with drag handle and column-span resize controls
- `frontend/src/components/dashboard/LayoutGrid.tsx` — grid container using `@dnd-kit/core` + `@dnd-kit/sortable` with snap-to-grid and reorder logic

### Modified Files
- `frontend/src/app/dashboard/page.tsx` — refactored to use `LayoutGrid`; added Edit Layout toggle, edit mode banner, Reset/Done controls

## Features

- **Layout Edit Mode** — toggled via "Edit Layout" button in the nav bar; a banner guides the user while active
- **Drag to reorder** — panels can be dragged and dropped to any position using `@dnd-kit/sortable`
- **Snap-to-Grid** — drag movements snap to an 8px grid for clean, precise placement
- **Column resize** — each panel exposes 1/2/3 column-span buttons in edit mode
- **Layout persistence** — layout is saved to `localStorage` on every change and restored on page load, scoped per user ID
- **Reset** — one-click reset back to the default layout

## How to Test

1. Navigate to `/dashboard`
2. Click "Edit Layout" in the top nav
3. Drag panels using the red "⠿ drag" handle to reorder
4. Click 1, 2, or 3 on any panel to change its column width
5. Click "Done" — layout is saved
6. Refresh the page — layout should be restored
7. Click "Edit Layout" → "Reset" to restore defaults

## Dependencies

Requires `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` to be installed:

```bash
npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
```
close #290 