### PR TITLE
feat: implement issues #698, #688, #716, #711

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -13,7 +13,10 @@ members = [
     "payment_streaming",
     "commit_reveal_rng",
     "quadratic_funding",
-    "multisig_wallet_timelock"
+    "multisig_wallet_timelock",
+    "course_proxy",
+    "auth_checker",
+    "cross_chain_client"
 ]
 
 [lib]

--- a/contracts/auth_checker/Cargo.toml
+++ b/contracts/auth_checker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "auth-checker"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/auth_checker/src/lib.rs
+++ b/contracts/auth_checker/src/lib.rs
@@ -1,0 +1,104 @@
+//! Auth Checker Contract – Lesson 3 – Issue #688
+//!
+//! Educational contract demonstrating Soroban's `require_auth` pattern for
+//! access control. Unauthorized callers are rejected at the SDK level before
+//! any state mutation occurs.
+//!
+//! ## Learning objectives
+//! - `address.require_auth()` enforces caller authorization on-chain.
+//! - State-mutating functions are gated; read functions are public.
+//! - Admin-only mutations make it impossible for arbitrary callers to tamper
+//!   with lesson state, satisfying the "unauthorized calls are rejected" criterion.
+
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address, Env, String};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum AuthKey {
+    Admin,
+    LessonValue,
+    MutationCount,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AuthError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+}
+
+#[contract]
+pub struct AuthChecker;
+
+#[contractimpl]
+impl AuthChecker {
+    /// Initialize with an admin address. The lesson value is set to an empty string.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&AuthKey::Admin) {
+            panic_with_error!(&env, AuthError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&AuthKey::Admin, &admin);
+        env.storage().instance().set(&AuthKey::MutationCount, &0u32);
+    }
+
+    /// Set the lesson value. **Requires admin authorization.**
+    ///
+    /// Calling this without a valid auth entry for `caller` causes Soroban to
+    /// revert the transaction before the body executes – a hard on-chain rejection.
+    pub fn set_value(env: Env, caller: Address, value: String) {
+        // `require_auth` is the core of this lesson: the SDK verifies the caller
+        // signed this invocation; if not, the transaction aborts here.
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+
+        env.storage().instance().set(&AuthKey::LessonValue, &value);
+
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&AuthKey::MutationCount)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&AuthKey::MutationCount, &(count + 1));
+
+        env.events()
+            .publish((symbol_short!("set_val"),), (caller, value));
+    }
+
+    /// Read the lesson value. No auth required – anyone may read.
+    pub fn get_value(env: Env) -> Option<String> {
+        env.storage().instance().get(&AuthKey::LessonValue)
+    }
+
+    /// Number of times `set_value` has been called successfully.
+    pub fn mutation_count(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&AuthKey::MutationCount)
+            .unwrap_or(0)
+    }
+
+    /// Transfer admin rights. Requires current admin auth.
+    pub fn transfer_admin(env: Env, caller: Address, new_admin: Address) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+        env.storage().instance().set(&AuthKey::Admin, &new_admin);
+    }
+
+    // -----------------------------------------------------------------------
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&AuthKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, AuthError::NotInitialized));
+        if *caller != admin {
+            panic_with_error!(env, AuthError::Unauthorized);
+        }
+    }
+}

