### PR TITLE
Add Language Translation Support for International Students

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -127,3 +127,27 @@ LOG_LEVEL=info
 # ------------------------------------------
 # Comma-separated list of allowed origins
 # CORS_ORIGINS="http://localhost:3000,http://localhost:5173"
+
+# ------------------------------------------
+# Rate Limiting Configuration
+# ------------------------------------------
+# Set to 'false' to disable rate limiting entirely
+RATE_LIMIT_ENABLED=true
+
+# Default limits for unauthenticated requests
+RATE_LIMIT_BURST_MAX=20
+RATE_LIMIT_BURST_WINDOW_MS=1000
+RATE_LIMIT_SUSTAINED_MAX=200
+RATE_LIMIT_SUSTAINED_WINDOW_MS=60000
+
+# Limits for authenticated users
+RATE_LIMIT_AUTH_BURST_MAX=80
+RATE_LIMIT_AUTH_SUSTAINED_MAX=600
+
+# Limits for admin users
+RATE_LIMIT_ADMIN_BURST_MAX=200
+RATE_LIMIT_ADMIN_SUSTAINED_MAX=2000
+
+# Strict limits for sensitive endpoints
+RATE_LIMIT_LOGIN_BURST_MAX=5
+RATE_LIMIT_REGISTER_BURST_MAX=3

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -55,6 +55,19 @@ export const config = {
   openai: {
     apiKey: process.env.OPENAI_API_KEY || '',
   },
+  rateLimiting: {
+    enabled: process.env.RATE_LIMIT_ENABLED !== 'false',
+    defaultBurstMax: parseInt(getEnvVar('RATE_LIMIT_BURST_MAX', '20'), 10),
+    defaultBurstWindowMs: parseInt(getEnvVar('RATE_LIMIT_BURST_WINDOW_MS', '1000'), 10),
+    defaultSustainedMax: parseInt(getEnvVar('RATE_LIMIT_SUSTAINED_MAX', '200'), 10),
+    defaultSustainedWindowMs: parseInt(getEnvVar('RATE_LIMIT_SUSTAINED_WINDOW_MS', '60000'), 10),
+    authBurstMax: parseInt(getEnvVar('RATE_LIMIT_AUTH_BURST_MAX', '80'), 10),
+    authSustainedMax: parseInt(getEnvVar('RATE_LIMIT_AUTH_SUSTAINED_MAX', '600'), 10),
+    adminBurstMax: parseInt(getEnvVar('RATE_LIMIT_ADMIN_BURST_MAX', '200'), 10),
+    adminSustainedMax: parseInt(getEnvVar('RATE_LIMIT_ADMIN_SUSTAINED_MAX', '2000'), 10),
+    loginBurstMax: parseInt(getEnvVar('RATE_LIMIT_LOGIN_BURST_MAX', '5'), 10),
+    registerBurstMax: parseInt(getEnvVar('RATE_LIMIT_REGISTER_BURST_MAX', '3'), 10),
+  },
   
   /**
    * Helper to safely log configuration without exposing secrets

--- a/backend/src/config/rateLimit.config.ts
+++ b/backend/src/config/rateLimit.config.ts
@@ -1,0 +1,115 @@
+export interface RateLimitProfile {
+  burst: {
+    windowMs: number;
+    max: number;
+  };
+  sustained: {
+    windowMs: number;
+    max: number;
+  };
+}
+
+export interface RateLimitRule {
+  name: string;
+  priority: number;
+  match: (path: string, method: string) => boolean;
+  profile: RateLimitProfile;
+}
+
+const DEFAULT_PROFILE: RateLimitProfile = {
+  burst: { windowMs: 1000, max: 20 },
+  sustained: { windowMs: 60_000, max: 200 },
+};
+
+const AUTH_PROFILE: RateLimitProfile = {
+  burst: { windowMs: 1000, max: 80 },
+  sustained: { windowMs: 60_000, max: 600 },
+};
+
+const ADMIN_PROFILE: RateLimitProfile = {
+  burst: { windowMs: 1000, max: 200 },
+  sustained: { windowMs: 60_000, max: 2000 },
+};
+
+const rules: RateLimitRule[] = [
+  {
+    name: 'auth-profile-status',
+    priority: 100,
+    match: (path) => path.includes('/auth/profile-status'),
+    profile: { burst: { windowMs: 1000, max: 30 }, sustained: { windowMs: 60_000, max: 120 } },
+  },
+  {
+    name: 'auth-login',
+    priority: 90,
+    match: (path, method) => path.includes('/auth/login') && method === 'POST',
+    profile: { burst: { windowMs: 1000, max: 5 }, sustained: { windowMs: 60_000, max: 20 } },
+  },
+  {
+    name: 'auth-register',
+    priority: 89,
+    match: (path, method) => path.includes('/auth/register') && method === 'POST',
+    profile: { burst: { windowMs: 1000, max: 3 }, sustained: { windowMs: 60_000, max: 10 } },
+  },
+  {
+    name: 'read-heavy',
+    priority: 80,
+    match: (path) => {
+      const readHeavy = ['/certificates', '/enrollments', '/courses'];
+      return readHeavy.some((prefix) => path.includes(prefix));
+    },
+    profile: { burst: { windowMs: 1000, max: 120 }, sustained: { windowMs: 60_000, max: 1000 } },
+  },
+  {
+    name: 'security',
+    priority: 75,
+    match: (path) => path.includes('/security'),
+    profile: { burst: { windowMs: 1000, max: 10 }, sustained: { windowMs: 60_000, max: 60 } },
+  },
+  {
+    name: 'generator',
+    priority: 70,
+    match: (path) => path.includes('/generator'),
+    profile: { burst: { windowMs: 1000, max: 5 }, sustained: { windowMs: 60_000, max: 30 } },
+  },
+  {
+    name: 'export',
+    priority: 65,
+    match: (path) => path.includes('/export'),
+    profile: { burst: { windowMs: 1000, max: 3 }, sustained: { windowMs: 60_000, max: 15 } },
+  },
+  {
+    name: 'contracts',
+    priority: 60,
+    match: (path) => path.includes('/contracts'),
+    profile: { burst: { windowMs: 1000, max: 15 }, sustained: { windowMs: 60_000, max: 100 } },
+  },
+];
+
+let envOverrides: Partial<Record<string, RateLimitProfile>> = {};
+
+export function setRateLimitEnvOverrides(overrides: Partial<Record<string, RateLimitProfile>>): void {
+  envOverrides = overrides;
+}
+
+export function resolveRateLimit(path: string, method: string, isAuthenticated: boolean, isAdmin: boolean): RateLimitProfile {
+  for (const rule of rules) {
+    if (rule.match(path, method)) {
+      const override = envOverrides[rule.name];
+      if (override) {
+        return override;
+      }
+      return rule.profile;
+    }
+  }
+
+  if (isAdmin) return ADMIN_PROFILE;
+  if (isAuthenticated) return AUTH_PROFILE;
+  return DEFAULT_PROFILE;
+}
+
+export function getRateLimitProfile(path: string, method: string, user?: { id: string; role?: string }): RateLimitProfile & { isAuthenticated: boolean; isAdmin: boolean } {
+  const isAuthenticated = !!user;
+  const isAdmin = isAuthenticated && user?.role === 'admin';
+  const profile = resolveRateLimit(path, method, isAuthenticated, isAdmin);
+  return { ...profile, isAuthenticated, isAdmin };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,5 @@
 import cors from 'cors';
 import express, { Request, Response } from 'express';
-import { rateLimit } from 'express-rate-limit';
 import { createServer } from 'http';
 import blockHeaderListener from './cache/BlockHeaderListener.js';
 import cacheMetrics from './cache/CacheMetrics.js';
@@ -11,7 +10,7 @@ import { rpcCacheHeadersMiddleware, rpcCacheMiddleware } from './cache/RPCInterc
 import prisma from './db/index.js';
 import { dbRoutingMiddleware } from './middleware/dbRouting.js';
 import { decryptionMiddleware } from './middleware/encryptionMiddleware.js';
-import { apiRateLimiter } from './middleware/rateLimiter.js';
+import { rateLimiter } from './middleware/rateLimiter.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import { requireWorkspaceMiddleware } from './middleware/WorkspaceContext.js';
 import freelanceRoute from './routes/freelance.js';
@@ -22,6 +21,7 @@ import { pubClient, redisConnection, subClient } from './utils/redis.js';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
 import config from './config/env.config.js';
+import { setRateLimitEnvOverrides } from './config/rateLimit.config.js';
 import { initializeWebSocket } from './websocket/WebSocketServer.js';
 import { initializeSentry, getSentryErrorHandler, getSentryRequestHandler } from './utils/sentry.js';
 import { errorHandler } from './middleware/errorHandler.js';
@@ -61,26 +61,28 @@ export const app: express.Application = express();
 const httpServer = createServer(app);
 const port = config.app.port || 8080;
 
+// Wire rate limit config from environment variables
+setRateLimitEnvOverrides({
+  'auth-login': {
+    burst: { windowMs: 1000, max: config.rateLimiting.loginBurstMax },
+    sustained: { windowMs: 60000, max: config.rateLimiting.defaultSustainedMax },
+  },
+  'auth-register': {
+    burst: { windowMs: 1000, max: config.rateLimiting.registerBurstMax },
+    sustained: { windowMs: 60000, max: config.rateLimiting.defaultSustainedMax },
+  },
+});
+
 app.use(cors());
 app.use(express.json());
 app.use(decryptionMiddleware);
 app.use(dbRoutingMiddleware);
 
-// Global Rate Limiting
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per windowMs
-  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-  message: {
-    status: 'error',
-    message: 'Too many requests from this IP, please try again after 15 minutes',
-  },
-});
+// Global Rate Limiting - configurable, multi-tier, per-user + per-endpoint
+if (config.rateLimiting.enabled) {
+  app.use(rateLimiter);
+}
 
-// Global Rate Limiting - now using sliding window
-app.use(apiRateLimiter);
-app.use(limiter);
 app.use(requestLogger);
 app.use(getSentryRequestHandler());
 

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -1,17 +1,164 @@
 import { NextFunction, Request, Response } from 'express';
+import { getRateLimitProfile } from '../config/rateLimit.config.js';
 import redis from '../utils/redis.js';
 import logger from '../utils/logger.js';
 
+interface TierResult {
+  limit: number;
+  remaining: number;
+  resetMs: number;
+  windowMs: number;
+}
+
+// Legacy interface for the slidingWindowRateLimiter factory
 interface RateLimitOptions {
   windowMs: number;
   limit: number;
   keyPrefix: string;
 }
 
-type ResolvedRateLimitConfig = RateLimitOptions;
+function tierKey(prefix: string, identifier: string, windowMs: number): string {
+  return `rl:${prefix}:${identifier}:${windowMs}`;
+}
 
-export const slidingWindowRateLimiter = (options: RateLimitOptions) => {
+async function checkTier(
+  key: string,
+  windowMs: number,
+  max: number,
+  now: number
+): Promise<TierResult> {
+  const windowStart = now - windowMs;
+  const multi = redis.multi();
+  multi.zremrangebyscore(key, 0, windowStart);
+  multi.zadd(key, now, now.toString());
+  multi.zcard(key);
+  multi.expire(key, Math.ceil(windowMs / 1000) + 1);
+  const results = await multi.exec();
+
+  if (!results) {
+    throw new Error('Redis transaction failed');
+  }
+
+  const requestCount = (results[2]?.[1] as number) ?? 0;
+  const remaining = Math.max(0, max - requestCount);
+
+  return {
+    limit: max,
+    remaining,
+    resetMs: now + windowMs,
+    windowMs,
+  };
+}
+
+function getIdentifier(req: Request): { userKey: string; ipKey: string } {
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  const userId = (req as any).user?.id;
+  return {
+    userKey: userId || ip,
+    ipKey: ip,
+  };
+}
+
+function enforceTier(
+  burst: TierResult,
+  sustained: TierResult,
+  identifier: string,
+  identifierType: string,
+  method: string,
+  path: string,
+  res: Response
+): boolean {
+  const allowed = burst.remaining > 0 && sustained.remaining > 0;
+  const retryAfterMs = Math.max(
+    allowed ? 0 : burst.resetMs - Date.now(),
+    allowed ? 0 : sustained.resetMs - Date.now()
+  );
+
+  const limit = Math.min(burst.limit, sustained.limit);
+  const remaining = Math.min(burst.remaining, sustained.remaining);
+
+  res.setHeader('RateLimit-Limit', limit);
+  res.setHeader('RateLimit-Remaining', remaining);
+  res.setHeader('RateLimit-Reset', new Date(Math.min(burst.resetMs, sustained.resetMs)).toISOString());
+  res.setHeader('X-RateLimit-Burst-Limit', burst.limit);
+  res.setHeader('X-RateLimit-Burst-Remaining', burst.remaining);
+  res.setHeader('X-RateLimit-Sustained-Limit', sustained.limit);
+  res.setHeader('X-RateLimit-Sustained-Remaining', sustained.remaining);
+
+  if (!allowed) {
+    logger.warn(`Rate limit exceeded for ${identifierType} ${identifier} on ${method} ${path}`, {
+      burst: burst.remaining,
+      sustained: sustained.remaining,
+    });
+    res.status(429).json({
+      status: 'error',
+      message: 'Too many requests. Please slow down.',
+      retry_after: Math.ceil(retryAfterMs / 1000),
+    });
+    return false;
+  }
+
+  return true;
+}
+
+// --- New config-driven middleware (used globally) ---
+
+export async function rateLimiter(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (process.env.NODE_ENV === 'test') {
+    return next();
+  }
+
+  const now = Date.now();
+  const path = req.path;
+  const method = req.method;
+  const user = (req as any).user;
+  const profile = getRateLimitProfile(path, method, user);
+  const identifier = getIdentifier(req);
+
+  try {
+    if (profile.isAuthenticated) {
+      const burstKey = tierKey('user', identifier.userKey, profile.burst.windowMs);
+      const sustainedKey = tierKey('user', identifier.userKey, profile.sustained.windowMs);
+
+      const [burst, sustained] = await Promise.all([
+        checkTier(burstKey, profile.burst.windowMs, profile.burst.max, now),
+        checkTier(sustainedKey, profile.sustained.windowMs, profile.sustained.max, now),
+      ]);
+
+      if (!enforceTier(burst, sustained, identifier.userKey, 'user', method, path, res)) {
+        return;
+      }
+    } else {
+      const burstKey = tierKey('ip', identifier.ipKey, profile.burst.windowMs);
+      const sustainedKey = tierKey('ip', identifier.ipKey, profile.sustained.windowMs);
+
+      const [burst, sustained] = await Promise.all([
+        checkTier(burstKey, profile.burst.windowMs, profile.burst.max, now),
+        checkTier(sustainedKey, profile.sustained.windowMs, profile.sustained.max, now),
+      ]);
+
+      if (!enforceTier(burst, sustained, identifier.ipKey, 'IP', method, path, res)) {
+        return;
+      }
+    }
+
+    next();
+  } catch (error) {
+    logger.error('Rate limiter error, failing open:', error);
+    next();
+  }
+}
+
+export const apiRateLimiter = rateLimiter;
+
+// --- Legacy factory for route-specific rate limiting ---
+
+export function slidingWindowRateLimiter(options: RateLimitOptions) {
   return async (req: Request, res: Response, next: NextFunction) => {
+    if (process.env.NODE_ENV === 'test') {
+      return next();
+    }
+
     const ip = req.ip || req.socket.remoteAddress || 'unknown';
     const userId = (req as any).user?.id || 'unauthenticated';
     const key = `${options.keyPrefix}:${userId}:${ip}`;
@@ -19,32 +166,20 @@ export const slidingWindowRateLimiter = (options: RateLimitOptions) => {
     const windowStart = now - options.windowMs;
 
     try {
-      // Use Redis transaction to ensure atomicity
       const multi = redis.multi();
-
-      // Remove timestamps outside the current window
       multi.zremrangebyscore(key, 0, windowStart);
-
-      // Add current request timestamp
       multi.zadd(key, now, now.toString());
-
-      // Count requests in the window
       multi.zcard(key);
-
-      // Set expiration to clean up the set
       multi.expire(key, Math.ceil(options.windowMs / 1000) + 1);
 
       const results = await multi.exec();
-
       if (!results) {
         throw new Error('Redis transaction failed');
       }
 
-      // results[2] contains the ZCARD result
-      const requestCount = (results[2] ? results[2][1] : 0) as number;
+      const requestCount = (results[2]?.[1] as number) ?? 0;
       const remaining = Math.max(0, options.limit - requestCount);
 
-      // Set RateLimit headers
       res.setHeader('X-RateLimit-Limit', options.limit);
       res.setHeader('X-RateLimit-Remaining', remaining);
       res.setHeader('X-RateLimit-Reset', new Date(now + options.windowMs).toISOString());
@@ -61,54 +196,7 @@ export const slidingWindowRateLimiter = (options: RateLimitOptions) => {
       next();
     } catch (error) {
       logger.error('Rate limiter error:', error);
-      // Fail open to avoid blocking users if Redis is down, or fail closed for security
-      // Here we fail open but log the error
       next();
     }
   };
-};
-
-export const apiRateLimiter = async (req: Request, res: Response, next: NextFunction) => {
-  if (process.env.NODE_ENV === 'test') {
-    return next();
-  }
-
-  return slidingWindowRateLimiter(resolveApiRateLimit(req))(req, res, next);
-};
-
-function resolveApiRateLimit(req: Request): ResolvedRateLimitConfig {
-  const isAuth = !!(req as any).user;
-  const baseConfig: ResolvedRateLimitConfig = {
-    windowMs: 1000,
-    limit: isAuth ? 80 : 20,
-    keyPrefix: 'rl:api',
-  };
-
-  if (req.method !== 'GET') {
-    return baseConfig;
-  }
-
-  const path = req.path;
-
-  if (path.startsWith('/api/v1/auth/profile-status')) {
-    return {
-      windowMs: 1000,
-      limit: 30,
-      keyPrefix: 'rl:api:profile-status',
-    };
-  }
-
-  if (
-    path.startsWith('/api/v1/certificates') ||
-    path.startsWith('/api/v1/enrollments') ||
-    path.startsWith('/api/v1/courses')
-  ) {
-    return {
-      windowMs: 1000,
-      limit: isAuth ? 120 : 40,
-      keyPrefix: 'rl:api:read-heavy',
-    };
-  }
-
-  return baseConfig;
 }

--- a/frontend/src/app/courses/[id]/page.tsx
+++ b/frontend/src/app/courses/[id]/page.tsx
@@ -2,8 +2,9 @@
 
 import { useAuth } from '@/contexts/AuthContext';
 import { useWallet } from '@/contexts/WalletContext';
+import { useI18n } from '@/i18n';
 import { certificatesAPI, Course, coursesAPI, enrollmentsAPI } from '@/lib/api';
-import { getCourseContent } from '@/lib/course-content';
+import { getTranslatedCourseContent } from '@/lib/course-content';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -13,6 +14,7 @@ export default function CourseDetailPage() {
   const router = useRouter();
   const { user, isLoading: isAuthLoading } = useAuth();
   const { publicKey } = useWallet();
+  const { t, tn } = useI18n();
   const [course, setCourse] = useState<Course | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isEnrolled, setIsEnrolled] = useState(false);
@@ -86,7 +88,7 @@ export default function CourseDetailPage() {
         <div className="text-center">
           <div className="mx-auto mb-4 h-16 w-16 animate-spin rounded-full border-4 border-red-600/30 border-t-red-600"></div>
           <p className="font-mono text-sm tracking-widest text-red-500 uppercase">
-            Loading Header Data...
+            {t('courses.detail.checking_session')}
           </p>
         </div>
       </div>
@@ -98,21 +100,21 @@ export default function CourseDetailPage() {
       <div className="flex min-h-[calc(100vh-80px)] items-center justify-center bg-black">
         <div className="rounded-2xl border border-red-500/50 bg-zinc-950 p-12 text-center shadow-[0_0_30px_rgba(220,38,38,0.2)]">
           <h2 className="mb-4 text-2xl font-black tracking-widest text-white uppercase">
-            Node Not Found
+            {t('courses.detail.not_found_title')}
           </h2>
           <Link
             href="/courses"
             className="group flex items-center justify-center gap-2 text-sm font-bold tracking-widest text-red-500 uppercase hover:text-red-400"
           >
             <span className="transform transition-transform group-hover:-translate-x-1">←</span>{' '}
-            Return to Directory
+            {t('courses.detail.not_found_back')}
           </Link>
         </div>
       </div>
     );
   }
 
-  const courseContent = getCourseContent(course);
+  const courseContent = getTranslatedCourseContent(course, tn);
 
   return (
     <div className="relative min-h-[calc(100vh-80px)] overflow-hidden bg-black pb-20 text-white">
@@ -127,12 +129,12 @@ export default function CourseDetailPage() {
             className="group mb-8 inline-flex items-center gap-2 text-xs font-bold tracking-widest text-gray-500 uppercase transition-colors hover:text-red-500"
           >
             <span className="transform transition-transform group-hover:-translate-x-1">←</span>{' '}
-            Network Directory
+            {t('courses.detail.back')}
           </Link>
           <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
             <div>
               <div className="mb-4 inline-block rounded-full border border-red-500/20 bg-red-500/10 px-3 py-1 font-mono text-xs tracking-widest text-red-500 uppercase">
-                Module Initialization
+                {t('courses.detail.badge')}
               </div>
               <h1 className="mb-4 text-4xl font-black tracking-tight text-white uppercase transition-colors group-hover:text-red-50 md:text-5xl">
                 {course.title}
@@ -141,19 +143,19 @@ export default function CourseDetailPage() {
               <div className="flex flex-wrap items-center gap-6 font-mono text-sm tracking-wider text-gray-400 uppercase">
                 <span className="flex items-center gap-2">
                   <span className="h-2 w-2 rounded-full bg-gray-600"></span>
-                  Instructor: <span className="text-white">{course.instructor}</span>
+                  {t('courses.detail.instructor')} <span className="text-white">{course.instructor}</span>
                 </span>
                 <span className="flex items-center gap-2">
                   <span className="h-2 w-2 rounded-full bg-red-600"></span>
-                  Payload: <span className="text-white">{course.credits} UNIT</span>
+                  {t('courses.detail.payload')} <span className="text-white">{course.credits} {t('courses.detail.unit')}</span>
                 </span>
                 <span className="flex items-center gap-2">
                   <span className="h-2 w-2 rounded-full bg-emerald-500"></span>
-                  Level: <span className="text-white">{courseContent.level}</span>
+                  {t('courses.detail.level')} <span className="text-white">{courseContent.level}</span>
                 </span>
                 <span className="flex items-center gap-2">
                   <span className="h-2 w-2 rounded-full bg-blue-500"></span>
-                  Duration: <span className="text-white">{courseContent.duration}</span>
+                  {t('courses.detail.duration')} <span className="text-white">{courseContent.duration}</span>
                 </span>
               </div>
             </div>
@@ -168,16 +170,15 @@ export default function CourseDetailPage() {
           <div className="space-y-8 lg:col-span-2">
             <div className="rounded-2xl border border-white/10 bg-zinc-950 p-8 transition-colors hover:border-red-500/30">
               <h2 className="mb-6 flex items-center gap-3 text-2xl font-black tracking-widest text-white uppercase">
-                <span className="inline-block h-4 w-4 rounded-sm bg-red-600"></span> Protocol
-                Specifications
+                <span className="inline-block h-4 w-4 rounded-sm bg-red-600"></span> {t('courses.detail.protocol_specs')}
               </h2>
               <p className="mb-8 text-lg leading-relaxed font-light text-gray-400">
-                {course.description || 'System metadata missing. Awaiting curriculum upload.'}
+                {course.description || t('courses.detail.description_fallback')}
               </p>
 
               <div className="mt-8 border-t border-white/10 pt-8">
                 <h3 className="mb-6 text-lg font-bold tracking-widest text-gray-300 uppercase">
-                  Execution Objectives
+                  {t('courses.detail.execution_objectives')}
                 </h3>
                 <ul className="space-y-4">
                   {courseContent.outcomes.map((outcome) => (
@@ -206,8 +207,7 @@ export default function CourseDetailPage() {
 
             <div className="rounded-2xl border border-white/10 bg-zinc-950 p-8">
               <h2 className="mb-6 flex items-center gap-3 text-2xl font-black tracking-widest text-white uppercase">
-                <span className="inline-block h-4 w-4 rounded-sm bg-emerald-500"></span> Curriculum
-                Map
+                <span className="inline-block h-4 w-4 rounded-sm bg-emerald-500"></span> {t('courses.detail.curriculum_map')}
               </h2>
               <div className="grid gap-4 md:grid-cols-3">
                 {courseContent.modules.map((module, index) => (
@@ -216,7 +216,7 @@ export default function CourseDetailPage() {
                     className="rounded-2xl border border-white/8 bg-white/4 p-5"
                   >
                     <p className="mb-3 text-xs font-bold tracking-[0.18em] text-red-400 uppercase">
-                      Module {index + 1}
+                      {t('courses.detail.module').replace('{number}', String(index + 1))}
                     </p>
                     <h3 className="text-lg font-semibold text-white">{module.title}</h3>
                     <p className="mt-3 text-sm leading-7 text-gray-400">{module.description}</p>
@@ -228,7 +228,7 @@ export default function CourseDetailPage() {
             <div className="grid gap-8 md:grid-cols-2">
               <div className="rounded-2xl border border-white/10 bg-zinc-950 p-8">
                 <h2 className="mb-6 text-xl font-black tracking-widest text-white uppercase">
-                  Deliverables
+                  {t('courses.detail.deliverables')}
                 </h2>
                 <div className="space-y-4">
                   {courseContent.deliverables.map((deliverable) => (
@@ -244,7 +244,7 @@ export default function CourseDetailPage() {
 
               <div className="rounded-2xl border border-white/10 bg-zinc-950 p-8">
                 <h2 className="mb-6 text-xl font-black tracking-widest text-white uppercase">
-                  Tools You Will Touch
+                  {t('courses.detail.tools')}
                 </h2>
                 <div className="flex flex-wrap gap-3">
                   {courseContent.tools.map((tool) => (
@@ -264,7 +264,7 @@ export default function CourseDetailPage() {
           <div className="lg:col-span-1">
             <div className="sticky top-28 rounded-2xl border border-white/10 bg-zinc-950 p-8 shadow-[0_0_30px_rgba(0,0,0,0.5)]">
               <h3 className="mb-6 text-xl font-black tracking-widest text-white uppercase">
-                Connection Status
+                {t('courses.detail.connection_status')}
               </h3>
 
               {isEnrolled ? (
@@ -286,26 +286,25 @@ export default function CourseDetailPage() {
                       </svg>
                     </div>
                     <p className="mb-1 text-sm font-bold tracking-widest text-green-500 uppercase">
-                      Uplink Active
+                      {t('courses.detail.uplink_active')}
                     </p>
                     <p className="font-mono text-xs text-gray-400">
-                      Module execution in progress...
+                      {t('courses.detail.in_progress')}
                     </p>
                   </div>
 
                   <div className="border-t border-white/10 pt-6">
                     <p className="mb-4 text-sm font-light text-gray-400">
-                      Completed the curriculum? Execute the smart contract below to mint your
-                      verifiable credential on the Stellar blockchain.
+                      {t('courses.detail.mint_prompt')}
                     </p>
 
                     {mintSuccess ? (
                       <div className="animate-pulse rounded-xl border border-blue-500/30 bg-blue-500/10 p-4 text-center">
                         <p className="text-sm font-bold tracking-widest text-blue-500 uppercase">
-                          Token Minted
+                          {t('courses.detail.token_minted')}
                         </p>
                         <p className="mt-1 font-mono text-xs text-blue-400/70">
-                          Redirecting to Vault...
+                          {t('courses.detail.redirecting')}
                         </p>
                       </div>
                     ) : (
@@ -318,7 +317,7 @@ export default function CourseDetailPage() {
                             : 'transform bg-red-600 text-white hover:-translate-y-0.5 hover:bg-red-700 hover:shadow-[0_0_30px_rgba(220,38,38,0.6)]'
                         }`}
                       >
-                        {isMinting ? 'Compiling tx...' : 'Extract Certificate'}
+                        {isMinting ? t('courses.detail.compiling_tx') : t('courses.detail.extract_certificate')}
                       </button>
                     )}
                   </div>
@@ -335,23 +334,23 @@ export default function CourseDetailPage() {
                     }`}
                   >
                     {isAuthLoading
-                      ? 'Checking session...'
+                      ? t('courses.detail.checking_session')
                       : !publicKey
-                        ? 'Connect Wallet'
+                        ? t('courses.detail.connect_wallet')
                         : !user
-                          ? 'Complete Profile'
-                          : 'Start Enrollment'}
+                          ? t('courses.detail.complete_profile')
+                          : t('courses.detail.start_enrollment')}
                   </button>
                   <p className="mt-4 text-center font-mono text-xs text-gray-500">
-                    5-step wizard with progress saving
+                    {t('courses.detail.wizard_hint')}
                   </p>
                   {!isAuthLoading && !user && publicKey && (
                     <p className="mt-2 text-center text-xs text-red-400">
-                      Finish your profile once, then enrollment will stay available.
+                      {t('courses.detail.profile_hint')}
                     </p>
                   )}
                   <p className="mt-2 text-center font-mono text-xs text-gray-600">
-                    NO GAS FEES • PUBLIC TESTNET
+                    {t('courses.detail.no_gas_fees')}
                   </p>
                 </div>
               )}
@@ -372,7 +371,7 @@ export default function CourseDetailPage() {
                         d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
                       />
                     </svg>
-                    Asynchronous Execution
+                    {t('courses.detail.async_execution')}
                   </div>
                   <div className="flex items-center gap-4 font-mono text-xs tracking-widest text-gray-400 uppercase">
                     <svg
@@ -388,7 +387,7 @@ export default function CourseDetailPage() {
                         d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
                       />
                     </svg>
-                    On-chain Verification
+                    {t('courses.detail.onchain_verification')}
                   </div>
                   <div className="flex items-center gap-4 font-mono text-xs tracking-widest text-gray-400 uppercase">
                     <svg
@@ -404,7 +403,7 @@ export default function CourseDetailPage() {
                         d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
                       />
                     </svg>
-                    Encrypted Payload
+                    {t('courses.detail.encrypted_payload')}
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useI18n } from '@/i18n';
 import { Course, coursesAPI } from '@/lib/api';
 import { ArrowRight, BookOpen, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 export default function CoursesPage() {
+  const { t } = useI18n();
   const [courses, setCourses] = useState<Course[]>([]);
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(true);
@@ -36,22 +38,24 @@ export default function CoursesPage() {
     return haystack.includes(query.toLowerCase());
   });
 
+  const countLabel = t('courses.page.count_available')
+    .replace('{count}', String(filteredCourses.length))
+    .replace('{plural}', filteredCourses.length === 1 ? '' : 's');
+
   return (
     <div className="mx-auto max-w-7xl px-4 pb-20 pt-12 sm:px-6 lg:px-8">
       <section className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr]">
         <div className="space-y-6">
-          <span className="eyebrow">Learning modules</span>
+          <span className="eyebrow">{t('courses.page.eyebrow')}</span>
           <h1 className="text-4xl font-semibold tracking-tight text-[var(--text-strong)] sm:text-5xl">
-            A clearer catalog for students who just want to get started.
+            {t('courses.page.title')}
           </h1>
           <p className="max-w-xl text-base leading-8 text-[var(--muted)]">
-            Browse the active modules, understand who teaches them, and jump into the next useful
-            step without digging through overloaded screens.
+            {t('courses.page.description')}
           </p>
           <div className="surface-card p-6">
             <p className="text-sm leading-7 text-[var(--muted)]">
-              Focus areas include blockchain fundamentals, Soroban smart contracts, and practical
-              open-source contribution patterns for hackathon teams.
+              {t('courses.page.focus')}
             </p>
           </div>
         </div>
@@ -61,7 +65,7 @@ export default function CoursesPage() {
             htmlFor="course-search"
             className="mb-3 block text-sm font-medium text-[var(--text-strong)]"
           >
-            Search modules
+            {t('courses.page.search_label')}
           </label>
           <div className="relative">
             <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--muted)]" />
@@ -69,14 +73,12 @@ export default function CoursesPage() {
               id="course-search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Try Soroban, DeFi, beginner, Stellar..."
+              placeholder={t('courses.page.search_placeholder')}
               className="w-full rounded-2xl border border-white/12 bg-white/5 px-11 py-3.5 text-sm text-[var(--text-strong)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--brand)]"
             />
           </div>
           <p className="mt-3 text-sm text-[var(--muted)]">
-            {loading
-              ? 'Loading modules...'
-              : `${filteredCourses.length} module${filteredCourses.length === 1 ? '' : 's'} available`}
+            {loading ? t('courses.page.loading') : countLabel}
           </p>
         </div>
       </section>
@@ -100,28 +102,28 @@ export default function CoursesPage() {
                     <BookOpen className="h-5 w-5" />
                   </div>
                   <span className="rounded-full bg-white/6 px-3 py-1 text-xs font-medium text-[var(--text-strong)]">
-                    {course.credits} credits
+                    {t('courses.page.credits').replace('{credits}', String(course.credits))}
                   </span>
                 </div>
                 <h2 className="mt-5 text-xl font-semibold text-[var(--text-strong)]">
                   {course.title}
                 </h2>
                 <p className="mt-3 text-sm leading-7 text-[var(--muted)]">
-                  {course.description || 'Description coming soon.'}
+                  {course.description || t('courses.page.description_fallback')}
                 </p>
               </div>
 
               <div className="mt-8 flex items-center justify-between border-t border-white/8 pt-5">
                 <div>
                   <p className="text-xs uppercase tracking-[0.12em] text-[var(--muted)]">
-                    Instructor
+                    {t('courses.page.instructor')}
                   </p>
                   <p className="mt-1 text-sm font-medium text-[var(--text-strong)]">
                     {course.instructor}
                   </p>
                 </div>
                 <span className="inline-flex items-center gap-2 text-sm font-medium text-[var(--text-strong)]">
-                  Open
+                  {t('courses.page.open')}
                   <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
                 </span>
               </div>
@@ -130,9 +132,9 @@ export default function CoursesPage() {
 
         {!loading && filteredCourses.length === 0 && (
           <div className="surface-card col-span-full p-8 text-center">
-            <h2 className="text-xl font-semibold text-[var(--text-strong)]">No modules found</h2>
+            <h2 className="text-xl font-semibold text-[var(--text-strong)]">{t('courses.page.no_results_title')}</h2>
             <p className="mt-2 text-sm text-[var(--muted)]">
-              Try a different search term or clear the filter to see the full learning catalog.
+              {t('courses.page.no_results_description')}
             </p>
           </div>
         )}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { LanguageSelector } from '@/components/common/LanguageSelector';
 import NotificationBell from '@/components/notifications/NotificationBell';
 import { useAuth } from '@/contexts/AuthContext';
 import { useWallet } from '@/contexts/WalletContext';
@@ -54,6 +55,7 @@ export default function Navbar() {
         </nav>
 
         <div className="hidden items-center gap-3 lg:flex">
+          <LanguageSelector />
           {user ? (
             <>
               <NotificationBell />
@@ -123,6 +125,9 @@ export default function Navbar() {
               </Link>
             ))}
 
+            <div className="mt-4">
+              <LanguageSelector />
+            </div>
             <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
               {user ? (
                 <>

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -1,26 +1,38 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useUserStore } from '@/stores/userStore';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import en from '@/i18n/locales/en.json';
 import es from '@/i18n/locales/es.json';
 import zh from '@/i18n/locales/zh.json';
 
 export type Locale = 'en' | 'es' | 'zh';
-type Dictionary = Record<string, string>;
+type Dictionary = Record<string, unknown>;
 
 const dictionaries: Record<Locale, Dictionary> = { en, es, zh };
 const LOCALE_KEY = 'app:locale';
+
+function getNestedValue(obj: unknown, path: string): unknown {
+  return path.split('.').reduce((current: unknown, key: string) => {
+    if (current && typeof current === 'object' && key in (current as Record<string, unknown>)) {
+      return (current as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
 
 interface I18nContextValue {
   locale: Locale;
   setLocale: (locale: Locale) => void;
   t: (key: string) => string;
+  tn: <T = unknown>(key: string) => T | undefined;
 }
 
 const I18nContext = createContext<I18nContextValue | null>(null);
 
 export function I18nProvider({ children }: { children: React.ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>('en');
+  const updatePreferences = useUserStore((state) => state.updatePreferences);
 
   useEffect(() => {
     const stored = window.localStorage.getItem(LOCALE_KEY) as Locale | null;
@@ -38,13 +50,34 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
     window.localStorage.setItem(LOCALE_KEY, locale);
   }, [locale]);
 
+  const handleSetLocale = useCallback(
+    (newLocale: Locale) => {
+      setLocaleState(newLocale);
+      updatePreferences({ language: newLocale });
+    },
+    [updatePreferences]
+  );
+
   const value = useMemo<I18nContextValue>(
     () => ({
       locale,
-      setLocale: setLocaleState,
-      t: (key: string) => dictionaries[locale][key] ?? dictionaries.en[key] ?? key,
+      setLocale: handleSetLocale,
+      t: (key: string) => {
+        const value = getNestedValue(dictionaries[locale], key);
+        if (typeof value === 'string') return value;
+        const fallback = getNestedValue(dictionaries.en, key);
+        if (typeof fallback === 'string') return fallback;
+        return key;
+      },
+      tn: <T,>(key: string) => {
+        const value = getNestedValue(dictionaries[locale], key);
+        if (value !== undefined) return value as T;
+        const fallback = getNestedValue(dictionaries.en, key);
+        if (fallback !== undefined) return fallback as T;
+        return undefined;
+      },
     }),
-    [locale]
+    [locale, handleSetLocale]
   );
 
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,16 +1,192 @@
 {
-  "nav.modules": "MODULES",
-  "nav.roadmap": "ROADMAP",
-  "nav.quiz": "QUIZ",
-  "nav.playground": "PLAYGROUND",
-  "nav.reviews": "REVIEWS",
-  "nav.simulator": "SIMULATOR",
-  "nav.ideas": "IDEAS",
-  "nav.verify": "VERIFY",
-  "nav.subscriptions": "SUBSCRIPTIONS",
-  "nav.notarization": "NOTARIZATION",
-  "nav.devtools": "DEVTOOLS",
-  "language.english": "English",
-  "language.spanish": "Spanish",
-  "language.chinese": "Chinese"
+  "nav": {
+    "modules": "MODULES",
+    "roadmap": "ROADMAP",
+    "quiz": "QUIZ",
+    "playground": "PLAYGROUND",
+    "reviews": "REVIEWS",
+    "simulator": "SIMULATOR",
+    "ideas": "IDEAS",
+    "verify": "VERIFY",
+    "subscriptions": "SUBSCRIPTIONS",
+    "notarization": "NOTARIZATION",
+    "devtools": "DEVTOOLS"
+  },
+  "language": {
+    "english": "English",
+    "spanish": "Spanish",
+    "chinese": "Chinese"
+  },
+  "courses": {
+    "page": {
+      "eyebrow": "Learning modules",
+      "title": "A clearer catalog for students who just want to get started.",
+      "description": "Browse the active modules, understand who teaches them, and jump into the next useful step without digging through overloaded screens.",
+      "focus": "Focus areas include blockchain fundamentals, Soroban smart contracts, and practical open-source contribution patterns for hackathon teams.",
+      "search_label": "Search modules",
+      "search_placeholder": "Try Soroban, DeFi, beginner, Stellar...",
+      "loading": "Loading modules...",
+      "count_available": "{count} module{plural} available",
+      "no_results_title": "No modules found",
+      "no_results_description": "Try a different search term or clear the filter to see the full learning catalog.",
+      "instructor": "Instructor",
+      "open": "Open",
+      "credits": "{credits} credits",
+      "description_fallback": "Description coming soon."
+    },
+    "detail": {
+      "back": "Network Directory",
+      "badge": "Module Initialization",
+      "instructor": "Instructor:",
+      "payload": "Payload:",
+      "unit": "UNIT",
+      "level": "Level:",
+      "duration": "Duration:",
+      "protocol_specs": "Protocol Specifications",
+      "description_fallback": "System metadata missing. Awaiting curriculum upload.",
+      "execution_objectives": "Execution Objectives",
+      "curriculum_map": "Curriculum Map",
+      "module": "Module {number}",
+      "deliverables": "Deliverables",
+      "tools": "Tools You Will Touch",
+      "connection_status": "Connection Status",
+      "uplink_active": "Uplink Active",
+      "in_progress": "Module execution in progress...",
+      "mint_prompt": "Completed the curriculum? Execute the smart contract below to mint your verifiable credential on the Stellar blockchain.",
+      "token_minted": "Token Minted",
+      "redirecting": "Redirecting to Vault...",
+      "extract_certificate": "Extract Certificate",
+      "compiling_tx": "Compiling tx...",
+      "start_enrollment": "Start Enrollment",
+      "connect_wallet": "Connect Wallet",
+      "complete_profile": "Complete Profile",
+      "checking_session": "Checking session...",
+      "wizard_hint": "5-step wizard with progress saving",
+      "profile_hint": "Finish your profile once, then enrollment will stay available.",
+      "no_gas_fees": "NO GAS FEES \\u2022 PUBLIC TESTNET",
+      "async_execution": "Asynchronous Execution",
+      "onchain_verification": "On-chain Verification",
+      "encrypted_payload": "Encrypted Payload",
+      "not_found_title": "Node Not Found",
+      "not_found_back": "Return to Directory"
+    }
+  },
+  "course": {
+    "cm1yxxxx-intro": {
+      "level": "Beginner",
+      "duration": "3 weeks",
+      "summary": "Build a clear mental model of wallets, ledgers, assets, consensus, and the role Stellar plays in practical Web3 systems.",
+      "outcomes": [
+        "Explain how blockchain networks reach consensus and record state changes",
+        "Understand Stellar accounts, assets, trustlines, and payments",
+        "Navigate wallets, transactions, and explorer tooling confidently"
+      ],
+      "modules": [
+        {
+          "title": "Web3 foundations",
+          "description": "The shift from centralized systems to open, shared infrastructure."
+        },
+        {
+          "title": "Stellar network primitives",
+          "description": "Accounts, balances, assets, trustlines, and transaction flow."
+        },
+        {
+          "title": "Hands-on network operations",
+          "description": "Use wallets, inspect transactions, and simulate real payment scenarios."
+        }
+      ],
+      "deliverables": [
+        "A short ecosystem explainer",
+        "A wallet setup and funding walkthrough",
+        "A basic Stellar transaction demo"
+      ],
+      "tools": ["Freighter", "Stellar Expert", "Testnet faucet", "Explorer tooling"]
+    },
+    "cm1yxxxx-soroban": {
+      "level": "Intermediate",
+      "duration": "5 weeks",
+      "summary": "Learn how to build secure Soroban smart contracts in Rust, test them properly, and deploy them with confidence.",
+      "outcomes": [
+        "Understand Soroban contract structure and storage patterns",
+        "Write contract logic with clear state transitions and validations",
+        "Test and deploy Rust-based contracts to the Stellar testnet"
+      ],
+      "modules": [
+        {
+          "title": "Soroban architecture",
+          "description": "How contracts execute, store data, and interact with transactions."
+        },
+        {
+          "title": "Rust contract patterns",
+          "description": "Functions, storage, auth, and defensive design for smart contracts."
+        },
+        {
+          "title": "Testing and deployment",
+          "description": "Run local tests, simulate scenarios, and publish to testnet."
+        }
+      ],
+      "deliverables": [
+        "A simple stateful contract",
+        "A test suite covering success and failure cases",
+        "A testnet deployment checklist"
+      ],
+      "tools": ["Rust", "Soroban SDK", "Stellar CLI", "Testnet RPC"]
+    },
+    "cm1yxxxx-defi": {
+      "level": "Intermediate",
+      "duration": "4 weeks",
+      "summary": "Explore how DeFi systems are composed, from liquidity pools and AMMs to incentives and risk management.",
+      "outcomes": [
+        "Describe how AMMs and liquidity pools price assets",
+        "Evaluate the risks behind yield, volatility, and slippage",
+        "Design basic token flows for lending, swaps, or rewards"
+      ],
+      "modules": [
+        {
+          "title": "DeFi building blocks",
+          "description": "Pools, LP tokens, swaps, routing, and fee mechanics."
+        },
+        {
+          "title": "Tokenomics and incentives",
+          "description": "How protocols align participation, rewards, and governance."
+        },
+        {
+          "title": "Risk analysis",
+          "description": "Impermanent loss, smart contract risk, and system-level tradeoffs."
+        }
+      ],
+      "deliverables": [
+        "A DeFi protocol teardown",
+        "A token-flow diagram",
+        "A simple AMM math exercise"
+      ],
+      "tools": ["AMM simulators", "Spreadsheet modeling", "Protocol dashboards", "Explorer tooling"]
+    },
+    "default": {
+      "level": "Open level",
+      "duration": "4 weeks",
+      "summary": "This module is ready for enrollment, but its structured curriculum metadata has not been fully published yet.",
+      "outcomes": [
+        "Understand the main concepts covered by the module",
+        "Practice with hands-on labs and guided exercises",
+        "Finish with a project or assessment tied to the module theme"
+      ],
+      "modules": [
+        {
+          "title": "Core concepts",
+          "description": "Learn the vocabulary, mental models, and system basics first."
+        },
+        {
+          "title": "Hands-on practice",
+          "description": "Work through applied exercises and implementation walkthroughs."
+        },
+        {
+          "title": "Project wrap-up",
+          "description": "Bring the pieces together in a final output or review checkpoint."
+        }
+      ],
+      "deliverables": ["Notes and checkpoints", "Hands-on lab work", "Final review artifact"],
+      "tools": ["Wallet tooling", "Explorer tools", "Course exercises"]
+    }
+  }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,16 +1,192 @@
 {
-  "nav.modules": "MODULOS",
-  "nav.roadmap": "RUTA",
-  "nav.quiz": "QUIZ",
-  "nav.playground": "LABORATORIO",
-  "nav.reviews": "REVISIONES",
-  "nav.simulator": "SIMULADOR",
-  "nav.ideas": "IDEAS",
-  "nav.verify": "VERIFICAR",
-  "nav.subscriptions": "SUSCRIPCIONES",
-  "nav.notarization": "NOTARIZACION",
-  "nav.devtools": "HERRAMIENTAS",
-  "language.english": "Ingles",
-  "language.spanish": "Espanol",
-  "language.chinese": "Chino"
+  "nav": {
+    "modules": "MÓDULOS",
+    "roadmap": "RUTA",
+    "quiz": "CUESTIONARIO",
+    "playground": "LABORATORIO",
+    "reviews": "REVISIONES",
+    "simulator": "SIMULADOR",
+    "ideas": "IDEAS",
+    "verify": "VERIFICAR",
+    "subscriptions": "SUSCRIPCIONES",
+    "notarization": "NOTARIZACIÓN",
+    "devtools": "HERRAMIENTAS"
+  },
+  "language": {
+    "english": "Inglés",
+    "spanish": "Español",
+    "chinese": "Chino"
+  },
+  "courses": {
+    "page": {
+      "eyebrow": "Módulos de aprendizaje",
+      "title": "Un catálogo más claro para estudiantes que quieren empezar.",
+      "description": "Explora los módulos activos, conoce quién los enseña y salta al siguiente paso útil sin tener que excavar entre pantallas abarrotadas.",
+      "focus": "Las áreas de enfoque incluyen fundamentos de blockchain, contratos inteligentes Soroban y patrones prácticos de contribución open-source para equipos de hackathon.",
+      "search_label": "Buscar módulos",
+      "search_placeholder": "Prueba Soroban, DeFi, principiante, Stellar...",
+      "loading": "Cargando módulos...",
+      "count_available": "{count} módulo{plural} disponible{plural}",
+      "no_results_title": "No se encontraron módulos",
+      "no_results_description": "Prueba con otro término de búsqueda o limpia el filtro para ver el catálogo completo.",
+      "instructor": "Instructor",
+      "open": "Abrir",
+      "credits": "{credits} créditos",
+      "description_fallback": "Descripción próximamente."
+    },
+    "detail": {
+      "back": "Directorio de Red",
+      "badge": "Inicialización del Módulo",
+      "instructor": "Instructor:",
+      "payload": "Carga:",
+      "unit": "UNIDAD",
+      "level": "Nivel:",
+      "duration": "Duración:",
+      "protocol_specs": "Especificaciones del Protocolo",
+      "description_fallback": "Metadatos del sistema faltantes. Esperando carga del plan de estudios.",
+      "execution_objectives": "Objetivos de Ejecución",
+      "curriculum_map": "Mapa Curricular",
+      "module": "Módulo {number}",
+      "deliverables": "Entregables",
+      "tools": "Herramientas que Usarás",
+      "connection_status": "Estado de Conexión",
+      "uplink_active": "Enlace Activo",
+      "in_progress": "Ejecución del módulo en progreso...",
+      "mint_prompt": "¿Completaste el plan de estudios? Ejecuta el contrato inteligente debajo para acuñar tu credencial verificable en la blockchain de Stellar.",
+      "token_minted": "Token Acuñado",
+      "redirecting": "Redirigiendo a la Bóveda...",
+      "extract_certificate": "Extraer Certificado",
+      "compiling_tx": "Compilando tx...",
+      "start_enrollment": "Iniciar Inscripción",
+      "connect_wallet": "Conectar Wallet",
+      "complete_profile": "Completar Perfil",
+      "checking_session": "Verificando sesión...",
+      "wizard_hint": "Asistente de 5 pasos con guardado de progreso",
+      "profile_hint": "Completa tu perfil una vez y la inscripción estará siempre disponible.",
+      "no_gas_fees": "SIN TASAS GAS • TESTNET PÚBLICO",
+      "async_execution": "Ejecución Asíncrona",
+      "onchain_verification": "Verificación en Cadena",
+      "encrypted_payload": "Carga Cifrada",
+      "not_found_title": "Nodo No Encontrado",
+      "not_found_back": "Volver al Directorio"
+    }
+  },
+  "course": {
+    "cm1yxxxx-intro": {
+      "level": "Principiante",
+      "duration": "3 semanas",
+      "summary": "Construye un modelo mental claro de wallets, libros contables, activos, consenso y el rol que juega Stellar en sistemas Web3 prácticos.",
+      "outcomes": [
+        "Explicar cómo las redes blockchain alcanzan consenso y registran cambios de estado",
+        "Comprender cuentas, activos, trustlines y pagos en Stellar",
+        "Navegar con confianza por wallets, transacciones y herramientas de exploración"
+      ],
+      "modules": [
+        {
+          "title": "Fundamentos de Web3",
+          "description": "La transición de sistemas centralizados a infraestructura abierta y compartida."
+        },
+        {
+          "title": "Primitivas de la red Stellar",
+          "description": "Cuentas, saldos, activos, trustlines y flujo de transacciones."
+        },
+        {
+          "title": "Operaciones prácticas de red",
+          "description": "Usa wallets, inspecciona transacciones y simula escenarios de pago reales."
+        }
+      ],
+      "deliverables": [
+        "Un breve explicador del ecosistema",
+        "Una guía de configuración y financiación de wallet",
+        "Una demostración básica de transacción en Stellar"
+      ],
+      "tools": ["Freighter", "Stellar Expert", "Testnet faucet", "Herramientas de exploración"]
+    },
+    "cm1yxxxx-soroban": {
+      "level": "Intermedio",
+      "duration": "5 semanas",
+      "summary": "Aprende a construir contratos inteligentes Soroban seguros en Rust, probarlos adecuadamente y desplegarlos con confianza.",
+      "outcomes": [
+        "Comprender la estructura de contratos Soroban y patrones de almacenamiento",
+        "Escribir lógica de contrato con transiciones de estado y validaciones claras",
+        "Probar y desplegar contratos Rust en la testnet de Stellar"
+      ],
+      "modules": [
+        {
+          "title": "Arquitectura Soroban",
+          "description": "Cómo los contratos ejecutan, almacenan datos e interactúan con transacciones."
+        },
+        {
+          "title": "Patrones de contratos Rust",
+          "description": "Funciones, almacenamiento, autenticación y diseño defensivo para contratos inteligentes."
+        },
+        {
+          "title": "Pruebas y despliegue",
+          "description": "Ejecuta pruebas locales, simula escenarios y publica en testnet."
+        }
+      ],
+      "deliverables": [
+        "Un contrato con estado simple",
+        "Un conjunto de pruebas que cubra casos de éxito y fallo",
+        "Una lista de verificación para despliegue en testnet"
+      ],
+      "tools": ["Rust", "Soroban SDK", "Stellar CLI", "Testnet RPC"]
+    },
+    "cm1yxxxx-defi": {
+      "level": "Intermedio",
+      "duration": "4 semanas",
+      "summary": "Explora cómo se componen los sistemas DeFi, desde pools de liquidez y AMMs hasta incentivos y gestión de riesgos.",
+      "outcomes": [
+        "Describir cómo los AMMs y pools de liquidez valoran activos",
+        "Evaluar los riesgos detrás del rendimiento, volatilidad y deslizamiento",
+        "Diseñar flujos básicos de tokens para préstamos, intercambios o recompensas"
+      ],
+      "modules": [
+        {
+          "title": "Bloques de construcción DeFi",
+          "description": "Pools, tokens LP, intercambios, enrutamiento y mecánicas de comisiones."
+        },
+        {
+          "title": "Tokenómica e incentivos",
+          "description": "Cómo los protocolos alinean participación, recompensas y gobernanza."
+        },
+        {
+          "title": "Análisis de Riesgos",
+          "description": "Pérdida impermanente, riesgo de contratos inteligentes y compensaciones a nivel de sistema."
+        }
+      ],
+      "deliverables": [
+        "Un análisis de un protocolo DeFi",
+        "Un diagrama de flujo de tokens",
+        "Un ejercicio simple de matemáticas de AMM"
+      ],
+      "tools": ["Simuladores AMM", "Modelado en hojas de cálculo", "Paneles de protocolo", "Herramientas de exploración"]
+    },
+    "default": {
+      "level": "Nivel abierto",
+      "duration": "4 semanas",
+      "summary": "Este módulo está listo para inscripción, pero su metadato curricular estructurado aún no se ha publicado completamente.",
+      "outcomes": [
+        "Comprender los conceptos principales cubiertos por el módulo",
+        "Practicar con laboratorios prácticos y ejercicios guiados",
+        "Finalizar con un proyecto o evaluación vinculada al tema del módulo"
+      ],
+      "modules": [
+        {
+          "title": "Conceptos básicos",
+          "description": "Aprende primero el vocabulario, modelos mentales y fundamentos del sistema."
+        },
+        {
+          "title": "Práctica hands-on",
+          "description": "Trabaja con ejercicios aplicados y guías de implementación."
+        },
+        {
+          "title": "Cierre del proyecto",
+          "description": "Integra todo en un resultado final o punto de revisión."
+        }
+      ],
+      "deliverables": ["Notas y puntos de control", "Trabajo práctico de laboratorio", "Artefacto de revisión final"],
+      "tools": ["Herramientas de wallet", "Exploradores", "Ejercicios del curso"]
+    }
+  }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1,16 +1,192 @@
 {
-  "nav.modules": "模块",
-  "nav.roadmap": "路线图",
-  "nav.quiz": "测验",
-  "nav.playground": "实验场",
-  "nav.reviews": "评审",
-  "nav.simulator": "模拟器",
-  "nav.ideas": "想法",
-  "nav.verify": "验证",
-  "nav.subscriptions": "订阅",
-  "nav.notarization": "公证",
-  "nav.devtools": "开发工具",
-  "language.english": "英语",
-  "language.spanish": "西班牙语",
-  "language.chinese": "中文"
+  "nav": {
+    "modules": "模块",
+    "roadmap": "路线图",
+    "quiz": "测验",
+    "playground": "实验场",
+    "reviews": "评审",
+    "simulator": "模拟器",
+    "ideas": "想法",
+    "verify": "验证",
+    "subscriptions": "订阅",
+    "notarization": "公证",
+    "devtools": "开发工具"
+  },
+  "language": {
+    "english": "英语",
+    "spanish": "西班牙语",
+    "chinese": "中文"
+  },
+  "courses": {
+    "page": {
+      "eyebrow": "学习模块",
+      "title": "为想要快速入门的学生提供更清晰的课程目录。",
+      "description": "浏览活跃模块，了解授课教师，直接进入下一个有用的步骤，无需在过载的屏幕中挖掘。",
+      "focus": "重点领域包括区块链基础、Soroban智能合约以及为黑客松团队提供的实用开源贡献模式。",
+      "search_label": "搜索模块",
+      "search_placeholder": "试试搜索 Soroban、DeFi、入门、Stellar...",
+      "loading": "加载模块中...",
+      "count_available": "共 {count} 个模块可用",
+      "no_results_title": "未找到模块",
+      "no_results_description": "尝试其他搜索词或清除筛选条件以查看完整学习目录。",
+      "instructor": "讲师",
+      "open": "打开",
+      "credits": "{credits} 学分",
+      "description_fallback": "描述即将推出。"
+    },
+    "detail": {
+      "back": "网络目录",
+      "badge": "模块初始化",
+      "instructor": "讲师：",
+      "payload": "负载：",
+      "unit": "单元",
+      "level": "级别：",
+      "duration": "时长：",
+      "protocol_specs": "协议规范",
+      "description_fallback": "系统元数据缺失，等待课程资料上传。",
+      "execution_objectives": "执行目标",
+      "curriculum_map": "课程地图",
+      "module": "模块 {number}",
+      "deliverables": "交付物",
+      "tools": "你将使用的工具",
+      "connection_status": "连接状态",
+      "uplink_active": "上行链路已激活",
+      "in_progress": "模块执行中...",
+      "mint_prompt": "完成课程了？执行下面的智能合约，在Stellar区块链上铸造你的可验证凭证。",
+      "token_minted": "代币已铸造",
+      "redirecting": "正在重定向到保管库...",
+      "extract_certificate": "提取证书",
+      "compiling_tx": "编译交易中...",
+      "start_enrollment": "开始注册",
+      "connect_wallet": "连接钱包",
+      "complete_profile": "完善资料",
+      "checking_session": "检查会话中...",
+      "wizard_hint": "5步向导，支持进度保存",
+      "profile_hint": "完善一次资料，注册将始终可用。",
+      "no_gas_fees": "无 Gas 费 • 公共测试网",
+      "async_execution": "异步执行",
+      "onchain_verification": "链上验证",
+      "encrypted_payload": "加密负载",
+      "not_found_title": "节点未找到",
+      "not_found_back": "返回目录"
+    }
+  },
+  "course": {
+    "cm1yxxxx-intro": {
+      "level": "入门",
+      "duration": "3周",
+      "summary": "建立关于钱包、账本、资产、共识以及Stellar在实用Web3系统中角色的清晰心智模型。",
+      "outcomes": [
+        "解释区块链网络如何达成共识并记录状态变更",
+        "理解Stellar账户、资产、信任线和支付",
+        "自信地使用钱包、交易和浏览器工具"
+      ],
+      "modules": [
+        {
+          "title": "Web3基础",
+          "description": "从中心化系统向开放共享基础设施的转变。"
+        },
+        {
+          "title": "Stellar网络原语",
+          "description": "账户、余额、资产、信任线和交易流程。"
+        },
+        {
+          "title": "动手网络操作",
+          "description": "使用钱包、检查交易、模拟真实支付场景。"
+        }
+      ],
+      "deliverables": [
+        "一份简短的生态系统说明",
+        "钱包设置和资金入门指南",
+        "一个基本的Stellar交易演示"
+      ],
+      "tools": ["Freighter", "Stellar Expert", "测试网水龙头", "浏览器工具"]
+    },
+    "cm1yxxxx-soroban": {
+      "level": "中级",
+      "duration": "5周",
+      "summary": "学习如何使用Rust构建安全的Soroban智能合约，正确测试并自信地部署它们。",
+      "outcomes": [
+        "理解Soroban合约结构和存储模式",
+        "编写具有清晰状态转换和验证的合约逻辑",
+        "测试并将基于Rust的合约部署到Stellar测试网"
+      ],
+      "modules": [
+        {
+          "title": "Soroban架构",
+          "description": "合约如何执行、存储数据以及与交易交互。"
+        },
+        {
+          "title": "Rust合约模式",
+          "description": "智能合约的函数、存储、认证和防御性设计。"
+        },
+        {
+          "title": "测试与部署",
+          "description": "运行本地测试、模拟场景并发布到测试网。"
+        }
+      ],
+      "deliverables": [
+        "一个简单的有状态合约",
+        "涵盖成功和失败案例的测试套件",
+        "一份测试网部署清单"
+      ],
+      "tools": ["Rust", "Soroban SDK", "Stellar CLI", "测试网 RPC"]
+    },
+    "cm1yxxxx-defi": {
+      "level": "中级",
+      "duration": "4周",
+      "summary": "探索DeFi系统的组成，从流动性池和AMM到激励机制和风险管理。",
+      "outcomes": [
+        "描述AMM和流动性池如何为资产定价",
+        "评估收益、波动性和滑点背后的风险",
+        "设计借贷、交换或奖励的基本代币流程"
+      ],
+      "modules": [
+        {
+          "title": "DeFi构建块",
+          "description": "流动性池、LP代币、交换、路由和费用机制。"
+        },
+        {
+          "title": "代币经济学与激励",
+          "description": "协议如何协调参与、奖励和治理。"
+        },
+        {
+          "title": "风险分析",
+          "description": "无常损失、智能合约风险和系统级权衡。"
+        }
+      ],
+      "deliverables": [
+        "一份DeFi协议分析报告",
+        "一份代币流程图",
+        "一个简单的AMM数学练习"
+      ],
+      "tools": ["AMM模拟器", "电子表格建模", "协议仪表板", "浏览器工具"]
+    },
+    "default": {
+      "level": "开放级别",
+      "duration": "4周",
+      "summary": "此模块已可注册，但其结构化课程元数据尚未完全发布。",
+      "outcomes": [
+        "理解模块涵盖的主要概念",
+        "通过动手实验室和引导练习进行实践",
+        "完成与模块主题相关的项目或评估"
+      ],
+      "modules": [
+        {
+          "title": "核心概念",
+          "description": "首先学习词汇、心智模型和系统基础知识。"
+        },
+        {
+          "title": "动手实践",
+          "description": "完成应用练习和实施演练。"
+        },
+        {
+          "title": "项目总结",
+          "description": "在最终产出或评审检查点中将各部分整合起来。"
+        }
+      ],
+      "deliverables": ["笔记和检查点", "动手实验室工作", "最终评审成果"],
+      "tools": ["钱包工具", "浏览器工具", "课程练习"]
+    }
+  }
 }

--- a/frontend/src/lib/course-content.ts
+++ b/frontend/src/lib/course-content.ts
@@ -161,3 +161,44 @@ export function getCourseContent(course: Course): CourseContent {
     summary: course.description || DEFAULT_CONTENT.summary,
   };
 }
+
+function resolveCourseContentKey(course: Course): string {
+  if (COURSE_CONTENT[course.id]) return course.id;
+  const title = course.title.toLowerCase();
+  if (title.includes('soroban')) return 'cm1yxxxx-soroban';
+  if (title.includes('stellar') || title.includes('web3')) return 'cm1yxxxx-intro';
+  if (title.includes('defi')) return 'cm1yxxxx-defi';
+  return 'default';
+}
+
+interface ModuleTranslation {
+  title: string;
+  description: string;
+}
+
+export function getTranslatedCourseContent(
+  course: Course,
+  tn: <T>(key: string) => T | undefined
+): CourseContent {
+  const base = getCourseContent(course);
+  const key = resolveCourseContentKey(course);
+  const prefix = `course.${key}`;
+
+  const translatedLevel = tn<string>(`${prefix}.level`);
+  const translatedDuration = tn<string>(`${prefix}.duration`);
+  const translatedSummary = tn<string>(`${prefix}.summary`);
+  const translatedOutcomes = tn<string[]>(`${prefix}.outcomes`);
+  const translatedModules = tn<ModuleTranslation[]>(`${prefix}.modules`);
+  const translatedDeliverables = tn<string[]>(`${prefix}.deliverables`);
+  const translatedTools = tn<string[]>(`${prefix}.tools`);
+
+  return {
+    level: translatedLevel ?? base.level,
+    duration: translatedDuration ?? base.duration,
+    summary: translatedSummary ?? base.summary,
+    outcomes: translatedOutcomes ?? base.outcomes,
+    modules: translatedModules ?? base.modules,
+    deliverables: translatedDeliverables ?? base.deliverables,
+    tools: translatedTools ?? base.tools,
+  };
+}


### PR DESCRIPTION
Close #597 

Add multi-language support for core educational content with automatic detection and manual selection.

This is an important, MVP-critical feature designed to expand the platform's impact globally.

🛠️ Implementation Requirements
Build translation support.
Include comprehensive unit tests with coverage >90%.
Add thorough documentation and educational comments.
Integrate with existing i18n infrastructure.
🔧 Technical Specifications
Built with React and TypeScript.
Use next-intl for internationalization.
Follow accessibility best practices (WCAG 2.1).
Include proper error handling and fallbacks.
✅ Acceptance Criteria
Translations load correctly.
Language switching works as expected.
All unit tests pass with full coverage.
Documentation is complete and educational.

Closes #604 

## Summary

Replaces the previous basic rate limiting (fixed-window `express-rate-limit` + hardcoded sliding window) with a comprehensive, configurable, multi-tier rate limiting system that protects against abuse and DoS attacks.

## Changes

### New file: `backend/src/config/rateLimit.config.ts`
- Centralized rate limit profile definitions per endpoint
- Endpoint-specific rules with priority-based matching:
  - `auth/login` (POST): 5 req/s burst, 20 req/min sustained
  - `auth/register` (POST): 3 req/s burst, 10 req/min sustained
  - `/certificates`, `/enrollments`, `/courses`: 120 req/s burst, 1000 req/min
  - `/security`: 10 req/s burst, 60 req/min
  - `/generator`: 5 req/s burst, 30 req/min
  - `/contracts`: 15 req/s burst, 100 req/min
- Role-based fallback profiles: unauthenticated (20/200), authenticated (80/600), admin (200/2000)
- Env-var override support via `setRateLimitEnvOverrides()`

### Rewritten: `backend/src/middleware/rateLimiter.ts`
- **Dual-tier rate limiting**: burst (short window) + sustained (long window) checked together
- **Per-user tracking**: authenticated requests keyed by `userId` for accurate quota enforcement
- **Per-IP tracking**: anonymous requests keyed by IP address
- **Standard RateLimit headers**: `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`
- **Detailed debug headers**: `X-RateLimit-Burst-*`, `X-RateLimit-Sustained-*`
- **Fail-open**: if Redis is unavailable, requests proceed with a warning log
- **Test mode bypass**: skips rate limiting in `NODE_ENV=test`
- **Abuse logging**: WARN-level logs when limits are exceeded (user/IP, endpoint, remaining quota)
- Preserved legacy `slidingWindowRateLimiter` factory for route-specific overrides

### Modified: `backend/src/index.ts`
- Replaced `express-rate-limit` + old `apiRateLimiter` with new `rateLimiter` middleware
- Rate limiting is conditionally applied via `config.rateLimiting.enabled`
- Wires env-var overrides for login/register limits

### Modified: `backend/src/config/env.config.ts`
- Added `rateLimiting` config section with env-var-backed settings

### Modified: `backend/.env.example`
- Added all `RATE_LIMIT_*` environment variables with documentation

## Configuration via environment variables

| Variable | Default | Description |
|---|---|---|
| `RATE_LIMIT_ENABLED` | true | Toggle rate limiting |
| `RATE_LIMIT_BURST_MAX` | 20 | Default burst limit (unauth) |
| `RATE_LIMIT_SUSTAINED_MAX` | 200 | Default sustained limit (unauth) |
| `RATE_LIMIT_AUTH_BURST_MAX` | 80 | Burst limit for authenticated users |
| `RATE_LIMIT_AUTH_SUSTAINED_MAX` | 600 | Sustained limit for authenticated users |
| `RATE_LIMIT_ADMIN_BURST_MAX` | 200 | Burst limit for admin users |
| `RATE_LIMIT_ADMIN_SUSTAINED_MAX` | 2000 | Sustained limit for admin users |
| `RATE_LIMIT_LOGIN_BURST_MAX` | 5 | Login endpoint burst limit |
| `RATE_LIMIT_REGISTER_BURST_MAX` | 3 | Registration endpoint burst limit |

## Testing

- Rate limiting applied globally with per-endpoint override rules
- Authenticated users tracked by userId, anonymous by IP
- Both burst and sustained limits must be satisfied
- Fail-open when Redis is unavailable
- Skipped entirely in test environment