### PR TITLE
Add offline support with service worker caching

### DIFF
--- a/docs/frontend/FRONTEND_README.md
+++ b/docs/frontend/FRONTEND_README.md
@@ -158,6 +158,13 @@ import { verifyCertificateOnChain } from "@/lib/soroban";
 const cert = await verifyCertificateOnChain("CERTIFICATE_SYMBOL");
 ```
 
+**Offline Mode**
+
+- The frontend now supports offline mode for learning content and core navigation.
+- A Service Worker is registered from `public/sw.js` to cache the app shell and navigation assets.
+- API responses for learning data are persisted in `localStorage` so previously viewed content loads when offline.
+- Offline write requests are queued in IndexedDB and automatically synchronized when connectivity returns.
+
 **Note**: Full blockchain integration requires:
 
 1. Deployed Soroban contract on Stellar network

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -12,10 +12,13 @@ export const metadata: Metadata = {
 
 import Navbar from '@/components/layout/Navbar';
 import ResiliencyBanner from '@/components/layout/ResiliencyBanner';
+import { OfflineNotification } from '@/components/notifications/OfflineNotification';
+import { OfflineReadyNotification } from '@/components/notifications/OfflineReadyNotification';
 import { ToastContainer } from '@/components/notifications/ToastContainer';
+import { OfflineSyncHandler } from '@/components/OfflineSyncHandler';
 import { NotificationProvider } from '@/contexts/NotificationContext';
-import { I18nProvider } from '@/i18n';
 import { Web3OnboardingProvider } from '@/contexts/Web3OnboardingContext';
+import { I18nProvider } from '@/i18n';
 
 export default function RootLayout({
   children,
@@ -55,6 +58,9 @@ export default function RootLayout({
                     </a>
                     <Navbar />
                     <ResiliencyBanner />
+                    <OfflineSyncHandler />
+                    <OfflineNotification />
+                    <OfflineReadyNotification />
                     <main id="main-content" className="flex-grow">
                       {children}
                     </main>

--- a/frontend/src/components/OfflineSyncHandler.tsx
+++ b/frontend/src/components/OfflineSyncHandler.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { flushQueuedRequests, registerOnlineSync } from '@/lib/offline-sync';
+import { useEffect } from 'react';
+
+export function OfflineSyncHandler() {
+  useEffect(() => {
+    const cleanup = registerOnlineSync();
+
+    if (navigator.onLine) {
+      flushQueuedRequests().catch((error) => {
+        console.error('[OfflineSyncHandler] Failed to flush queued requests:', error);
+      });
+    }
+
+    return cleanup;
+  }, []);
+
+  return null;
+}

--- a/frontend/src/lib/api-cache.test.ts
+++ b/frontend/src/lib/api-cache.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequestCache } from './api-cache';
+
+describe('apiRequestCache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('stores successful responses in localStorage', async () => {
+    const result = await apiRequestCache.fetch(
+      'courses:list',
+      async () => {
+        return { id: 'c1', title: 'Blockchain Basics' };
+      },
+      { ttlMs: 1000 }
+    );
+
+    expect(result).toEqual({ id: 'c1', title: 'Blockchain Basics' });
+    expect(localStorage.getItem('web3-student-lab-api-cache:courses:list')).toBeTruthy();
+  });
+
+  it('returns cached response when network fails and offline', async () => {
+    const persisted = {
+      data: { id: 'c2', title: 'Smart Contracts 101' },
+      expiresAt: Date.now() + 1000,
+    };
+    localStorage.setItem('web3-student-lab-api-cache:courses:detail:c2', JSON.stringify(persisted));
+
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+
+    const result = await apiRequestCache.fetch(
+      'courses:detail:c2',
+      async () => {
+        throw new Error('Network unavailable');
+      },
+      { ttlMs: 1000 }
+    );
+
+    expect(result).toEqual(persisted.data);
+  });
+});

--- a/frontend/src/lib/api-cache.ts
+++ b/frontend/src/lib/api-cache.ts
@@ -10,6 +10,37 @@ interface CachedFetchOptions {
   allowStaleOnRateLimit?: boolean;
 }
 
+const PERSIST_PREFIX = 'web3-student-lab-api-cache:';
+
+function persistCacheEntry<T>(key: string, entry: CacheEntry<T>) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(`${PERSIST_PREFIX}${key}`, JSON.stringify(entry));
+  } catch {
+    // Ignore storage errors. Offline fallback should not break the app.
+  }
+}
+
+function loadPersistedCacheEntry<T>(key: string): CacheEntry<T> | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = localStorage.getItem(`${PERSIST_PREFIX}${key}`);
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(stored) as CacheEntry<T>;
+  } catch {
+    return null;
+  }
+}
+
 class ApiRequestCache {
   private cache = new Map<string, CacheEntry<unknown>>();
   private inFlight = new Map<string, Promise<unknown>>();
@@ -22,6 +53,8 @@ class ApiRequestCache {
     const { ttlMs = 15_000, allowStaleOnRateLimit = true } = options;
     const now = Date.now();
     const cached = this.cache.get(key) as CacheEntry<T> | undefined;
+    const persisted = loadPersistedCacheEntry<T>(key);
+    const isOffline = typeof window !== 'undefined' && !navigator.onLine;
 
     if (cached && cached.expiresAt > now) {
       return cached.data;
@@ -35,16 +68,26 @@ class ApiRequestCache {
     const request = (async () => {
       try {
         const data = await fetcher();
-        this.cache.set(key, {
+        const entry: CacheEntry<T> = {
           data,
           expiresAt: Date.now() + ttlMs,
-        });
+        };
+        this.cache.set(key, entry);
+        persistCacheEntry(key, entry);
         return data;
       } catch (error) {
         if (allowStaleOnRateLimit && cached && axios.isAxiosError(error)) {
           if (error.response?.status === 429) {
             return cached.data;
           }
+        }
+
+        if (isOffline && persisted) {
+          return persisted.data;
+        }
+
+        if (persisted && persisted.expiresAt > now) {
+          return persisted.data;
         }
 
         throw error;
@@ -60,6 +103,9 @@ class ApiRequestCache {
   invalidate(key: string) {
     this.cache.delete(key);
     this.inFlight.delete(key);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(`${PERSIST_PREFIX}${key}`);
+    }
   }
 
   invalidatePrefix(prefix: string) {
@@ -72,6 +118,15 @@ class ApiRequestCache {
     for (const key of this.inFlight.keys()) {
       if (key.startsWith(prefix)) {
         this.inFlight.delete(key);
+      }
+    }
+
+    if (typeof window !== 'undefined') {
+      for (let i = 0; i < localStorage.length; i += 1) {
+        const storageKey = localStorage.key(i);
+        if (storageKey?.startsWith(PERSIST_PREFIX + prefix)) {
+          localStorage.removeItem(storageKey);
+        }
       }
     }
   }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { API_BASE_URL, getWorkspaceId } from './api-config';
+import { queueOfflineRequest } from './offline-sync';
 
 // Create axios instance
 const apiClient = axios.create({
@@ -13,6 +14,37 @@ import { encryptPayload } from './encryption';
 
 // Add token to requests if available
 apiClient.interceptors.request.use(async (config) => {
+  const isBrowser = typeof window !== 'undefined';
+  const method = config.method?.toLowerCase();
+
+  if (
+    isBrowser &&
+    !navigator.onLine &&
+    method &&
+    ['post', 'put', 'patch', 'delete'].includes(method) &&
+    config.url
+  ) {
+    const url = config.baseURL
+      ? new URL(config.url, config.baseURL).toString()
+      : config.url;
+
+    await queueOfflineRequest({
+      url,
+      method: method.toUpperCase() as 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+      headers: { ...(config.headers as Record<string, string>) },
+      body:
+        typeof config.data === 'string'
+          ? config.data
+          : config.data !== undefined
+          ? JSON.stringify(config.data)
+          : undefined,
+    });
+
+    return Promise.reject(
+      new Error('Offline: request queued for later synchronization.')
+    );
+  }
+
   const token = localStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
@@ -40,12 +72,44 @@ apiClient.interceptors.request.use(async (config) => {
 // Handle response errors
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
     if (error.response?.status === 401) {
       // Token expired or invalid
       localStorage.removeItem('token');
       localStorage.removeItem('user');
       window.location.href = '/auth/login';
+    }
+
+    const isBrowser = typeof window !== 'undefined';
+    const config = error.config;
+    const method = config?.method?.toLowerCase();
+    const shouldQueue =
+      isBrowser &&
+      !navigator.onLine &&
+      method &&
+      ['post', 'put', 'patch', 'delete'].includes(method) &&
+      config?.url;
+
+    if (shouldQueue) {
+      const url = config.baseURL
+        ? new URL(config.url, config.baseURL).toString()
+        : config.url;
+
+      await queueOfflineRequest({
+        url,
+        method: method.toUpperCase() as 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+        headers: { ...(config.headers as Record<string, string>) },
+        body:
+          typeof config.data === 'string'
+            ? config.data
+            : config.data !== undefined
+            ? JSON.stringify(config.data)
+            : undefined,
+      });
+
+      return Promise.reject(
+        new Error('Offline: request queued for later synchronization.')
+      );
     }
 
     if (error.response?.data?.error && !error.message) {

--- a/frontend/src/lib/offline-sync.test.ts
+++ b/frontend/src/lib/offline-sync.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushQueuedRequests, getQueuedRequests, queueOfflineRequest, removeQueuedRequest } from './offline-sync';
+
+describe('offline-sync', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+
+    const queued = await getQueuedRequests();
+    for (const item of queued) {
+      await removeQueuedRequest(item.id);
+    }
+  });
+
+  it('queues requests when offline and flushes when online', async () => {
+    const request = {
+      url: '/test-sync',
+      method: 'POST' as const,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hello' }),
+    };
+
+    await queueOfflineRequest(request);
+    let queuedRequests = await getQueuedRequests();
+    expect(queuedRequests.length).toBe(1);
+    expect(queuedRequests[0].url).toBe('/test-sync');
+
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushQueuedRequests();
+    expect(fetchMock).toHaveBeenCalledWith('/test-sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: request.body,
+      credentials: 'same-origin',
+    });
+
+    queuedRequests = await getQueuedRequests();
+    expect(queuedRequests.length).toBe(0);
+  });
+});

--- a/frontend/src/lib/offline-sync.ts
+++ b/frontend/src/lib/offline-sync.ts
@@ -1,0 +1,114 @@
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+
+const DB_NAME = 'web3-student-lab-offline-sync';
+const DB_VERSION = 1;
+const STORE_NAME = 'queued-requests';
+
+interface OfflineSyncSchema extends DBSchema {
+  [STORE_NAME]: {
+    key: string;
+    value: QueuedRequest;
+  };
+}
+
+export type QueuedRequestMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface QueuedRequest {
+  id: string;
+  url: string;
+  method: QueuedRequestMethod;
+  headers: Record<string, string>;
+  body?: string;
+  createdAt: number;
+}
+
+let dbPromise: Promise<IDBPDatabase<OfflineSyncSchema>> | null = null;
+
+function getDb() {
+  if (!dbPromise) {
+    dbPromise = openDB<OfflineSyncSchema>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+export async function queueOfflineRequest(request: Omit<QueuedRequest, 'id' | 'createdAt'>) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const db = await getDb();
+  const queuedRequest: QueuedRequest = {
+    ...request,
+    id: crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    createdAt: Date.now(),
+  };
+
+  await db.put(STORE_NAME, queuedRequest);
+}
+
+export async function getQueuedRequests(): Promise<QueuedRequest[]> {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const db = await getDb();
+  return db.getAll(STORE_NAME);
+}
+
+export async function removeQueuedRequest(id: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const db = await getDb();
+  await db.delete(STORE_NAME, id);
+}
+
+export async function flushQueuedRequests() {
+  if (typeof window === 'undefined' || !navigator.onLine) {
+    return;
+  }
+
+  const requests = await getQueuedRequests();
+  for (const request of requests) {
+    try {
+      const fetchOptions = {
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+        credentials: 'same-origin' as RequestCredentials,
+      };
+      const response = await fetch(request.url, fetchOptions);
+      if (response.ok) {
+        await removeQueuedRequest(request.id);
+      }
+    } catch (error) {
+      console.warn('[OfflineSync] Flush failed, keeping queued request:', request.id, error);
+      // Leave failed requests in the queue for the next online event.
+    }
+  }
+}
+
+export function registerOnlineSync() {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const handleOnline = () => {
+    flushQueuedRequests().catch((error) => {
+      console.error('[OfflineSync] Error flushing queued requests:', error);
+    });
+  };
+
+  window.addEventListener('online', handleOnline);
+
+  return () => {
+    window.removeEventListener('online', handleOnline);
+  };
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -13,10 +13,7 @@ export default defineConfig({
         branches: 85,
         statements: 90,
       },
-      include: [
-        'src/lib/p2p-crypto.ts',
-        'src/lib/web3-transaction-simulator.ts',
-      ],
+      include: ['src/**/*.{ts,tsx}'],
     },
   },
 });


### PR DESCRIPTION
close #584 

# PR: Implement Offline Mode Support for Learning Content

## Summary
This PR adds offline-first support to the frontend learning experience. It introduces a service worker for app shell caching, persistent API response caching for offline read access, and a queued request sync mechanism for offline write operations.

## Key Changes
- Added `public/sw.js` to cache navigation, assets, and provide an offline fallback.
- Extended API caching in `src/lib/api-cache.ts` to persist GET responses in `localStorage` and serve cached content when offline.
- Added `src/lib/offline-sync.ts` for queuing POST/PUT/PATCH/DELETE requests in IndexedDB and flushing them when the app regains connectivity.
- Integrated offline sync at runtime with `src/components/OfflineSyncHandler.tsx`.
- Updated `src/app/layout.tsx` to include offline notifications and sync handler components.
- Added tests for API cache behavior and offline sync queue handling.
- Updated frontend documentation to describe offline mode behavior.

## Testing
- `npm test` in the `frontend` package should pass.
- Manual validation:
  1. Load the app while online and navigate learning content.
  2. Confirm offline-ready notification appears after service worker activation.
  3. Go offline and refresh; previously viewed content should still display.
  4. Perform a write action while offline and verify it syncs automatically when back online.

## Notes
- This implementation focuses on learning content availability and automatic sync for offline write operations.
- The service worker is scoped to the app and caches both shell assets and navigation responses for better offline reliability.