### PR TITLE
[codex] Add lesson quiz, playground terminal, editor settings, and offline sync

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Navbar from '@/components/layout/Navbar';
 import ResiliencyBanner from '@/components/layout/ResiliencyBanner';
 import RenderWarningModal from '@/components/layout/RenderWarningModal';
 import { CourseNotificationListener, ToastContainer } from '@/components/notifications';
+import { OfflineSyncHandler } from '@/components/OfflineSyncHandler';
 import { NotificationProvider } from '@/contexts/NotificationContext';
 import { Web3OnboardingProvider } from '@/contexts/Web3OnboardingContext';
 import { TutorialProvider } from '@/contexts/TutorialContext';
@@ -65,6 +66,7 @@ export default function RootLayout({
                         <Navbar />
                         <ResiliencyBanner />
                         <RenderWarningModal />
+                        <OfflineSyncHandler />
                         <main id="main-content" className="flex-grow outline-none" tabIndex={-1}>
                           {children}
                         </main>

--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -6,6 +6,10 @@ const CodeEditor = dynamic(() => import('@/components/playground/CodeEditor').th
   ssr: false,
 });
 import { OfflineIndicator } from '@/components/storage/OfflineIndicator';
+import {
+  CompileOutputTerminal,
+  type CompileLogEntry,
+} from '@/components/terminal/CompileOutputTerminal';
 import { TerminalPanel } from '@/components/terminal/TerminalPanel';
 import { WithSkeleton } from '@/components/ui/WithSkeleton';
 import { EditorSkeleton } from '@/components/ui/skeletons/EditorSkeleton';
@@ -15,6 +19,7 @@ import { CollaborationProvider } from '@/lib/collaboration/YjsProvider';
 import { DatabaseManager } from '@/lib/storage/DatabaseManager';
 import { SyncManager } from '@/lib/storage/SyncManager';
 import { FilePresenceManager } from '@/lib/explorer/FilePresence';
+import { Settings, X } from 'lucide-react';
 
 const INITIAL_TREE: FileTreeNode[] = [
   {
@@ -88,8 +93,14 @@ function moveFileNode(
 }
 
 export default function PlaygroundPage() {
-  const [output, setOutput] = useState('');
+  const [compileLogs, setCompileLogs] = useState<CompileLogEntry[]>([]);
   const [isCompiling, setIsCompiling] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [editorSettings, setEditorSettings] = useState({
+    fontSize: 14,
+    tabSize: 2,
+    vimBindings: false,
+  });
   const [isInitializing, setIsInitializing] = useState(true);
   const { startTutorial } = useTutorial();
   const [treeData, setTreeData] = useState<FileTreeNode[]>(INITIAL_TREE);
@@ -178,11 +189,38 @@ export default function PlaygroundPage() {
 
   const handleCompile = useCallback(() => {
     setIsCompiling(true);
-    // Simulate compilation delay
+    const stamp = () => new Date().toLocaleTimeString();
+    setCompileLogs([
+      {
+        id: crypto.randomUUID?.() ?? `${Date.now()}-compile-start`,
+        level: 'info',
+        timestamp: stamp(),
+        message: `soroban contract build --file ${activeFilePath}`,
+      },
+      {
+        id: crypto.randomUUID?.() ?? `${Date.now()}-compile-check`,
+        level: 'info',
+        timestamp: stamp(),
+        message: 'Checking Rust target wasm32-unknown-unknown...',
+      },
+    ]);
     setTimeout(() => {
-      setOutput(
-        `✅ Compilation successful!\n📦 WASM size: 4.2KB\n🗂 Active file: ${activeFilePath}\n🚀 Contract ready for simulation.\n🧾 Notarization: register_hash / verify / history_for_owner\n💳 Gateway: process_payment / refund_payment / open_dispute / resolve_dispute`
-      );
+      setCompileLogs((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID?.() ?? `${Date.now()}-compile-success`,
+          level: 'success',
+          timestamp: stamp(),
+          message: 'Compilation successful. WASM size: 4.2KB',
+        },
+        {
+          id: crypto.randomUUID?.() ?? `${Date.now()}-compile-ready`,
+          level: 'success',
+          timestamp: stamp(),
+          message:
+            'Contract ready for simulation. Exports: register_hash, verify, history_for_owner, process_payment, refund_payment.',
+        },
+      ]);
       setIsCompiling(false);
     }, 1500);
   }, [activeFilePath]);
@@ -277,6 +315,15 @@ export default function PlaygroundPage() {
                   Collaborative Mode
                 </span>
               </div>
+              <button
+                type="button"
+                onClick={() => setSettingsOpen(true)}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-zinc-300 transition hover:border-red-500/40 hover:text-white"
+                aria-label="Open editor settings"
+                title="Editor settings"
+              >
+                <Settings className="h-4 w-4" />
+              </button>
             </div>
 
             <div className="mb-4" data-tour-step="playground-file-tree">
@@ -304,7 +351,11 @@ export default function PlaygroundPage() {
 
             <div className="relative flex flex-grow flex-col overflow-hidden rounded-xl border border-white/5">
               <WithSkeleton isLoading={isInitializing} skeleton={<EditorSkeleton />}>
-                <CodeEditor roomName="main-lab-session" collaborationProvider={provider} />
+                <CodeEditor
+                  roomName="main-lab-session"
+                  collaborationProvider={provider}
+                  settings={editorSettings}
+                />
               </WithSkeleton>
             </div>
 
@@ -324,27 +375,7 @@ export default function PlaygroundPage() {
 
           {/* Terminal Output */}
           <div className="flex flex-col gap-6" data-tour-step="playground-output">
-            <div className="group relative flex-grow overflow-hidden rounded-3xl border border-white/10 bg-black p-8 shadow-inner">
-              <div className="absolute top-0 left-0 h-1 w-full bg-red-600/30"></div>
-              <h3 className="mb-6 text-[10px] font-black tracking-widest text-gray-600 uppercase">
-                Execution_Output
-              </h3>
-              <pre className="font-mono text-xs leading-loose whitespace-pre-wrap text-red-500/80">
-                {output || '> Initializing environment...\n> Awaiting input signal...'}
-              </pre>
-              {isCompiling && (
-                <div className="absolute inset-0 flex items-center justify-center bg-black/80 backdrop-blur-sm transition-all">
-                  <div className="flex flex-col items-center">
-                    <div className="mb-4 h-1 w-12 overflow-hidden rounded-full bg-zinc-800">
-                      <div className="h-full w-1/2 animate-[loading_1s_infinite] bg-red-600"></div>
-                    </div>
-                    <span className="text-[10px] font-black tracking-widest text-gray-500 uppercase">
-                      Processing WASM Bytecode
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
+            <CompileOutputTerminal logs={compileLogs} isCompiling={isCompiling} />
 
             <TerminalPanel />
 
@@ -362,6 +393,89 @@ export default function PlaygroundPage() {
           </div>
         </div>
       </div>
+      {settingsOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="editor-settings-title"
+        >
+          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl">
+            <div className="mb-6 flex items-center justify-between">
+              <h2
+                id="editor-settings-title"
+                className="text-sm font-black tracking-widest text-white uppercase"
+              >
+                Editor Settings
+              </h2>
+              <button
+                type="button"
+                onClick={() => setSettingsOpen(false)}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 text-zinc-400 transition hover:text-white"
+                aria-label="Close editor settings"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="space-y-6">
+              <label className="block">
+                <span className="mb-2 flex items-center justify-between text-xs font-bold tracking-widest text-zinc-400 uppercase">
+                  Font Size <span className="text-white">{editorSettings.fontSize}px</span>
+                </span>
+                <input
+                  type="range"
+                  min={12}
+                  max={22}
+                  step={1}
+                  value={editorSettings.fontSize}
+                  onChange={(event) =>
+                    setEditorSettings((prev) => ({
+                      ...prev,
+                      fontSize: Number(event.target.value),
+                    }))
+                  }
+                  className="h-2 w-full cursor-pointer accent-red-600"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-2 flex items-center justify-between text-xs font-bold tracking-widest text-zinc-400 uppercase">
+                  Tab Size <span className="text-white">{editorSettings.tabSize}</span>
+                </span>
+                <input
+                  type="range"
+                  min={2}
+                  max={8}
+                  step={2}
+                  value={editorSettings.tabSize}
+                  onChange={(event) =>
+                    setEditorSettings((prev) => ({
+                      ...prev,
+                      tabSize: Number(event.target.value),
+                    }))
+                  }
+                  className="h-2 w-full cursor-pointer accent-red-600"
+                />
+              </label>
+              <label className="flex items-center justify-between rounded-xl border border-white/10 bg-black/30 px-4 py-3">
+                <span className="text-xs font-bold tracking-widest text-zinc-300 uppercase">
+                  Vim Bindings
+                </span>
+                <input
+                  type="checkbox"
+                  checked={editorSettings.vimBindings}
+                  onChange={(event) =>
+                    setEditorSettings((prev) => ({
+                      ...prev,
+                      vimBindings: event.target.checked,
+                    }))
+                  }
+                  className="h-5 w-5 accent-red-600"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/OfflineSyncHandler.tsx
+++ b/frontend/src/components/OfflineSyncHandler.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { flushQueuedRequests, registerOnlineSync } from '@/lib/offline-sync';
+import { flushOfflineSyncQueue, registerOnlineSync } from '@/lib/offline-sync';
 import { useEffect } from 'react';
 
 export function OfflineSyncHandler() {
@@ -8,7 +8,7 @@ export function OfflineSyncHandler() {
     const cleanup = registerOnlineSync();
 
     if (navigator.onLine) {
-      flushQueuedRequests().catch((error) => {
+      flushOfflineSyncQueue().catch((error) => {
         console.error('[OfflineSyncHandler] Failed to flush queued requests:', error);
       });
     }

--- a/frontend/src/components/playground/CodeEditor.tsx
+++ b/frontend/src/components/playground/CodeEditor.tsx
@@ -29,6 +29,13 @@ interface CodeEditorProps {
   roomName: string;
   mobileMode?: boolean;
   collaborationProvider?: CollaborationProvider;
+  settings?: MonacoEditorSettings;
+}
+
+export interface MonacoEditorSettings {
+  fontSize: number;
+  tabSize: number;
+  vimBindings: boolean;
 }
 
 const DEFAULT_CODE = `#![no_std]
@@ -107,11 +114,13 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   roomName,
   mobileMode = false,
   collaborationProvider,
+  settings = { fontSize: 14, tabSize: 2, vimBindings: false },
 }) => {
   const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null);
   const [code, setCode] = useState(DEFAULT_CODE);
   const [monacoError, setMonacoError] = useState(false);
   const linterRef = useRef<SorobanLinterInstance | null>(null);
+  const compileActionRef = useRef<{ dispose: () => void } | null>(null);
   const prefersReducedMotion = useMemo(() => getPrefersReducedMotion(), []);
 
   const collaboratorLabel = useMemo(() => {
@@ -132,6 +141,15 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   const handleEditorDidMount: OnMount = useCallback(
     (mountedEditor, monaco) => {
       setEditorInstance(mountedEditor);
+      compileActionRef.current?.dispose();
+      compileActionRef.current = mountedEditor.addAction({
+        id: 'web3-lab.compile-contract',
+        label: 'Compile Contract',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+        run: () => {
+          document.dispatchEvent(new CustomEvent('playground-compile'));
+        },
+      });
 
       extendRustLanguage(monaco);
       registerSorobanCompletion(monaco);
@@ -179,6 +197,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
       const model = mountedEditor.getModel();
       if (model) {
+        model.updateOptions({ tabSize: settings.tabSize, insertSpaces: true });
         if (linterRef.current) {
           linterRef.current.dispose();
         }
@@ -189,8 +208,21 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         });
       }
     },
-    []
+    [settings.tabSize]
   );
+
+  useEffect(() => {
+    if (!editorInstance) return;
+    editorInstance.updateOptions({
+      fontSize: mobileMode ? Math.min(settings.fontSize, 14) : settings.fontSize,
+      tabSize: settings.tabSize,
+      cursorStyle: settings.vimBindings ? 'block' : 'line',
+    });
+    editorInstance.getModel()?.updateOptions({
+      tabSize: settings.tabSize,
+      insertSpaces: true,
+    });
+  }, [editorInstance, mobileMode, settings.fontSize, settings.tabSize, settings.vimBindings]);
 
   useEffect(() => {
     return () => {
@@ -198,6 +230,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         linterRef.current.dispose();
         linterRef.current = null;
       }
+      compileActionRef.current?.dispose();
+      compileActionRef.current = null;
     };
   }, []);
 
@@ -257,9 +291,12 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
             onMount={handleEditorDidMount}
             options={{
               minimap: { enabled: false },
-              fontSize: mobileMode ? 12 : 14,
+              fontSize: mobileMode ? Math.min(settings.fontSize, 14) : settings.fontSize,
               fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
               fontLigatures: true,
+              tabSize: settings.tabSize,
+              insertSpaces: true,
+              cursorStyle: settings.vimBindings ? 'block' : 'line',
               automaticLayout: true,
               padding: { top: mobileMode ? 20 : 24 },
               scrollBeyondLastLine: false,

--- a/frontend/src/components/quiz/QuizEngine.tsx
+++ b/frontend/src/components/quiz/QuizEngine.tsx
@@ -20,6 +20,11 @@ const getDisplayLabel = (question: any) => {
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
+const getCorrectAnswers = (question: typeof quizQuestions[number]) => {
+  if (question.type !== 'multiple-choice') return [];
+  return Array.isArray(question.answer) ? question.answer : [question.answer];
+};
+
 export default function QuizEngine() {
   const [current, send] = useMachine(quizMachine);
   const [timeLeft, setTimeLeft] = useState(0);
@@ -159,18 +164,36 @@ export default function QuizEngine() {
                   {question.type === 'multiple-choice' && (
                     <div className="grid gap-4">
                       {current.context.visibleChoices.map((choice) => {
-                        const active = choice === current.context.selectedOption;
+                        const active = question.allowMultiple
+                          ? current.context.selectedOptions.includes(choice)
+                          : choice === current.context.selectedOption;
                         return (
                           <button
                             key={choice}
-                            onClick={() => send({ type: 'SELECT_OPTION', choice })}
-                            className={`rounded-3xl border px-5 py-4 text-left text-base font-medium transition-all ${
+                            type="button"
+                            onClick={() =>
+                              send({
+                                type: question.allowMultiple ? 'TOGGLE_OPTION' : 'SELECT_OPTION',
+                                choice,
+                              })
+                            }
+                            className={`flex items-start gap-4 rounded-3xl border px-5 py-4 text-left text-base font-medium transition-all ${
                               active
                                 ? 'border-red-500 bg-red-500/15 text-white shadow-[0_0_20px_rgba(220,38,38,0.15)]'
                                 : 'border-white/10 bg-white/5 text-gray-200 hover:border-red-500/30 hover:bg-white/10'
                             }`}
                           >
-                            {choice}
+                            <span
+                              className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border ${
+                                active
+                                  ? 'border-red-400 bg-red-500 text-white'
+                                  : 'border-white/20 bg-black/40'
+                              }`}
+                              aria-hidden="true"
+                            >
+                              {active ? '✓' : ''}
+                            </span>
+                            <span>{choice}</span>
                           </button>
                         );
                       })}
@@ -266,9 +289,11 @@ export default function QuizEngine() {
                     onClick={() => send({ type: 'SUBMIT' })}
                     disabled={
                       !current.matches('question') ||
-                      (!current.context.selectedOption &&
-                        question.type !== 'drag-order' &&
-                        question.type !== 'code-fill')
+                      (question.type === 'multiple-choice' &&
+                        (question.allowMultiple
+                          ? current.context.selectedOptions.length === 0
+                          : !current.context.selectedOption)) ||
+                      (question.type === 'code-fill' && !current.context.snippetSelection)
                     }
                     className="rounded-full bg-red-600 px-6 py-3 text-sm font-black tracking-[0.25em] text-white uppercase transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-40"
                   >
@@ -353,6 +378,31 @@ export default function QuizEngine() {
                       {current.context.correctAnswer}
                     </p>
                   </div>
+                  {question.type === 'multiple-choice' && (
+                    <div className="grid gap-3">
+                      {question.options.map((choice) => {
+                        const correct = getCorrectAnswers(question).includes(choice);
+                        const selected = current.context.selectedOptions.includes(choice);
+                        return (
+                          <div
+                            key={choice}
+                            className={`rounded-2xl border px-4 py-3 text-sm ${
+                              correct
+                                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                                : selected
+                                  ? 'border-red-500/40 bg-red-500/10 text-red-100'
+                                  : 'border-white/10 bg-white/5 text-gray-400'
+                            }`}
+                          >
+                            <span className="font-semibold">
+                              {correct ? 'Correct' : selected ? 'Incorrect' : 'Not selected'}:
+                            </span>{' '}
+                            {choice}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                   <button
                     onClick={() => send({ type: 'NEXT' })}
                     className="rounded-full bg-red-600 px-8 py-4 font-bold tracking-[0.25em] text-white uppercase transition hover:bg-red-700"

--- a/frontend/src/components/terminal/CompileOutputTerminal.tsx
+++ b/frontend/src/components/terminal/CompileOutputTerminal.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { CheckCircle2, CircleAlert } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+export type CompileLogLevel = 'info' | 'success' | 'error';
+
+export interface CompileLogEntry {
+  id: string;
+  level: CompileLogLevel;
+  message: string;
+  timestamp: string;
+}
+
+interface CompileOutputTerminalProps {
+  logs: CompileLogEntry[];
+  isCompiling?: boolean;
+}
+
+export function CompileOutputTerminal({ logs, isCompiling = false }: CompileOutputTerminalProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    viewport.scrollTop = viewport.scrollHeight;
+  }, [logs, isCompiling]);
+
+  return (
+    <div className="group relative flex min-h-[280px] flex-grow flex-col overflow-hidden rounded-3xl border border-white/10 bg-black shadow-inner">
+      <div className="absolute top-0 left-0 h-1 w-full bg-red-600/30" />
+      <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+        <h3 className="text-[10px] font-black tracking-widest text-gray-500 uppercase">
+          Compile_Output
+        </h3>
+        <span className="text-[9px] font-bold tracking-widest text-zinc-600 uppercase">
+          {isCompiling ? 'Running' : 'Ready'}
+        </span>
+      </div>
+      <div
+        ref={viewportRef}
+        className="flex-1 overflow-y-auto p-5 font-mono text-xs leading-6"
+        role="log"
+        aria-live="polite"
+      >
+        {logs.length === 0 ? (
+          <div className="text-zinc-500">
+            <p>&gt; Initializing environment...</p>
+            <p>&gt; Awaiting input signal...</p>
+          </div>
+        ) : (
+          logs.map((log) => (
+            <div
+              key={log.id}
+              className={
+                log.level === 'success'
+                  ? 'text-emerald-400'
+                  : log.level === 'error'
+                    ? 'text-red-400'
+                    : 'text-zinc-300'
+              }
+            >
+              <span className="mr-2 text-zinc-600">[{log.timestamp}]</span>
+              <span className="mr-2 inline-flex align-middle">
+                {log.level === 'success' ? (
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                ) : log.level === 'error' ? (
+                  <CircleAlert className="h-3.5 w-3.5" />
+                ) : (
+                  '$'
+                )}
+              </span>
+              <span className="whitespace-pre-wrap">{log.message}</span>
+            </div>
+          ))
+        )}
+      </div>
+      {isCompiling && (
+        <div className="border-t border-white/10 px-5 py-3">
+          <div className="h-1 w-20 overflow-hidden rounded-full bg-zinc-800">
+            <div className="h-full w-1/2 animate-[loading_1s_infinite] bg-red-600" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/learning-api.ts
+++ b/frontend/src/lib/learning-api.ts
@@ -1,6 +1,7 @@
 import apiClient from './api-client';
 import { apiRequestCache } from './api-cache';
 import type { ProgressData } from './types/roadmap';
+import { queueLessonProgressCompletion } from './offline-sync';
 
 export interface CourseCurriculum {
   id: string;
@@ -118,6 +119,13 @@ export const learningAPI = {
       status: string;
     }>
   ): Promise<LearningProgressResponse | null> => {
+    if (typeof window !== 'undefined' && !navigator.onLine && data.completedLessons?.length) {
+      await queueLessonProgressCompletion({
+        courseId,
+        lessonId: data.completedLessons[data.completedLessons.length - 1],
+      });
+    }
+
     try {
       const response = await apiClient.patch(
         `/learning/courses/${courseId}/progress`,

--- a/frontend/src/lib/offline-sync.test.ts
+++ b/frontend/src/lib/offline-sync.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushQueuedRequests, getQueuedRequests, queueOfflineRequest, removeQueuedRequest } from './offline-sync';
+import {
+  flushQueuedLessonProgress,
+  flushQueuedRequests,
+  getQueuedLessonProgress,
+  getQueuedRequests,
+  queueLessonProgressCompletion,
+  queueOfflineRequest,
+  removeQueuedLessonProgress,
+  removeQueuedRequest,
+} from './offline-sync';
 
 describe('offline-sync', () => {
   beforeEach(async () => {
@@ -9,6 +18,11 @@ describe('offline-sync', () => {
     const queued = await getQueuedRequests();
     for (const item of queued) {
       await removeQueuedRequest(item.id);
+    }
+
+    const progressItems = await getQueuedLessonProgress();
+    for (const item of progressItems) {
+      await removeQueuedLessonProgress(item.id);
     }
   });
 
@@ -39,5 +53,36 @@ describe('offline-sync', () => {
 
     queuedRequests = await getQueuedRequests();
     expect(queuedRequests.length).toBe(0);
+  });
+
+  it('queues lesson progress and flushes it when online', async () => {
+    await queueLessonProgressCompletion({
+      courseId: 'course-1',
+      lessonId: 'lesson-1',
+      completedAt: '2026-06-25T00:00:00.000Z',
+    });
+
+    let queuedProgress = await getQueuedLessonProgress();
+    expect(queuedProgress).toHaveLength(1);
+    expect(queuedProgress[0].id).toBe('course-1:lesson-1');
+
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushQueuedLessonProgress();
+
+    expect(fetchMock).toHaveBeenCalledWith('/learning/courses/course-1/progress', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        completedLessonId: 'lesson-1',
+        completedAt: '2026-06-25T00:00:00.000Z',
+      }),
+    });
+
+    queuedProgress = await getQueuedLessonProgress();
+    expect(queuedProgress).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/offline-sync.ts
+++ b/frontend/src/lib/offline-sync.ts
@@ -1,15 +1,7 @@
-import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
-
 const DB_NAME = 'web3-student-lab-offline-sync';
-const DB_VERSION = 1;
-const STORE_NAME = 'queued-requests';
-
-interface OfflineSyncSchema extends DBSchema {
-  [STORE_NAME]: {
-    key: string;
-    value: QueuedRequest;
-  };
-}
+const DB_VERSION = 2;
+const REQUEST_STORE = 'queued-requests';
+const PROGRESS_STORE = 'lesson-progress';
 
 export type QueuedRequestMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -22,77 +14,173 @@ export interface QueuedRequest {
   createdAt: number;
 }
 
-let dbPromise: Promise<IDBPDatabase<OfflineSyncSchema>> | null = null;
+export interface QueuedLessonProgress {
+  id: string;
+  courseId: string;
+  lessonId: string;
+  completedAt: string;
+  url: string;
+  createdAt: number;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function createId() {
+  return crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
 
 function getDb() {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('IndexedDB is only available in the browser.'));
+  }
+
   if (!dbPromise) {
-    dbPromise = openDB<OfflineSyncSchema>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains(STORE_NAME)) {
-          db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(REQUEST_STORE)) {
+          db.createObjectStore(REQUEST_STORE, { keyPath: 'id' });
         }
-      },
+        if (!db.objectStoreNames.contains(PROGRESS_STORE)) {
+          db.createObjectStore(PROGRESS_STORE, { keyPath: 'id' });
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
     });
   }
+
   return dbPromise;
 }
 
-export async function queueOfflineRequest(request: Omit<QueuedRequest, 'id' | 'createdAt'>) {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
+async function writeItem<T>(storeName: string, value: T) {
   const db = await getDb();
-  const queuedRequest: QueuedRequest = {
-    ...request,
-    id: crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    createdAt: Date.now(),
-  };
+  return new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(storeName, 'readwrite');
+    transaction.objectStore(storeName).put(value);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
 
-  await db.put(STORE_NAME, queuedRequest);
+async function readAll<T>(storeName: string): Promise<T[]> {
+  const db = await getDb();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, 'readonly');
+    const request = transaction.objectStore(storeName).getAll();
+    request.onsuccess = () => resolve(request.result as T[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function deleteItem(storeName: string, id: string) {
+  const db = await getDb();
+  return new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(storeName, 'readwrite');
+    transaction.objectStore(storeName).delete(id);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+export async function queueOfflineRequest(request: Omit<QueuedRequest, 'id' | 'createdAt'>) {
+  if (typeof window === 'undefined') return;
+
+  await writeItem<QueuedRequest>(REQUEST_STORE, {
+    ...request,
+    id: createId(),
+    createdAt: Date.now(),
+  });
+}
+
+export async function queueLessonProgressCompletion(input: {
+  courseId: string;
+  lessonId: string;
+  completedAt?: string;
+}) {
+  if (typeof window === 'undefined') return;
+
+  const completedAt = input.completedAt ?? new Date().toISOString();
+  await writeItem<QueuedLessonProgress>(PROGRESS_STORE, {
+    id: `${input.courseId}:${input.lessonId}`,
+    courseId: input.courseId,
+    lessonId: input.lessonId,
+    completedAt,
+    url: `/learning/courses/${input.courseId}/progress`,
+    createdAt: Date.now(),
+  });
 }
 
 export async function getQueuedRequests(): Promise<QueuedRequest[]> {
-  if (typeof window === 'undefined') {
-    return [];
-  }
+  if (typeof window === 'undefined') return [];
+  return readAll<QueuedRequest>(REQUEST_STORE);
+}
 
-  const db = await getDb();
-  return db.getAll(STORE_NAME);
+export async function getQueuedLessonProgress(): Promise<QueuedLessonProgress[]> {
+  if (typeof window === 'undefined') return [];
+  return readAll<QueuedLessonProgress>(PROGRESS_STORE);
 }
 
 export async function removeQueuedRequest(id: string) {
-  if (typeof window === 'undefined') {
-    return;
-  }
+  if (typeof window === 'undefined') return;
+  await deleteItem(REQUEST_STORE, id);
+}
 
-  const db = await getDb();
-  await db.delete(STORE_NAME, id);
+export async function removeQueuedLessonProgress(id: string) {
+  if (typeof window === 'undefined') return;
+  await deleteItem(PROGRESS_STORE, id);
 }
 
 export async function flushQueuedRequests() {
-  if (typeof window === 'undefined' || !navigator.onLine) {
-    return;
-  }
+  if (typeof window === 'undefined' || !navigator.onLine) return;
 
   const requests = await getQueuedRequests();
   for (const request of requests) {
     try {
-      const fetchOptions = {
+      const response = await fetch(request.url, {
         method: request.method,
         headers: request.headers,
         body: request.body,
-        credentials: 'same-origin' as RequestCredentials,
-      };
-      const response = await fetch(request.url, fetchOptions);
+        credentials: 'same-origin',
+      });
       if (response.ok) {
         await removeQueuedRequest(request.id);
       }
     } catch (error) {
       console.warn('[OfflineSync] Flush failed, keeping queued request:', request.id, error);
-      // Leave failed requests in the queue for the next online event.
     }
   }
+}
+
+export async function flushQueuedLessonProgress() {
+  if (typeof window === 'undefined' || !navigator.onLine) return;
+
+  const queuedItems = await getQueuedLessonProgress();
+  for (const item of queuedItems) {
+    try {
+      const response = await fetch(item.url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          completedLessonId: item.lessonId,
+          completedAt: item.completedAt,
+        }),
+      });
+      if (response.ok) {
+        await removeQueuedLessonProgress(item.id);
+      }
+    } catch (error) {
+      console.warn('[OfflineSync] Progress flush failed, keeping item:', item.id, error);
+    }
+  }
+}
+
+export async function flushOfflineSyncQueue() {
+  await Promise.all([flushQueuedRequests(), flushQueuedLessonProgress()]);
 }
 
 export function registerOnlineSync() {
@@ -101,8 +189,8 @@ export function registerOnlineSync() {
   }
 
   const handleOnline = () => {
-    flushQueuedRequests().catch((error) => {
-      console.error('[OfflineSync] Error flushing queued requests:', error);
+    flushOfflineSyncQueue().catch((error) => {
+      console.error('[OfflineSync] Error flushing queued work:', error);
     });
   };
 

--- a/frontend/src/lib/quizMachine.ts
+++ b/frontend/src/lib/quizMachine.ts
@@ -5,6 +5,7 @@ export interface QuizContext {
   currentIndex: number;
   score: number;
   selectedOption: string | null;
+  selectedOptions: string[];
   dragOrder: string[];
   snippetSelection: string | null;
   visibleChoices: string[];
@@ -18,6 +19,7 @@ export interface QuizContext {
 export type QuizEvent =
   | { type: 'START' }
   | { type: 'SELECT_OPTION'; choice: string }
+  | { type: 'TOGGLE_OPTION'; choice: string }
   | { type: 'UPDATE_ORDER'; order: string[] }
   | { type: 'UPDATE_SNIPPET'; choice: string }
   | { type: 'USE_HINT' }
@@ -31,6 +33,7 @@ const initialContext: QuizContext = {
   currentIndex: 0,
   score: 0,
   selectedOption: null,
+  selectedOptions: [],
   dragOrder: [],
   snippetSelection: null,
   visibleChoices: [],
@@ -54,6 +57,7 @@ const buildQuestionContext = (index: number) => {
 
   return {
     selectedOption: null,
+    selectedOptions: [],
     dragOrder: question.type === 'drag-order' ? question.segments : [],
     snippetSelection: null,
     visibleChoices: randomize(choicePool),
@@ -61,7 +65,9 @@ const buildQuestionContext = (index: number) => {
     timedOut: false,
     correctAnswer:
       question.type === 'multiple-choice'
-        ? question.answer
+        ? Array.isArray(question.answer)
+          ? question.answer.join(', ')
+          : question.answer
         : question.type === 'code-fill'
           ? question.answer
           : null,
@@ -73,6 +79,12 @@ const isCorrect = (context: QuizContext) => {
   const question = getQuestion(context);
 
   if (question.type === 'multiple-choice') {
+    if (question.allowMultiple && Array.isArray(question.answer)) {
+      return (
+        question.answer.length === context.selectedOptions.length &&
+        question.answer.every((answer) => context.selectedOptions.includes(answer))
+      );
+    }
     return context.selectedOption === question.answer;
   }
 
@@ -105,6 +117,18 @@ export const quizMachine = setup({
       return {
         ...context,
         selectedOption: event.choice,
+        selectedOptions: [event.choice],
+      };
+    }),
+    toggleSelectedOption: assign(({ context, event }) => {
+      if (event.type !== 'TOGGLE_OPTION') return context;
+      const selectedOptions = context.selectedOptions.includes(event.choice)
+        ? context.selectedOptions.filter((choice) => choice !== event.choice)
+        : [...context.selectedOptions, event.choice];
+      return {
+        ...context,
+        selectedOption: selectedOptions[0] ?? null,
+        selectedOptions,
       };
     }),
     setDragOrder: assign(({ context, event }) => {
@@ -129,13 +153,14 @@ export const quizMachine = setup({
       const question = getQuestion(context);
       if (question.type === 'multiple-choice' || question.type === 'code-fill') {
         const answer = question.answer;
+        const answers = Array.isArray(answer) ? answer : [answer];
         const incorrectOptions =
           'choices' in question && question.choices
-            ? question.choices.filter((choice) => choice !== answer)
+            ? question.choices.filter((choice) => !answers.includes(choice))
             : 'options' in question && question.options
-              ? question.options.filter((choice) => choice !== answer)
+              ? question.options.filter((choice) => !answers.includes(choice))
               : [];
-        const reduced = [answer, incorrectOptions[0]].sort();
+        const reduced = [...answers, incorrectOptions[0]].filter(Boolean).sort();
         return {
           ...context,
           visibleChoices: reduced,
@@ -168,7 +193,9 @@ export const quizMachine = setup({
           ? 'Complete order matches the correct lifecycle.'
           : question.type === 'code-fill'
             ? question.answer
-            : question.answer;
+            : Array.isArray(question.answer)
+              ? question.answer.join(', ')
+              : question.answer;
       return {
         ...context,
         correctAnswer: answer,
@@ -187,7 +214,9 @@ export const quizMachine = setup({
     canSubmit: ({ context }) => {
       const question = getQuestion(context);
       if (question.type === 'multiple-choice') {
-        return Boolean(context.selectedOption);
+        return question.allowMultiple
+          ? context.selectedOptions.length > 0
+          : Boolean(context.selectedOption);
       }
       if (question.type === 'drag-order') {
         return context.dragOrder.length > 0;
@@ -217,6 +246,9 @@ export const quizMachine = setup({
       on: {
         SELECT_OPTION: {
           actions: { type: 'setSelectedOption' },
+        },
+        TOGGLE_OPTION: {
+          actions: { type: 'toggleSelectedOption' },
         },
         UPDATE_ORDER: {
           actions: { type: 'setDragOrder' },

--- a/frontend/src/lib/quizQuestions.ts
+++ b/frontend/src/lib/quizQuestions.ts
@@ -10,7 +10,8 @@ export interface BaseQuizQuestion {
 export interface MultipleChoiceQuestion extends BaseQuizQuestion {
   type: 'multiple-choice';
   options: string[];
-  answer: string;
+  answer: string | string[];
+  allowMultiple?: boolean;
 }
 
 export interface DragOrderQuestion extends BaseQuizQuestion {
@@ -42,6 +43,25 @@ export const quizQuestions: QuizQuestion[] = [
       'IPFS off-chain storage',
     ],
     answer: 'Ledger entries and contract storage',
+  },
+  {
+    id: 'q1b',
+    type: 'multiple-choice',
+    prompt: 'Which checkpoints should pass before shipping a Stellar lesson project?',
+    hint: 'A solid checkpoint proves both the code path and the learner-facing explanation.',
+    time: 30,
+    allowMultiple: true,
+    options: [
+      'The contract compiles without errors',
+      'The lesson explains why the contract behavior matters',
+      'The UI stores private keys in localStorage',
+      'The learner can verify expected output',
+    ],
+    answer: [
+      'The contract compiles without errors',
+      'The lesson explains why the contract behavior matters',
+      'The learner can verify expected output',
+    ],
   },
   {
     id: 'q2',

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import 'fake-indexeddb/auto';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import { webcrypto } from 'node:crypto';
 
 // Polyfill window.crypto with Node's webcrypto so crypto.subtle is available in jsdom
 Object.defineProperty(window, 'crypto', {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -30,9 +30,4 @@ export default defineConfig({
       ],
     },
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-    },
-  },
 });


### PR DESCRIPTION
## Summary
- add interactive lesson checkpoint quiz support for single and multi-select answers with submit feedback
- add playground compile output terminal with colored success/error log handling and auto-scroll
- add Monaco editor settings modal for font size, tab size, vim-style cursor mode, plus Ctrl/Cmd+Enter compile keybinding
- add native IndexedDB offline lesson progress queueing and app-level online flush handling

## Validation
- npm run build
- npx vitest run src/lib/offline-sync.test.ts
- changed-file TypeScript scan for touched files

Closes #703
Closes #704
Closes #708
Closes #710