--- a/contracts/course_proxy/Cargo.toml
+++ b/contracts/course_proxy/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "course-proxy"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/course_proxy/src/lib.rs
+++ b/contracts/course_proxy/src/lib.rs
@@ -1,0 +1,117 @@
+//! Course Version Proxy – Issue #698
+//!
+//! Implements an upgradeable proxy using Soroban's native WASM-replacement
+//! mechanism (UUPS pattern) so instructors can roll out new course metadata
+//! logic without losing stored state.
+//!
+//! ## Storage layout
+//! All proxy-specific keys live under `CourseProxyKey` to prevent collisions
+//! with metadata stored by the implementation WASM.
+//!
+//! ## Upgrade flow
+//! 1. Admin calls `upgrade(new_wasm_hash)`.
+//! 2. Contract persists the hash and calls
+//!    `env.deployer().update_current_contract_wasm(hash)`.
+//! 3. The contract instance (and its storage) is unchanged; only the logic is
+//!    replaced – satisfying the "state preserved across upgrades" requirement.
+
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, Address, BytesN, Env};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum CourseProxyKey {
+    Admin,
+    ImplWasm,
+    CourseVersion,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ProxyError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+}
+
+#[contract]
+pub struct CourseProxy;
+
+#[contractimpl]
+impl CourseProxy {
+    /// Initialize with an admin and the initial implementation WASM hash.
+    /// Also sets the course version to 1.
+    pub fn init(env: Env, admin: Address, wasm_hash: BytesN<32>) {
+        if env.storage().instance().has(&CourseProxyKey::Admin) {
+            panic_with_error!(&env, ProxyError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&CourseProxyKey::Admin, &admin);
+        env.storage().instance().set(&CourseProxyKey::ImplWasm, &wasm_hash);
+        env.storage().instance().set(&CourseProxyKey::CourseVersion, &1u32);
+        // Upgrade WASM so the contract immediately executes implementation logic.
+        env.deployer().update_current_contract_wasm(wasm_hash);
+    }
+
+    /// Upgrade to a new implementation WASM, bumping the course version counter.
+    /// Only the admin may call this; `require_auth` enforces on-chain authorization.
+    pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+
+        // Bump version so consumers can detect the rollout.
+        let version: u32 = env
+            .storage()
+            .instance()
+            .get(&CourseProxyKey::CourseVersion)
+            .unwrap_or(1);
+        env.storage()
+            .instance()
+            .set(&CourseProxyKey::CourseVersion, &(version + 1));
+
+        env.storage()
+            .instance()
+            .set(&CourseProxyKey::ImplWasm, &new_wasm_hash);
+
+        // Native UUPS upgrade – state is preserved, only logic changes.
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    /// Return the current implementation WASM hash.
+    pub fn get_impl(env: Env) -> BytesN<32> {
+        env.storage()
+            .instance()
+            .get(&CourseProxyKey::ImplWasm)
+            .unwrap_or_else(|| panic_with_error!(&env, ProxyError::NotInitialized))
+    }
+
+    /// Return the current course version number (increments on each upgrade).
+    pub fn get_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&CourseProxyKey::CourseVersion)
+            .unwrap_or(1)
+    }
+
+    /// Transfer admin rights to a new address.
+    pub fn transfer_admin(env: Env, caller: Address, new_admin: Address) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+        env.storage()
+            .instance()
+            .set(&CourseProxyKey::Admin, &new_admin);
+    }
+
+    // -----------------------------------------------------------------------
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&CourseProxyKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, ProxyError::NotInitialized));
+        if *caller != admin {
+            panic_with_error!(env, ProxyError::Unauthorized);
+        }
+    }
+}

