### PR TITLE
Feat/accessibility audit and fixes

### DIFF
--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Course, coursesAPI } from "@/lib/api";
 import Link from "next/link";
-import { coursesAPI, Course } from "@/lib/api";
+import { useEffect, useState } from "react";
 
 export default function CoursesPage() {
   const [courses, setCourses] = useState<Course[]>([]);
@@ -83,18 +83,23 @@ export default function CoursesPage() {
         {/* Search Bar */}
         <div className="mb-12 relative z-10">
           <div className="relative max-w-xl">
+            <label htmlFor="course-search" className="sr-only">Search courses</label>
             <input
-              type="text"
+              id="course-search"
+              type="search"
               placeholder="SEARCH NODE DIRECTORY..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="w-full px-5 py-4 pl-14 rounded-xl border border-white/20 bg-black text-white font-mono focus:ring-1 focus:ring-red-500 focus:border-red-500 transition-colors uppercase tracking-wide placeholder-gray-600 shadow-[0_4px_20px_rgba(0,0,0,0.5)]"
+              aria-label="Search courses by title or description"
             />
             <svg
               className="absolute left-5 top-1/2 transform -translate-y-1/2 w-6 h-6 text-red-600"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 strokeLinecap="round"
@@ -109,13 +114,15 @@ export default function CoursesPage() {
         {/* Courses Grid */}
         <div className="relative z-10">
           {filteredCourses.length === 0 ? (
-            <div className="text-center py-20 border border-white/10 rounded-2xl bg-zinc-950/50 backdrop-blur-sm">
-              <div className="w-20 h-20 bg-red-900/20 rounded-2xl flex items-center justify-center mx-auto mb-6 border border-red-500/20">
+            <div className="text-center py-20 border border-white/10 rounded-2xl bg-zinc-950/50 backdrop-blur-sm" role="status">
+              <div className="w-20 h-20 bg-red-900/20 rounded-2xl flex items-center justify-center mx-auto mb-6 border border-red-500/20" aria-hidden="true">
                 <svg
                   className="h-10 w-10 text-red-500"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -135,22 +142,29 @@ export default function CoursesPage() {
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
+              aria-live="polite"
+              aria-label={`${filteredCourses.length} course${filteredCourses.length !== 1 ? "s" : ""} found`}
+            >
               {filteredCourses.map((course) => (
                 <Link
                   key={course.id}
                   href={`/courses/${course.id}`}
                   className="group bg-zinc-950 border border-white/10 rounded-2xl p-8 hover:border-red-500/50 hover:shadow-[0_0_30px_rgba(220,38,38,0.15)] hover:-translate-y-1 transition-all duration-300 flex flex-col h-full relative overflow-hidden"
+                  aria-label={`${course.title} - ${course.credits} credits, taught by ${course.instructor}`}
                 >
-                  <div className="absolute top-0 right-0 w-32 h-32 bg-red-600/5 rounded-bl-[100px] pointer-events-none group-hover:bg-red-600/10 transition-colors"></div>
+                  <div className="absolute top-0 right-0 w-32 h-32 bg-red-600/5 rounded-bl-[100px] pointer-events-none group-hover:bg-red-600/10 transition-colors" aria-hidden="true"></div>
 
                   <div className="flex items-start justify-between mb-8 relative z-10">
-                    <div className="w-14 h-14 bg-black border border-white/10 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:border-red-500/50 group-hover:bg-red-500/10 transition-colors">
+                    <div className="w-14 h-14 bg-black border border-white/10 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:border-red-500/50 group-hover:bg-red-500/10 transition-colors" aria-hidden="true">
                       <svg
                         className="w-7 h-7 text-white group-hover:text-red-500 transition-colors"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
+                        aria-hidden="true"
+                        focusable="false"
                       >
                         <path
                           strokeLinecap="round"
@@ -176,7 +190,7 @@ export default function CoursesPage() {
                     <span className="text-xs font-bold text-gray-500 uppercase tracking-widest">
                       {course.instructor}
                     </span>
-                    <span className="inline-flex items-center gap-2 text-red-500 font-bold uppercase text-xs tracking-widest group-hover:text-red-400 transition-colors">
+                    <span className="inline-flex items-center gap-2 text-red-500 font-bold uppercase text-xs tracking-widest group-hover:text-red-400 transition-colors" aria-hidden="true">
                       Enter Node{" "}
                       <span className="transform group-hover:translate-x-1 transition-transform">
                         →

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -30,6 +30,57 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Skip to main content link for keyboard/screen reader users */
+.skip-to-content {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 9999;
+  padding: 0.75rem 1.5rem;
+  background: #dc2626;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.875rem;
+  text-decoration: none;
+  border-radius: 0 0 0.5rem 0;
+  transition: top 0.2s;
+}
+
+.skip-to-content:focus {
+  top: 0;
+}
+
+/* Screen reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Visible focus styles for keyboard navigation */
+:focus-visible {
+  outline: 2px solid #dc2626;
+  outline-offset: 2px;
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 10px;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
+import { AuthProvider } from "@/contexts/AuthContext";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import { AuthProvider } from "@/contexts/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -32,8 +32,11 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-black text-white min-h-screen`}
       >
         <AuthProvider>
+          <a href="#main-content" className="skip-to-content">
+            Skip to main content
+          </a>
           <Navbar />
-          <main className="flex-grow">{children}</main>
+          <main id="main-content" className="flex-grow">{children}</main>
         </AuthProvider>
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -49,13 +49,13 @@ export default function Home() {
   return (
     <div className="bg-black text-white selection:bg-red-600 selection:text-white">
       {/* Hero Section */}
-      <main className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32 overflow-hidden">
+      <section aria-label="Hero" className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32 overflow-hidden">
         {/* Abstract Background Glows */}
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-red-600/20 rounded-full blur-[120px] pointer-events-none"></div>
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-red-600/20 rounded-full blur-[120px] pointer-events-none" aria-hidden="true"></div>
 
         <div className="relative z-10 text-center max-w-4xl mx-auto">
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-red-500/30 bg-red-500/10 text-red-500 font-medium text-sm mb-8 animate-pulse">
-            <span className="w-2 h-2 rounded-full bg-red-500"></span>
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-red-500/30 bg-red-500/10 text-red-500 font-medium text-sm mb-8 animate-pulse" role="status" aria-live="polite">
+            <span className="w-2 h-2 rounded-full bg-red-500" aria-hidden="true"></span>
             Stellar Testnet Integration Live
           </div>
 
@@ -87,7 +87,7 @@ export default function Home() {
             </Link>
           </div>
         </div>
-      </main>
+      </section>
 
       {/* Features Grid - The Lab Modules */}
       <section className="relative bg-zinc-950 py-24 border-y border-white/5">
@@ -105,13 +105,16 @@ export default function Home() {
             <Link
               href="/simulator"
               className="bg-black border border-white/10 hover:border-red-500/50 rounded-2xl p-8 transition-all hover:-translate-y-2 group"
+              aria-label="Simulator - Observe live Stellar ledger activity"
             >
-              <div className="w-14 h-14 bg-red-500/10 rounded-xl flex items-center justify-center mb-6 border border-red-500/20 group-hover:bg-red-600 transition-colors">
+              <div className="w-14 h-14 bg-red-500/10 rounded-xl flex items-center justify-center mb-6 border border-red-500/20 group-hover:bg-red-600 transition-colors" aria-hidden="true">
                 <svg
                   className="w-7 h-7 text-red-500 group-hover:text-white"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -128,7 +131,7 @@ export default function Home() {
                 Observe live Stellar ledger activity in a terminal-themed
                 visualization.
               </p>
-              <span className="text-[10px] font-black text-red-500 uppercase tracking-widest group-hover:pl-2 transition-all">
+              <span className="text-[10px] font-black text-red-500 uppercase tracking-widest group-hover:pl-2 transition-all" aria-hidden="true">
                 Enter →
               </span>
             </Link>
@@ -136,13 +139,16 @@ export default function Home() {
             <Link
               href="/playground"
               className="bg-black border border-white/10 hover:border-red-500/50 rounded-2xl p-8 transition-all hover:-translate-y-2 group"
+              aria-label="Playground - Compile and execute Soroban smart contracts"
             >
-              <div className="w-14 h-14 bg-white/5 rounded-xl flex items-center justify-center mb-6 border border-white/10 group-hover:bg-white group-hover:text-black transition-colors">
+              <div className="w-14 h-14 bg-white/5 rounded-xl flex items-center justify-center mb-6 border border-white/10 group-hover:bg-white group-hover:text-black transition-colors" aria-hidden="true">
                 <svg
                   className="w-7 h-7 text-white group-hover:text-black"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -159,7 +165,7 @@ export default function Home() {
                 Compile and execute Soroban smart contract logic in a sandboxed
                 environment.
               </p>
-              <span className="text-[10px] font-black text-white uppercase tracking-widest group-hover:pl-2 transition-all">
+              <span className="text-[10px] font-black text-white uppercase tracking-widest group-hover:pl-2 transition-all" aria-hidden="true">
                 Execute →
               </span>
             </Link>
@@ -167,13 +173,16 @@ export default function Home() {
             <Link
               href="/roadmap"
               className="bg-black border border-white/10 hover:border-red-500/50 rounded-2xl p-8 transition-all hover:-translate-y-2 group"
+              aria-label="Roadmap - Track your progression through the Stellar mastery tree"
             >
-              <div className="w-14 h-14 bg-red-500/10 rounded-xl flex items-center justify-center mb-6 border border-red-500/20 group-hover:bg-red-600 transition-colors">
+              <div className="w-14 h-14 bg-red-500/10 rounded-xl flex items-center justify-center mb-6 border border-red-500/20 group-hover:bg-red-600 transition-colors" aria-hidden="true">
                 <svg
                   className="w-7 h-7 text-red-500 group-hover:text-white"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -190,7 +199,7 @@ export default function Home() {
                 Track your progression through the multi-stage Stellar mastery
                 tree.
               </p>
-              <span className="text-[10px] font-black text-red-500 uppercase tracking-widest group-hover:pl-2 transition-all">
+              <span className="text-[10px] font-black text-red-500 uppercase tracking-widest group-hover:pl-2 transition-all" aria-hidden="true">
                 Visualize →
               </span>
             </Link>
@@ -198,13 +207,16 @@ export default function Home() {
             <Link
               href="/ideas"
               className="bg-black border border-white/10 hover:border-red-500/50 rounded-2xl p-8 transition-all hover:-translate-y-2 group"
+              aria-label="Incubator - Generate optimized project concepts for your next build"
             >
-              <div className="w-14 h-14 bg-white/5 rounded-xl flex items-center justify-center mb-6 border border-white/10 group-hover:bg-white group-hover:text-black transition-colors">
+              <div className="w-14 h-14 bg-white/5 rounded-xl flex items-center justify-center mb-6 border border-white/10 group-hover:bg-white group-hover:text-black transition-colors" aria-hidden="true">
                 <svg
                   className="w-7 h-7 text-white group-hover:text-black"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -221,7 +233,7 @@ export default function Home() {
                 Generate heuristically optimized project concepts for your next
                 build.
               </p>
-              <span className="text-[10px] font-black text-white uppercase tracking-widest group-hover:pl-2 transition-all">
+              <span className="text-[10px] font-black text-white uppercase tracking-widest group-hover:pl-2 transition-all" aria-hidden="true">
                 Initialize →
               </span>
             </Link>
@@ -230,36 +242,36 @@ export default function Home() {
       </section>
 
       {/* Stats Section */}
-      <section className="py-24 bg-black border-b border-white/5">
+      <section className="py-24 bg-black border-b border-white/5" aria-label="Platform statistics">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-12 text-center">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-12 text-center" aria-live="polite" aria-busy={isLoading}>
             <div className="p-6">
-              <p className="text-5xl font-black text-red-600 mb-4 tracking-tighter">
-                {isLoading ? "..." : `${stats.coursesCount}+`}
+              <p className="text-5xl font-black text-red-600 mb-4 tracking-tighter" aria-label={`${stats.coursesCount} active modules`}>
+                {isLoading ? <span aria-hidden="true">...</span> : `${stats.coursesCount}+`}
               </p>
               <p className="text-gray-300 font-bold uppercase tracking-widest text-sm">
                 Active Modules
               </p>
             </div>
             <div className="p-6">
-              <p className="text-5xl font-black text-white mb-4 tracking-tighter shadow-white">
-                {isLoading ? "..." : `${stats.studentsCount}+`}
+              <p className="text-5xl font-black text-white mb-4 tracking-tighter shadow-white" aria-label={`${stats.studentsCount} engineers enrolled`}>
+                {isLoading ? <span aria-hidden="true">...</span> : `${stats.studentsCount}+`}
               </p>
               <p className="text-gray-300 font-bold uppercase tracking-widest text-sm">
                 Engineers Enrolled
               </p>
             </div>
             <div className="p-6">
-              <p className="text-5xl font-black text-red-600 mb-4 tracking-tighter">
-                {isLoading ? "..." : `${stats.certificatesCount}+`}
+              <p className="text-5xl font-black text-red-600 mb-4 tracking-tighter" aria-label={`${stats.certificatesCount} credentials issued`}>
+                {isLoading ? <span aria-hidden="true">...</span> : `${stats.certificatesCount}+`}
               </p>
               <p className="text-gray-300 font-bold uppercase tracking-widest text-sm">
                 Credentials Issued
               </p>
             </div>
             <div className="p-6">
-              <p className="text-5xl font-black text-white mb-4 tracking-tighter shadow-white">
-                {isLoading ? "..." : stats.verificationRate}
+              <p className="text-5xl font-black text-white mb-4 tracking-tighter shadow-white" aria-label={`${stats.verificationRate} on-chain verified`}>
+                {isLoading ? <span aria-hidden="true">...</span> : stats.verificationRate}
               </p>
               <p className="text-gray-300 font-bold uppercase tracking-widest text-sm">
                 On-Chain Verified
@@ -295,16 +307,18 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="bg-zinc-950 border-t border-white/5 py-12">
+      <footer className="bg-zinc-950 border-t border-white/5 py-12" role="contentinfo" aria-label="Site footer">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row justify-between items-center gap-8">
             <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-red-600 rounded-md flex items-center justify-center">
+              <div className="w-8 h-8 bg-red-600 rounded-md flex items-center justify-center" aria-hidden="true">
                 <svg
                   className="w-5 h-5 text-white"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -319,7 +333,7 @@ export default function Home() {
               </span>
             </div>
 
-            <div className="flex gap-8 text-sm font-bold tracking-wide uppercase text-gray-500">
+            <nav className="flex gap-8 text-sm font-bold tracking-wide uppercase text-gray-500" aria-label="Footer navigation">
               <Link
                 href="/courses"
                 className="hover:text-white transition-colors"
@@ -338,7 +352,7 @@ export default function Home() {
               <a href="#" className="hover:text-white transition-colors">
                 Terms
               </a>
-            </div>
+            </nav>
 
             <p className="text-sm font-medium text-gray-600">
               © 2026 WEB3 STUDENT LAB. PROTOCOL SECURED.

--- a/frontend/src/app/simulator/page.tsx
+++ b/frontend/src/app/simulator/page.tsx
@@ -90,9 +90,15 @@ export default function SimulatorPage() {
             </p>
           </div>
           <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2 px-4 py-2 bg-zinc-900 border border-white/10 rounded">
+            <div
+              className="flex items-center gap-2 px-4 py-2 bg-zinc-900 border border-white/10 rounded"
+              role="status"
+              aria-live="polite"
+              aria-label={isLive ? "Live feed active" : "Feed paused"}
+            >
               <div
                 className={`w-2 h-2 rounded-full ${isLive ? "bg-green-500 animate-pulse" : "bg-red-500"}`}
+                aria-hidden="true"
               ></div>
               <span className="text-[10px] uppercase font-bold tracking-widest">
                 {isLive ? "Live Feed" : "Paused"}
@@ -101,6 +107,8 @@ export default function SimulatorPage() {
             <button
               onClick={() => setIsLive(!isLive)}
               className="px-4 py-2 bg-white text-black text-[10px] font-black uppercase tracking-widest hover:bg-gray-200 transition-colors"
+              aria-pressed={isLive}
+              aria-label={isLive ? "Stop live sync" : "Start live sync"}
             >
               {isLive ? "Stop Sync" : "Start Sync"}
             </button>
@@ -110,22 +118,23 @@ export default function SimulatorPage() {
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 flex-grow h-[calc(100vh-250px)]">
           {/* Recent Ledgers */}
           <div className="lg:col-span-1 bg-zinc-950 border border-white/10 p-6 rounded-2xl flex flex-col shadow-2xl overflow-hidden">
-            <h3 className="text-sm font-bold border-b border-white/10 pb-4 mb-6 uppercase tracking-widest flex items-center justify-between">
+            <h2 className="text-sm font-bold border-b border-white/10 pb-4 mb-6 uppercase tracking-widest flex items-center justify-between">
               Ledger Chain
               <span className="text-[10px] text-gray-600 font-normal">
                 History [10]
               </span>
-            </h3>
-            <div className="space-y-4 overflow-y-auto pr-2 custom-scrollbar flex-grow">
+            </h2>
+            <div className="space-y-4 overflow-y-auto pr-2 custom-scrollbar flex-grow" role="feed" aria-label="Recent ledgers" aria-live="polite">
               {ledgers.length === 0 && (
                 <p className="text-gray-700 italic text-xs">
                   Awaiting first ledger pulse...
                 </p>
               )}
               {ledgers.map((l) => (
-                <div
+                <article
                   key={l.sequence}
                   className="p-4 bg-black border-l-2 border-red-600 border-r border-t border-b border-white/5 rounded-r group hover:border-red-500/50 transition-colors"
+                  aria-label={`Ledger #${l.sequence}, ${l.txCount} transactions, at ${l.time}`}
                 >
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-red-500 font-black text-sm">
@@ -140,7 +149,7 @@ export default function SimulatorPage() {
                     </span>
                     <span className="text-gray-600 font-mono">{l.hash}</span>
                   </div>
-                </div>
+                </article>
               ))}
             </div>
           </div>
@@ -152,19 +161,19 @@ export default function SimulatorPage() {
 
           {/* Live Transaction Stream */}
           <div className="lg:col-span-1 bg-zinc-950 border border-white/10 p-6 rounded-2xl flex flex-col shadow-2xl overflow-hidden">
-            <h3 className="text-sm font-bold border-b border-white/10 pb-4 mb-6 uppercase tracking-widest flex items-center justify-between">
+            <h2 className="text-sm font-bold border-b border-white/10 pb-4 mb-6 uppercase tracking-widest flex items-center justify-between">
               TX Stream
               <span className="text-[10px] text-gray-600 font-normal">
                 Memory [50]
               </span>
-            </h3>
+            </h2>
             <div className="flex-grow overflow-y-auto custom-scrollbar">
-              <table className="w-full text-left text-[11px] border-collapse">
+              <table className="w-full text-left text-[11px] border-collapse" aria-label="Live transaction stream" aria-live="polite">
                 <thead>
                   <tr className="text-gray-600 border-b border-white/5 uppercase tracking-widest">
-                    <th className="pb-3 font-normal">Hash</th>
-                    <th className="pb-3 font-normal">Op</th>
-                    <th className="pb-3 font-normal text-right">Status</th>
+                    <th className="pb-3 font-normal" scope="col">Hash</th>
+                    <th className="pb-3 font-normal" scope="col">Op</th>
+                    <th className="pb-3 font-normal text-right" scope="col">Status</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
@@ -172,6 +181,7 @@ export default function SimulatorPage() {
                     <tr
                       key={tx.id}
                       className="group hover:bg-white/5 transition-colors"
+                      aria-label={`Transaction ${tx.id}, operation ${tx.op}, status ${tx.status}`}
                     >
                       <td className="py-3 text-red-500 font-bold tracking-tighter">
                         {tx.id}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { useAuth } from "@/contexts/AuthContext";
 
 export default function Navbar() {
   const pathname = usePathname();
@@ -22,18 +22,26 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="sticky top-0 z-50 w-full border-b border-white/10 bg-black/80 backdrop-blur-md">
+    <nav
+      className="sticky top-0 z-50 w-full border-b border-white/10 bg-black/80 backdrop-blur-md"
+      aria-label="Main navigation"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-20">
           {/* Logo */}
           <div className="flex items-center gap-3">
-            <Link href="/" className="flex items-center gap-3 group">
-              <div className="w-10 h-10 bg-red-600 rounded-lg flex items-center justify-center transform group-hover:rotate-12 transition-transform duration-300 shadow-[0_0_15px_rgba(220,38,38,0.5)]">
+            <Link href="/" className="flex items-center gap-3 group" aria-label="Web3 Lab - Go to homepage">
+              <div
+                className="w-10 h-10 bg-red-600 rounded-lg flex items-center justify-center transform group-hover:rotate-12 transition-transform duration-300 shadow-[0_0_15px_rgba(220,38,38,0.5)]"
+                aria-hidden="true"
+              >
                 <svg
                   className="w-6 h-6 text-white"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
                 >
                   <path
                     strokeLinecap="round"
@@ -50,11 +58,13 @@ export default function Navbar() {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden xl:flex items-center gap-6">
+          <div className="hidden xl:flex items-center gap-6" role="menubar" aria-label="Site navigation">
             {navLinks.map((link) => (
               <Link
                 key={link.path}
                 href={link.path}
+                role="menuitem"
+                aria-current={isActive(link.path) ? "page" : undefined}
                 className={`text-[10px] font-black tracking-[0.2em] transition-colors uppercase ${
                   isActive(link.path)
                     ? "text-red-500"
@@ -71,6 +81,7 @@ export default function Navbar() {
               <div className="flex items-center gap-4">
                 <Link
                   href="/dashboard"
+rent={isActive("/dashboard") ? "page" : undefined}
                   className={`text-[10px] font-black tracking-[0.2em] px-4 py-2 border rounded transition-all uppercase ${
                     isActive("/dashboard")
                       ? "bg-red-600 border-red-500 text-white shadow-[0_0_15px_rgba(220,38,38,0.4)]"
@@ -81,6 +92,7 @@ export default function Navbar() {
                 </Link>
                 <Link
                   href="/certificates"
+                  aria-current={isActive("/certificates") ? "page" : undefined}
                   className={`text-[10px] font-black tracking-[0.2em] px-4 py-2 border rounded transition-all uppercase ${
                     isActive("/certificates")
                       ? "bg-red-600 border-red-500 text-white shadow-[0_0_15px_rgba(220,38,38,0.4)]"
@@ -91,14 +103,16 @@ export default function Navbar() {
                 </Link>
                 <button
                   onClick={logout}
+                  aria-label="Logout from your account"
                   className="w-10 h-10 rounded-full bg-zinc-900 border border-white/10 flex items-center justify-center hover:border-red-500/50 transition-colors group"
-                  title="Logout"
                 >
                   <svg
                     className="w-5 h-5 text-gray-500 group-hover:text-red-500 transition-colors"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
                   >
                     <path
                       strokeLinecap="round"
@@ -131,13 +145,18 @@ export default function Navbar() {
           <div className="xl:hidden flex items-center">
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="text-gray-300 hover:text-white focus:outline-none"
+              aria-expanded={isMobileMenuOpen}
+              aria-controls="mobile-menu"
+              aria-label={isMobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+              className="text-gray-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded"
             >
               <svg
                 className="w-8 h-8"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
+                focusable="false"
               >
                 {isMobileMenuOpen ? (
                   <path
@@ -162,11 +181,18 @@ export default function Navbar() {
 
       {/* Mobile Menu Panel */}
       {isMobileMenuOpen && (
-        <div className="xl:hidden bg-black border-b border-white/10 px-4 pt-2 pb-6 space-y-2 shadow-2xl">
+        <div
+          id="mobile-menu"
+          className="xl:hidden bg-black border-b border-white/10 px-4 pt-2 pb-6 space-y-2 shadow-2xl"
+          role="menu"
+          aria-label="Mobile navigation"
+        >
           {navLinks.map((link) => (
             <Link
               key={link.path}
               href={link.path}
+              role="menuitem"
+              aria-current={isActive(link.path) ? "page" : undefined}
               onClick={() => setIsMobileMenuOpen(false)}
               className={`block px-3 py-3 text-sm font-black tracking-widest uppercase rounded-md transition-colors ${
                 isActive(link.path)
@@ -177,11 +203,12 @@ export default function Navbar() {
               {link.name}
             </Link>
           ))}
-          <div className="h-px w-full bg-white/10 my-2"></div>
+          <div className="h-px w-full bg-white/10 my-2" role="separator"></div>
           {user ? (
             <>
               <Link
                 href="/dashboard"
+                role="menuitem"
                 onClick={() => setIsMobileMenuOpen(false)}
                 className="block px-3 py-3 text-sm font-black tracking-widest text-white uppercase bg-red-600 rounded-md"
               >
@@ -192,6 +219,7 @@ export default function Navbar() {
                   logout();
                   setIsMobileMenuOpen(false);
                 }}
+                role="menuitem"
                 className="block w-full text-left px-3 py-3 text-sm font-black tracking-widest text-red-500 uppercase hover:bg-red-500/10 rounded-md"
               >
                 Logout
@@ -201,6 +229,7 @@ export default function Navbar() {
             <>
               <Link
                 href="/auth/login"
+                role="menuitem"
                 onClick={() => setIsMobileMenuOpen(false)}
                 className="block px-3 py-3 text-sm font-black tracking-widest text-gray-400 hover:text-white uppercase"
               >
@@ -208,6 +237,7 @@ export default function Navbar() {
               </Link>
               <Link
                 href="/auth/register"
+                role="menuitem"
                 onClick={() => setIsMobileMenuOpen(false)}
                 className="block px-3 py-3 text-sm font-black tracking-widest text-red-500 hover:text-red-400 uppercase"
               >

--- a/frontend/src/components/simulator/GraphEdge.tsx
+++ b/frontend/src/components/simulator/GraphEdge.tsx
@@ -13,7 +13,7 @@ export const GraphEdge: React.FC<GraphEdgeProps> = ({ edge }) => {
   if (!source.x || !source.y || !target.x || !target.y) return null;
 
   return (
-    <g>
+    <g aria-hidden="true">
       <line
         x1={source.x}
         y1={source.y}

--- a/frontend/src/components/simulator/GraphNode.tsx
+++ b/frontend/src/components/simulator/GraphNode.tsx
@@ -16,6 +16,10 @@ export const GraphNode: React.FC<GraphNodeProps> = ({ node, onClick }) => {
       animate={{ scale: 1, x: node.x, y: node.y }}
       transition={{ type: 'spring', stiffness: 260, damping: 20 }}
       onClick={() => onClick(node)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(node); }}
+      role="button"
+      tabIndex={0}
+      aria-label={`${node.type === 'account' ? 'Account' : node.type === 'asset' ? 'Asset' : 'Node'}: ${node.label || node.id}. Click to view details.`}
       style={{ cursor: 'pointer' }}
     >
       <circle
@@ -24,6 +28,7 @@ export const GraphNode: React.FC<GraphNodeProps> = ({ node, onClick }) => {
         stroke="#fff"
         strokeWidth={2}
         className="drop-shadow-lg"
+        aria-hidden="true"
       />
       <motion.circle
         r={12}
@@ -32,6 +37,7 @@ export const GraphNode: React.FC<GraphNodeProps> = ({ node, onClick }) => {
         strokeWidth={2}
         animate={{ scale: [1, 1.5, 1], opacity: [0.5, 0, 0.5] }}
         transition={{ duration: 2, repeat: Infinity }}
+        aria-hidden="true"
       />
       <text
         dy={25}
@@ -39,6 +45,7 @@ export const GraphNode: React.FC<GraphNodeProps> = ({ node, onClick }) => {
         fill="#888"
         fontSize="10"
         className="font-mono font-bold uppercase tracking-tighter"
+        aria-hidden="true"
       >
         {node.label || node.id.slice(0, 4)}
       </text>

--- a/frontend/src/components/simulator/NetworkGraph.tsx
+++ b/frontend/src/components/simulator/NetworkGraph.tsx
@@ -53,33 +53,76 @@ export const NetworkGraph: React.FC<NetworkGraphProps> = ({ transactions }) => {
     <div ref={containerRef} className="relative w-full h-full bg-zinc-950 border border-white/10 rounded-2xl overflow-hidden group">
       {/* Controls */}
       <div className="absolute top-4 left-4 z-20 flex flex-col gap-2">
-        <div className="flex items-center gap-2 bg-black/50 backdrop-blur-md border border-white/10 rounded-lg p-1">
-          <button onClick={() => setZoom(z => Math.min(z + 0.1, 2))} className="p-2 hover:bg-white/10 rounded transition-colors">
-            <ZoomIn size={16} />
+        <div className="flex items-center gap-2 bg-black/50 backdrop-blur-md border border-white/10 rounded-lg p-1" role="toolbar" aria-label="Graph zoom controls">
+          <button
+            onClick={() => setZoom(z => Math.min(z + 0.1, 2))}
+            className="p-2 hover:bg-white/10 rounded transition-colors"
+            aria-label="Zoom in"
+          >
+            <ZoomIn size={16} aria-hidden="true" />
           </button>
-          <button onClick={() => setZoom(z => Math.max(z - 0.1, 0.5))} className="p-2 hover:bg-white/10 rounded transition-colors">
-            <ZoomOut size={16} />
+          <button
+            onClick={() => setZoom(z => Math.max(z - 0.1, 0.5))}
+            className="p-2 hover:bg-white/10 rounded transition-colors"
+            aria-label="Zoom out"
+          >
+            <ZoomOut size={16} aria-hidden="true" />
           </button>
-          <button onClick={() => setZoom(1)} className="p-2 hover:bg-white/10 rounded transition-colors">
-            <Maximize size={16} />
+          <button
+            onClick={() => setZoom(1)}
+            className="p-2 hover:bg-white/10 rounded transition-colors"
+            aria-label="Reset zoom to 100%"
+          >
+            <Maximize size={16} aria-hidden="true" />
           </button>
         </div>
       </div>
 
       <div className="absolute top-4 right-4 z-20">
         <div className="flex items-center gap-2 bg-black/50 backdrop-blur-md border border-white/10 rounded-lg px-3 py-1.5">
-          <Search size={14} className="text-gray-500" />
+          <Search size={14} className="text-gray-500" aria-hidden="true" />
+          <label htmlFor="graph-search" className="sr-only">Search account in graph</label>
           <input
+            id="graph-search"
             type="text"
             placeholder="Search Account..."
             className="bg-transparent border-none outline-none text-xs w-32 font-mono"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search account in graph"
           />
         </div>
       </div>
 
-      <svg width="100%" height="100%" viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}>
+      {/* Screen reader description of the graph */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        <p>
+          Network graph visualization showing {graph.nodes.length} nodes and {graph.edges.length} connections.
+          {filteredNodes.length !== graph.nodes.length
+            ? ` Filtered to ${filteredNodes.length} nodes matching "${search}".`
+            : ""}
+          {" "}Nodes represent Stellar accounts and assets. Edges represent transactions between them.
+          {graph.nodes.length > 0 && (
+            ` Accounts: ${graph.nodes.filter(n => n.type === "account").map(n => n.label || n.id.slice(0, 8)).join(", ")}.`
+          )}
+        </p>
+      </div>
+
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        role="img"
+        aria-label={`Stellar network graph with ${graph.nodes.length} nodes and ${graph.edges.length} transaction edges`}
+      >
+        <title>Stellar Network Transaction Graph</title>
+        <desc>
+          An interactive force-directed graph showing Stellar blockchain accounts and assets as nodes,
+          with transaction flows represented as animated edges between them.
+          {graph.nodes.length > 0
+            ? ` Currently displaying ${graph.nodes.filter(n => n.type === "account").length} accounts and ${graph.nodes.filter(n => n.type === "asset").length} assets.`
+            : " No transactions have been recorded yet."}
+        </desc>
         <g transform={`translate(${dimensions.width/2}, ${dimensions.height/2}) scale(${zoom}) translate(${-dimensions.width/2}, ${-dimensions.height/2})`}>
           {graph.edges.map(edge => (
             <GraphEdge key={edge.id} edge={edge} />
@@ -101,14 +144,14 @@ export const NetworkGraph: React.FC<NetworkGraphProps> = ({ transactions }) => {
         />
       )}
 
-      <div className="absolute bottom-4 left-4 pointer-events-none">
+      <div className="absolute bottom-4 left-4 pointer-events-none" aria-hidden="true">
         <h4 className="text-[10px] uppercase tracking-widest text-gray-500 font-black">Graph Visualization Engine</h4>
-        <div className="flex gap-4 mt-1">
-          <div className="flex items-center gap-1.5">
+        <div className="flex gap-4 mt-1" role="list" aria-label="Graph legend">
+          <div className="flex items-center gap-1.5" role="listitem">
             <div className="w-2 h-2 rounded-full bg-red-500"></div>
             <span className="text-[9px] uppercase text-gray-400">Accounts</span>
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5" role="listitem">
             <div className="w-2 h-2 rounded-full bg-blue-500"></div>
             <span className="text-[9px] uppercase text-gray-400">Assets</span>
           </div>

--- a/frontend/src/components/simulator/NodeDetailPanel.tsx
+++ b/frontend/src/components/simulator/NodeDetailPanel.tsx
@@ -16,32 +16,44 @@ export const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ node, onClose 
         animate={{ x: 0, opacity: 1 }}
         exit={{ x: 300, opacity: 0 }}
         className="absolute top-0 right-0 w-80 h-full bg-black/80 backdrop-blur-xl border-l border-white/10 z-30 p-6 flex flex-col gap-6"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Account details for ${node.label || node.id}`}
       >
         <div className="flex justify-between items-center">
-          <h3 className="text-xs font-black uppercase tracking-[0.2em] text-red-500">Account Details</h3>
-          <button onClick={onClose} className="p-1 hover:bg-white/10 rounded">
-            <X size={16} />
+          <h3 className="text-xs font-black uppercase tracking-[0.2em] text-red-500" id="node-detail-title">Account Details</h3>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-white/10 rounded"
+            aria-label="Close account details panel"
+          >
+            <X size={16} aria-hidden="true" />
           </button>
         </div>
 
         <div className="flex flex-col gap-1">
-          <span className="text-[10px] text-gray-500 uppercase tracking-widest font-bold">Public Key</span>
-          <div className="bg-zinc-900 border border-white/5 p-3 rounded font-mono text-[10px] break-all text-gray-300 flex items-center justify-between group">
-            {node.id}
-            <ExternalLink size={12} className="opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer" />
+          <span className="text-[10px] text-gray-500 uppercase tracking-widest font-bold" id="public-key-label">Public Key</span>
+          <div
+            className="bg-zinc-900 border border-white/5 p-3 rounded font-mono text-[10px] break-all text-gray-300 flex items-center justify-between group"
+            aria-labelledby="public-key-label"
+          >
+            <span>{node.id}</span>
+            <ExternalLink size={12} className="opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer" aria-hidden="true" />
           </div>
         </div>
 
         <div className="grid grid-cols-2 gap-4">
           <div className="bg-zinc-900 border border-white/5 p-4 rounded-xl flex flex-col gap-2">
-            <Wallet size={16} className="text-blue-500" />
+            <Wallet size={16} className="text-blue-500" aria-hidden="true" />
             <div className="flex flex-col">
               <span className="text-[9px] text-gray-500 uppercase font-black">Balance</span>
-              <span className="text-sm font-black text-white italic">1,240.50 <span className="text-[10px] text-gray-600 not-italic">XLM</span></span>
+              <span className="text-sm font-black text-white italic">
+                1,240.50 <span className="text-[10px] text-gray-600 not-italic">XLM</span>
+              </span>
             </div>
           </div>
           <div className="bg-zinc-900 border border-white/5 p-4 rounded-xl flex flex-col gap-2">
-            <Activity size={16} className="text-green-500" />
+            <Activity size={16} className="text-green-500" aria-hidden="true" />
             <div className="flex flex-col">
               <span className="text-[9px] text-gray-500 uppercase font-black">Operations</span>
               <span className="text-sm font-black text-white italic">42</span>
@@ -51,7 +63,7 @@ export const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ node, onClose 
 
         <div className="flex flex-col gap-3">
           <h4 className="text-[10px] uppercase font-black tracking-widest text-gray-500 flex items-center gap-2">
-            <Shield size={12} />
+            <Shield size={12} aria-hidden="true" />
             Security Status
           </h4>
           <div className="space-y-2">
@@ -67,7 +79,10 @@ export const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ node, onClose 
         </div>
 
         <div className="mt-auto">
-          <button className="w-full py-3 bg-red-600 hover:bg-red-700 text-white text-[10px] font-black uppercase tracking-widest transition-colors rounded">
+          <button
+            className="w-full py-3 bg-red-600 hover:bg-red-700 text-white text-[10px] font-black uppercase tracking-widest transition-colors rounded"
+            aria-label={`View account ${node.label || node.id} on Stellar Explorer`}
+          >
             View on Explorer
           </button>
         </div>


### PR DESCRIPTION
## ♿ Accessibility Audit & Fixes

Closes #[issue-number]

### Summary

Full accessibility pass across the frontend to meet WCAG 2.1 AA standards. Covers ARIA labeling, keyboard navigation, screen reader support for complex graphs, live regions, focus management, and reduced motion support.

---

### Changes

**Global (`globals.css`, `layout.tsx`)**
- Added skip-to-content link that becomes visible on focus
- Added `id="main-content"` to the root `<main>` element
- Added `.sr-only` utility class for screen reader-only text
- Added `:focus-visible` outline styles for keyboard navigation
- Added `prefers-reduced-motion` media query to disable animations for users who opt out

**Navbar (`Navbar.tsx`)**
- Added `aria-label` to the `<nav>` element
- Added `aria-expanded`, `aria-controls`, and `aria-label` to the mobile menu toggle button
- Added `aria-current="page"` to the active nav link
- Added `aria-label="Logout from your account"` to the icon-only logout button
- Added `role="menubar"` / `role="menu"` to desktop and mobile nav lists
- Added `aria-hidden="true"` and `focusable="false"` to all decorative SVGs

**Homepage (`page.tsx`)**
- Converted hero `<main>` tag to `<section aria-label="Hero">` (layout already provides `<main>`)
- Added `role="status"` and `aria-live="polite"` to the live integration badge
- Added `aria-live="polite"` and `aria-busy` to the stats grid for dynamic content
- Added `aria-label` to each feature card link with descriptive text
- Added `role="contentinfo"` and `aria-label` to the footer
- Wrapped footer links in a `<nav aria-label="Footer navigation">`
- Marked all decorative SVGs and glows as `aria-hidden="true"`

**Network Graph (`NetworkGraph.tsx`, `GraphNode.tsx`, `GraphEdge.tsx`, `NodeDetailPanel.tsx`)**
- Added `<title>` and `<desc>` elements inside the SVG for screen readers
- Added `role="img"` and `aria-label` to the SVG element
- Added a live `aria-live="polite"` region outside the SVG that describes node/edge counts in plain text — this is the "screen reader friendly" description for the complex graph
- Added `<label htmlFor>` to the graph search input
- Added `role="toolbar"` and `aria-label` to the zoom controls; each button now has an `aria-label`
- `GraphNode`: added `role="button"`, `tabIndex={0}`, `aria-label` with node type and ID, and `onKeyDown` for Enter/Space keyboard activation
- `GraphEdge`: marked entirely as `aria-hidden="true"` since it is purely visual
- `NodeDetailPanel`: added `role="dialog"`, `aria-modal="true"`, `aria-label`, and a descriptive `aria-label` on the close button and explorer button

**Simulator Page (`simulator/page.tsx`)**
- Added `aria-pressed` to the sync toggle button
- Added `role="status"` and `aria-live="polite"` to the live feed indicator
- Changed ledger list container to `role="feed"` with `aria-live="polite"`
- Wrapped each ledger entry in `<article>` with a descriptive `aria-label`
- Added `scope="col"` to all table header cells
- Added `aria-label` and `aria-live` to the transaction table
- Added `aria-label` to each transaction row

**Courses Page (`courses/page.tsx`)**
- Changed search input to `type="search"` and added `<label htmlFor>` with `.sr-only`
- Added `aria-live="polite"` and `aria-label` to the courses grid for search result announcements
- Added `role="status"` to the empty state container
- Added descriptive `aria-label` to each course card link
- Marked decorative SVGs as `aria-hidden="true"`

---

closes #288 