### PR TITLE
[Style] Standardize Prettier configuration across frontend and backend

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,2 +1,13 @@
+# Build output
+.next/
+dist/
+
+# Dependencies
+node_modules/
+
+# Generated
+.next/
+
+# Large generated/third-party files
 src/components/rewards/RewardsDashboard.tsx
 src/components/subscriptions/SubscriptionDashboard.tsx

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "quoteProps": "as-needed",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
## Description

Standardizes Prettier formatting configuration across both frontend and backend:

- Created `frontend/.prettierrc` matching the existing `backend/.prettierrc` config
- Updated `frontend/.prettierignore` with standard patterns (build output, dependencies, etc.)
- Both projects now use: semi, singleQuote, trailingComma es5, printWidth 100, lf endOfLine

Closes #977