--- a/contracts/cross_chain_client/Cargo.toml
+++ b/contracts/cross_chain_client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cross-chain-client"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/cross_chain_client/src/lib.rs
+++ b/contracts/cross_chain_client/src/lib.rs
@@ -1,0 +1,262 @@
+//! Cross-Chain Messaging Client – Issue #716
+//!
+//! Educational contract demonstrating how a Soroban contract ingests cross-chain
+//! messages, verifies their ed25519 signatures, and emits structured execution
+//! payload event maps. Designed for the "learning multi-network assets" module.
+//!
+//! ## Message lifecycle
+//! ```text
+//! Relayer (off-chain)
+//!   │  signs: sha256(chain_id[4] || nonce[8] || sender_bytes || payload)
+//!   ▼
+//! ingest_message(source_chain, nonce, sender, payload, relayer_pubkey, signature)
+//!   │
+//!   ├─ verify relayer is registered and active
+//!   ├─ replay-protection: reject duplicate (source_chain, nonce)
+//!   ├─ ed25519_verify(pubkey, hash, sig)  ← SDK-level crypto, no custom code
+//!   ├─ persist MessageRecord in storage
+//!   └─ emit event map { msg_id, source_chain, nonce, payload_len }
+//! ```
+//!
+//! ## Acceptance criteria
+//! Valid signed payloads → state modification (record stored) + event emitted.
+//! Invalid/unsigned payloads → transaction reverts before any state change.
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
+    Address, Bytes, BytesN, Env,
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+pub type ChainId = u32;
+
+/// Stored record for every successfully verified inbound message.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageRecord {
+    pub message_id: BytesN<32>,
+    pub source_chain: ChainId,
+    pub nonce: u64,
+    pub sender: Bytes,
+    /// Raw application payload (ABI-encoded, JSON, etc.)
+    pub payload: Bytes,
+    pub accepted_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum ClientKey {
+    Admin,
+    /// Active relayer public keys: pubkey → bool (active flag)
+    Relayer(BytesN<32>),
+    /// Stored message record by its message_id hash
+    Message(BytesN<32>),
+    /// Replay guard: (source_chain, nonce) → bool
+    Nonce(ChainId, u64),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ClientError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    UnknownRelayer = 4,
+    NonceReplayed = 5,
+    InvalidSignature = 6,
+    MessageNotFound = 7,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct CrossChainClient;
+
+#[contractimpl]
+impl CrossChainClient {
+    /// Initialize the client with an admin address.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&ClientKey::Admin) {
+            panic_with_error!(&env, ClientError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&ClientKey::Admin, &admin);
+    }
+
+    // -----------------------------------------------------------------------
+    // Relayer registry
+    // -----------------------------------------------------------------------
+
+    /// Register a trusted relayer public key (admin only).
+    pub fn add_relayer(env: Env, caller: Address, pubkey: BytesN<32>) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+        env.storage()
+            .persistent()
+            .set(&ClientKey::Relayer(pubkey.clone()), &true);
+        env.events().publish((symbol_short!("rly_add"),), pubkey);
+    }
+
+    /// Deactivate a relayer (admin only).
+    pub fn remove_relayer(env: Env, caller: Address, pubkey: BytesN<32>) {
+        caller.require_auth();
+        Self::assert_admin(&env, &caller);
+        env.storage()
+            .persistent()
+            .set(&ClientKey::Relayer(pubkey.clone()), &false);
+        env.events().publish((symbol_short!("rly_rm"),), pubkey);
+    }
+
+    // -----------------------------------------------------------------------
+    // Message ingestion
+    // -----------------------------------------------------------------------
+
+    /// Ingest a cross-chain message.
+    ///
+    /// Validates the ed25519 signature over the canonical message hash, guards
+    /// against replay, stores the record, and emits an execution payload event.
+    ///
+    /// ### Canonical hash layout
+    /// `sha256( source_chain[4] || nonce[8] || sender || payload )`
+    pub fn ingest_message(
+        env: Env,
+        source_chain: ChainId,
+        nonce: u64,
+        sender: Bytes,
+        payload: Bytes,
+        relayer_pubkey: BytesN<32>,
+        signature: BytesN<64>,
+    ) -> BytesN<32> {
+        Self::assert_initialized(&env);
+
+        // Relayer must be registered and active.
+        let active: bool = env
+            .storage()
+            .persistent()
+            .get(&ClientKey::Relayer(relayer_pubkey.clone()))
+            .unwrap_or(false);
+        if !active {
+            panic_with_error!(&env, ClientError::UnknownRelayer);
+        }
+
+        // Replay protection.
+        let nonce_key = ClientKey::Nonce(source_chain, nonce);
+        if env
+            .storage()
+            .persistent()
+            .get::<ClientKey, bool>(&nonce_key)
+            .unwrap_or(false)
+        {
+            panic_with_error!(&env, ClientError::NonceReplayed);
+        }
+
+        // Build canonical hash input and verify signature.
+        let hash_input = Self::canonical_bytes(&env, source_chain, nonce, &sender, &payload);
+        let message_hash: BytesN<32> = env.crypto().sha256(&hash_input).into();
+
+        // `ed25519_verify` panics (reverts the tx) if the signature is invalid.
+        env.crypto()
+            .ed25519_verify(&relayer_pubkey, &message_hash.clone().into(), &signature);
+
+        // --- all checks passed, now mutate state ---
+
+        env.storage().persistent().set(&nonce_key, &true);
+
+        let message_id: BytesN<32> = env.crypto().sha256(&hash_input).into();
+
+        let record = MessageRecord {
+            message_id: message_id.clone(),
+            source_chain,
+            nonce,
+            sender: sender.clone(),
+            payload: payload.clone(),
+            accepted_at: env.ledger().timestamp(),
+        };
+        env.storage()
+            .persistent()
+            .set(&ClientKey::Message(message_id.clone()), &record);
+
+        // Emit execution payload event map so indexers can act on it.
+        env.events().publish(
+            (symbol_short!("xc_msg"), source_chain),
+            (nonce, message_id.clone(), payload.len()),
+        );
+
+        message_id
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Retrieve a stored message record by its ID.
+    pub fn get_message(env: Env, message_id: BytesN<32>) -> MessageRecord {
+        env.storage()
+            .persistent()
+            .get(&ClientKey::Message(message_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ClientError::MessageNotFound))
+    }
+
+    /// Check whether a (source_chain, nonce) pair has been processed.
+    pub fn is_processed(env: Env, source_chain: ChainId, nonce: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get::<ClientKey, bool>(&ClientKey::Nonce(source_chain, nonce))
+            .unwrap_or(false)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// `source_chain[4] || nonce[8] || sender || payload` (big-endian)
+    fn canonical_bytes(env: &Env, source_chain: ChainId, nonce: u64, sender: &Bytes, payload: &Bytes) -> Bytes {
+        let mut data = Bytes::new(env);
+        data.push_back((source_chain >> 24) as u8);
+        data.push_back((source_chain >> 16) as u8);
+        data.push_back((source_chain >> 8) as u8);
+        data.push_back(source_chain as u8);
+        data.push_back((nonce >> 56) as u8);
+        data.push_back((nonce >> 48) as u8);
+        data.push_back((nonce >> 40) as u8);
+        data.push_back((nonce >> 32) as u8);
+        data.push_back((nonce >> 24) as u8);
+        data.push_back((nonce >> 16) as u8);
+        data.push_back((nonce >> 8) as u8);
+        data.push_back(nonce as u8);
+        data.append(sender);
+        data.append(payload);
+        data
+    }
+
+    fn assert_initialized(env: &Env) {
+        if !env.storage().instance().has(&ClientKey::Admin) {
+            panic_with_error!(env, ClientError::NotInitialized);
+        }
+    }
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ClientKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, ClientError::NotInitialized));
+        if *caller != admin {
+            panic_with_error!(env, ClientError::Unauthorized);
+        }
+    }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -190,3 +190,136 @@ textarea {
     outline: 3px solid ButtonText;
   }
 }
+
+/* ─── Issue #711: Lesson Viewer – Dark Mode Code Block Overrides ───────────
+ *
+ * Scope Prism.js / Shiki CSS custom properties to the lesson viewer so that
+ * switching the site theme seamlessly swaps code highlight backgrounds and
+ * token colours without touching the global stylesheet or third-party bundles.
+ *
+ * Strategy:
+ *  - `.lesson-viewer` wraps all markdown-rendered lesson content.
+ *  - The `dark` selector matches Tailwind's dark-mode class strategy
+ *    (`class` strategy on <html>).
+ *  - Custom properties override Prism / Shiki tokens at the component scope.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/* Light-mode defaults (already in effect unless .dark is present) */
+.lesson-viewer pre,
+.lesson-viewer code {
+  --code-bg: #f4f6fa;
+  --code-fg: #1e2430;
+  --code-border: rgba(0, 0, 0, 0.08);
+  --code-selection: rgba(37, 181, 164, 0.25);
+
+  /* Prism token overrides */
+  --prism-bg: var(--code-bg);
+  --prism-default: var(--code-fg);
+  --prism-comment: #6b7280;
+  --prism-keyword: #7c3aed;
+  --prism-string: #059669;
+  --prism-number: #d97706;
+  --prism-function: #2563eb;
+  --prism-operator: #db2777;
+  --prism-punctuation: #6b7280;
+
+  /* Shiki CSS variable tokens */
+  --shiki-color-background: var(--code-bg);
+  --shiki-color-text: var(--code-fg);
+  --shiki-token-comment: var(--prism-comment);
+  --shiki-token-keyword: var(--prism-keyword);
+  --shiki-token-string: var(--prism-string);
+  --shiki-token-number: var(--prism-number);
+  --shiki-token-function: var(--prism-function);
+  --shiki-token-operator: var(--prism-operator);
+  --shiki-token-punctuation: var(--prism-punctuation);
+}
+
+/* Dark-mode overrides – activated by Tailwind's html.dark class */
+.dark .lesson-viewer pre,
+.dark .lesson-viewer code {
+  --code-bg: #0d1520;
+  --code-fg: #cdd6f4;
+  --code-border: rgba(255, 255, 255, 0.08);
+  --code-selection: rgba(37, 181, 164, 0.20);
+
+  --prism-bg: var(--code-bg);
+  --prism-default: var(--code-fg);
+  --prism-comment: #6c7a8e;
+  --prism-keyword: #cba6f7;
+  --prism-string: #a6e3a1;
+  --prism-number: #fab387;
+  --prism-function: #89b4fa;
+  --prism-operator: #f38ba8;
+  --prism-punctuation: #7f849c;
+
+  --shiki-color-background: var(--code-bg);
+  --shiki-color-text: var(--code-fg);
+  --shiki-token-comment: var(--prism-comment);
+  --shiki-token-keyword: var(--prism-keyword);
+  --shiki-token-string: var(--prism-string);
+  --shiki-token-number: var(--prism-number);
+  --shiki-token-function: var(--prism-function);
+  --shiki-token-operator: var(--prism-operator);
+  --shiki-token-punctuation: var(--prism-punctuation);
+}
+
+/* Apply the resolved custom properties to actual elements */
+.lesson-viewer pre {
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  overflow-x: auto;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.lesson-viewer code {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  font-family: var(--font-mono, 'JetBrains Mono', 'SFMono-Regular', monospace);
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+/* Inline code inside prose */
+.lesson-viewer p code,
+.lesson-viewer li code {
+  padding: 0.15em 0.4em;
+  border-radius: 0.3rem;
+  border: 1px solid var(--code-border);
+}
+
+/* Selection highlight */
+.lesson-viewer pre ::selection,
+.lesson-viewer code ::selection {
+  background: var(--code-selection);
+}
+
+/* Prism.js token colour bindings */
+.lesson-viewer .token.comment,
+.lesson-viewer .token.block-comment,
+.lesson-viewer .token.prolog,
+.lesson-viewer .token.doctype,
+.lesson-viewer .token.cdata { color: var(--prism-comment); }
+
+.lesson-viewer .token.keyword,
+.lesson-viewer .token.important,
+.lesson-viewer .token.atrule,
+.lesson-viewer .token.builtin { color: var(--prism-keyword); }
+
+.lesson-viewer .token.string,
+.lesson-viewer .token.char,
+.lesson-viewer .token.attr-value { color: var(--prism-string); }
+
+.lesson-viewer .token.number,
+.lesson-viewer .token.boolean { color: var(--prism-number); }
+
+.lesson-viewer .token.function,
+.lesson-viewer .token.function-name { color: var(--prism-function); }
+
+.lesson-viewer .token.operator,
+.lesson-viewer .token.entity,
+.lesson-viewer .token.url { color: var(--prism-operator); }
+
+.lesson-viewer .token.punctuation { color: var(--prism-punctuation); }


### PR DESCRIPTION
=== Issue #698 – [Smart Contract] Upgradeable Proxy for Course Version Rollouts ===

Created: contracts/course_proxy/Cargo.toml
         contracts/course_proxy/src/lib.rs

Approach:
  Soroban does not have a delegatecall opcode, so a traditional transparent
  proxy (logic in Contract B, state in Contract A) is architecturally
  impossible. Instead, the UUPS (Universal Upgradeable Proxy Standard) pattern
  is used via Soroban's native env.deployer().update_current_contract_wasm().
  The contract instance (and therefore all of its stored state) stays constant
  while the underlying WASM logic is hot-swapped on upgrade.

Implementation details:
  - CourseProxy stores three keys: Admin, ImplWasm, CourseVersion.
  - init(admin, wasm_hash) sets initial state and immediately upgrades to the first implementation WASM so execution begins with the correct logic.
  - upgrade(caller, new_wasm_hash) requires caller.require_auth() + an admin assertion to ensure only the authorised instructor can trigger a rollout. It bumps a CourseVersion counter so consumers can detect which version is live without querying external state.
  - get_impl() and get_version() are read-only getters.
  - transfer_admin() lets the current admin hand off rights atomically.
  - Acceptance criterion met: all instance storage (course metadata, version counter, admin) is preserved across upgrades because only the WASM code is replaced, never the contract instance.

Closes #698

=== Issue #688 – [Smart Contract] Auth Checker Contract for Lesson 3 ===

Created: contracts/auth_checker/Cargo.toml
         contracts/auth_checker/src/lib.rs

Approach:
  Built as a self-contained educational contract whose entire point is to
  demonstrate the require_auth() pattern. Every state-mutating function calls
  caller.require_auth() first; if the invoker did not sign the invocation, the
  Soroban host reverts the transaction before any state is touched.

Implementation details:
  - AuthChecker stores: Admin (Address), LessonValue (String), MutationCount (u32).
  - init(admin) bootstraps the contract; calling it a second time panics with AlreadyInitialized so the admin cannot be overwritten.
  - set_value(caller, value) is the guarded mutation:
      1. caller.require_auth() – SDK-level auth; unauthorized tx reverts here.
      2. assert_admin() – secondary check that the authorized caller is the admin. 3. Stores the new lesson value and increments the mutation counter. 4. Emits a 'set_val' event for off-chain indexers.
  - get_value() and mutation_count() are public reads, no auth needed.
  - transfer_admin() allows admin rotation (requires current admin auth).
  - Acceptance criterion met: any call by a non-admin address or an un-authorized invocation is hard-rejected by the SDK before storage is mutated.

Closes #688

=== Issue #716 – [Smart Contract] Cross-Chain Messaging Client ===

Created: contracts/cross_chain_client/Cargo.toml
         contracts/cross_chain_client/src/lib.rs

Approach:
  A standalone Soroban contract (separate from the existing cross_chain_messaging
  module in contracts/src/) purpose-built for the 'learning multi-network assets'
  lesson. It focuses on the client/ingestion side: accepting inbound messages
  from a permissioned relayer set, verifying ed25519 signatures, guarding against
  replay, storing MessageRecord structs, and emitting structured execution payload
  event maps that off-chain indexers or lesson evaluators can consume.

Implementation details:
  - ChainId = u32 (CAIP-2 inspired). MessageRecord holds: message_id (sha256), source_chain, nonce, sender (raw bytes), payload, accepted_at timestamp.
  - Storage keys: Admin, Relayer(BytesN<32>) → bool, Message(BytesN<32>), Nonce(ChainId, u64) → bool.
  - init(admin) initializes. add_relayer / remove_relayer are admin-only ops that emit relayer lifecycle events.
  - ingest_message(source_chain, nonce, sender, payload, relayer_pubkey, signature):
      1. Verify relayer is registered and active (UnknownRelayer error otherwise).
      2. Replay protection: check Nonce(source_chain, nonce) key; reject with NonceReplayed if already seen. 3. Build canonical hash: sha256(source_chain[4] || nonce[8] || sender || payload). 4. env.crypto().ed25519_verify(pubkey, hash, sig) – host-level crypto, reverts the entire transaction on invalid signature (InvalidSignature path). 5. Mark nonce as processed, persist MessageRecord, emit event map: topic=(xc_msg, source_chain), data=(nonce, message_id, payload_len). 6. Returns message_id to the caller.
  - get_message(id) and is_processed(chain, nonce) are public read accessors.
  - Canonical byte layout documented in-contract for relayer implementors.
  - Acceptance criterion met: valid signed payloads trigger state mutation and event emission; invalid payloads revert before any storage write.

Closes #716

=== Issue #711 – [Frontend] Dark Mode CSS Override for Lesson Viewer Code Blocks ===

Modified: frontend/src/app/globals.css

Approach:
  Extended the existing globals.css (which already uses CSS custom properties for
  the site palette) with a scoped .lesson-viewer block. All Prism.js and Shiki
  token colour variables are declared as CSS custom properties so that a single
  class toggle on <html> (Tailwind's dark-mode class strategy) switches every
  token colour simultaneously with zero JavaScript required.

Implementation details:
  - Light-mode base: declared on '.lesson-viewer pre, .lesson-viewer code'. Token colours use a calm light palette (purple keywords, green strings, etc.)
  - Dark-mode override: declared on '.dark .lesson-viewer pre, .dark .lesson-viewer code'. Token colours use a Catppuccin-Mocha inspired dark palette matching the site's existing --bg: #09111d dark base.
  - Custom properties bridged to real elements: --code-bg / --code-fg applied to <pre> background and <code> color. --prism-* mapped to .token.keyword, .token.string, .token.number, etc. --shiki-color-background, --shiki-token-* for Shiki-rendered blocks.
  - <pre> gets border-radius, padding, overflow-x:auto and a 0.2s transition on background/border-color so the theme switch is smooth.
  - Inline code inside <p> and <li> gets subtle padding + border.
  - ::selection uses --code-selection (semi-transparent accent) in both modes.
  - No changes to third-party CSS; no new dependencies introduced.
  - Acceptance criterion met: switching html.dark seamlessly swaps code block highlight backgrounds and all token colours via pure CSS cascading.

Closes #711 