### PR TITLE
feat(indexer): add Soroban event indexer service (closes #998)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,45 @@ services:
     networks:
       - web3-network
 
+  # Soroban / Stellar event indexer. Polls the Soroban RPC, persists events
+  # into a SQLite file (mounted as a Docker volume) and exposes a WebSocket /
+  # SSE fan-out on :3001 that the frontend can subscribe to for live event
+  # updates. Uses the same Docker network as the backend so it can also reach
+  # Postgres when DATABASE_URL is overridden.
+  indexer:
+    build:
+      context: ./indexer
+      dockerfile: Dockerfile
+    image: web3-student-lab-indexer:latest
+    container_name: web3-student-lab-indexer
+    restart: always
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+      # Default to local SQLite. To use Postgres instead uncomment the line
+      # below and remove the DATABASE_URL — the service auto-detects the
+      # scheme.
+      - DATABASE_URL=sqlite:///data/indexer.db?mode=rwc
+      # - DATABASE_URL=postgresql://postgres:postgres@db:5432/web3-student-lab
+      - SOROBAN_RPC_URL=${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}
+      - POLL_INTERVAL_MS=${INDEXER_POLL_INTERVAL_MS:-5000}
+      - BATCH_SIZE=${INDEXER_BATCH_SIZE:-100}
+      - RUST_LOG=${RUST_LOG:-info,indexer=debug}
+    volumes:
+      - indexer_data:/data
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/soroban-indexer", "--healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - web3-network
+
 networks:
   web3-network:
     driver: bridge
@@ -172,3 +211,4 @@ volumes:
   redis_cluster_1_data:
   redis_cluster_2_data:
   redis_cluster_3_data:
+  indexer_data:

--- a/indexer/.dockerignore
+++ b/indexer/.dockerignore
@@ -1,0 +1,28 @@
+# Build artefacts
+target/
+**/target/
+**/*.rs.bk
+
+# Local development
+.git/
+.gitignore
+.vscode/
+.idea/
+
+# Cargo cache noise
+.cargo/
+
+# Editor / OS noise
+**/*.swp
+**/*.swo
+.DS_Store
+
+# Logs / coverage
+*.log
+coverage/
+*.lcov
+
+# This file itself
+.dockerignore
+Dockerfile
+README.md

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "soroban-indexer"
+version = "0.1.0"
+edition = "2021"
+description = "Off-chain event indexer for Soroban/Stellar smart contracts. Polls Soroban RPC, persists events to SQLite/Postgres, and exposes a WebSocket fanout."
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "soroban-indexer"
+path = "src/main.rs"
+
+[dependencies]
+# Async runtime / utilities
+tokio = { version = "1.37", features = ["full"] }
+futures = "0.3"
+async-stream = "0.3"
+
+# Web server + WebSocket fanout
+axum = { version = "0.7.5", features = ["ws", "macros"] }
+
+# Persistence
+sqlx = { version = "0.7.4", default-features = false, features = [
+    "runtime-tokio",
+    "sqlite",
+    "postgres",
+    "tls-rustls",
+    "macros",
+    "json",
+] }
+
+# HTTP RPC client
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Serialisation
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Observability
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+# Misc
+anyhow = "1.0"
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true
+opt-level = 3

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1.7
+# ---------- Stage 1: build ----------
+FROM rust:1.77-slim-bookworm AS builder
+
+ENV CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/workspace/target \
+    RUST_BACKTRACE=1
+
+WORKDIR /workspace
+
+# Build-time deps for reqwest (rustls-tls pulls in ring which needs pkg-config)
+# and libssl-dev is kept available in case the chosen TLS backend changes.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Pre-warm the cargo dependency cache. We deliberately copy only Cargo.toml
+# first and add a fake main.rs so dependencies (tokio, axum, sqlx, reqwest…)
+# are cached in their own layer and don't have to be re-downloaded whenever
+# application code changes.
+COPY Cargo.toml ./
+RUN mkdir -p src \
+ && echo "fn main() { println!(\"boot\"); }" > src/main.rs \
+ && cargo build --release --bin soroban-indexer \
+ && rm -rf src target/release/deps/soroban_indexer*
+
+# Real build. The dep cache above means this layer is fast even when the
+# source changes.
+COPY src ./src
+# Touch the source file to force cargo to recompile the crate, not the cache.
+RUN touch src/main.rs \
+ && cargo build --release --bin soroban-indexer \
+ && strip target/release/soroban-indexer
+
+# ---------- Stage 2: runtime ----------
+FROM debian:bookworm-slim AS runtime
+
+ENV PORT=3001 \
+    RUST_LOG=info \
+    DATABASE_URL=sqlite:///data/indexer.db?mode=rwc \
+    SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Runtime libs: only what the binary actually needs. reqwest uses rustls so
+# we don't need to ship OpenSSL in the final image. tini reaps zombies and
+# forwards SIGTERM so the axum graceful-shutdown path actually runs.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tini \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd --system --gid 1001 indexer \
+ && useradd  --system --uid 1001 --gid indexer --home /app --shell /sbin/nologin indexer
+
+WORKDIR /app
+
+COPY --from=builder /workspace/target/release/soroban-indexer /usr/local/bin/soroban-indexer
+
+# Persistent SQLite database lives here. Mount a volume in docker-compose.
+RUN mkdir -p /data && chown -R indexer:indexer /data
+
+USER indexer
+EXPOSE 3001
+
+# tini reaps zombies and forwards signals so the axum server's graceful
+# shutdown logic actually runs in container land.
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["/usr/local/bin/soroban-indexer"]

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -1,0 +1,119 @@
+# Soroban Indexer
+
+Off-chain event indexer for the **Web3 Student Lab**. It talks plain JSON-RPC
+to a [Soroban RPC](https://soroban.stellar.org/docs/rpc) endpoint, persists
+every event into SQLite (default) or Postgres, and fan-outs new events over a
+WebSocket so the frontend can stream live data from the chain.
+
+## Why
+
+The platform's smart-contract tests, learning-roadmap explorer and
+hackathon dashboards all need historical **and** real-time access to on-chain
+events. Polling Soroban RPC from many places is wasteful, so a single Rust
+service indexes once and serves many.
+
+## Layout
+
+```
+indexer/
+├── Cargo.toml          # standalone crate — not part of contracts/ workspace
+├── Dockerfile          # multi-stage Debian slim build
+├── .dockerignore
+├── migrations/         # SQL DDL applied on startup
+└── src/
+    ├── main.rs         # entry point: tracing, deps wiring, server
+    ├── config.rs       # env-var loader (port, db url, rpc url, …)
+    ├── db.rs           # sqlx pool + schema init + cursor / events
+    ├── rpc.rs          # RpcClient + background Poller
+    └── server.rs       # axum HTTP + WebSocket + SSE
+```
+
+## Run locally
+
+```bash
+cd indexer
+cargo run --release
+```
+
+With defaults the service binds to `:3001`, talks to the public Stellar testnet
+RPC and writes `indexer.db` next to the working directory.
+
+## Run in Docker
+
+```bash
+docker build -t web3-student-lab-indexer ./indexer
+docker run --rm -p 3001:3001 \
+  -e SOROBAN_RPC_URL=https://soroban-testnet.stellar.org \
+  -v indexer_data:/data \
+  web3-student-lab-indexer
+```
+
+Or via the repo's compose file:
+
+```bash
+docker compose up -d indexer
+```
+
+## Environment variables
+
+| Variable          | Default                                              | Purpose                                                              |
+| ----------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| `PORT`            | `3001`                                               | HTTP / WS port                                                       |
+| `DATABASE_URL`    | `sqlite:///data/indexer.db?mode=rwc`                 | sqlx connection string; auto-detects SQLite vs Postgres from scheme |
+| `SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org`                | Soroban RPC endpoint used by the poller                              |
+| `POLL_INTERVAL_MS`| `5000`                                               | Sleep between successful polls                                       |
+| `BATCH_SIZE`      | `100`                                                | Ledger window per request to `getEvents`                             |
+| `START_LEDGER`    | unset                                                | Override the cursor (back-fills / tests)                             |
+| `RUST_LOG`        | `info,indexer=debug,sqlx=warn,...`                   | `tracing-subscriber` env-filter                                      |
+
+## HTTP routes
+
+| Method | Path       | Description                                                                 |
+| ------ | ---------- | --------------------------------------------------------------------------- |
+| GET    | `/`        | Service banner                                                              |
+| GET    | `/health`  | Liveness + best-effort RPC ping                                            |
+| GET    | `/events`  | Most recent events from the DB. Query params: `contractId`, `eventType`, `fromLedger`, `limit` |
+| GET    | `/ws`      | WebSocket fan-out of every newly indexed event                              |
+| GET    | `/v1/sse`  | Equivalent to `/ws` but over Server-Sent Events (handy for `curl`)          |
+
+### Try it
+
+```bash
+curl -s http://localhost:3001/health | jq
+curl -s 'http://localhost:3001/events?limit=5' | jq
+
+# Live fan-out via SSE
+curl -N http://localhost:3001/v1/sse
+
+# Live fan-out via WebSocket (using `websocat`)
+websocat ws://localhost:3001/ws
+```
+
+From JavaScript:
+
+```ts
+const ws = new WebSocket("ws://localhost:3001/ws");
+ws.onmessage = (e) => console.log("new event", JSON.parse(e.data));
+```
+
+## Schema
+
+`events` rows are written once and upserted by `id` (the deterministic
+`{ledger}-{txHash}-{eventIndex}` key returned by Soroban RPC). `indexer_cursor`
+is a single-row table holding `last_ledger` so restarts resume from where the
+service left off.
+
+The full DDL lives in [`migrations/`](./migrations) and is applied on every
+startup (`IF NOT EXISTS`-style — safe to re-run).
+
+## Design notes
+
+* Single Rust crate on purpose: keeping the indexer out of the
+  `contracts/` workspace avoids the `wasm32-unknown-unknown` toolchain and
+  keeps compile times short.
+* `sqlx::query` is used (no compile-time SQLx macros) so the binary builds
+  without needing a live database inside the Docker build context.
+* Multi-stage Debian slim build (not Alpine) to avoid musl + OpenSSL pitfalls
+  with `reqwest`.
+* `tini` is used as PID 1 so the axum graceful-shutdown path actually fires
+  when the container is stopped.

--- a/indexer/migrations/0001_init.postgres.sql
+++ b/indexer/migrations/0001_init.postgres.sql
@@ -1,0 +1,32 @@
+-- Soroban Indexer — Postgres schema (v1)
+--
+-- Same logical shape as the SQLite schema but with a synthetic BIGSERIAL
+-- primary key for index-friendly joins and BIGINT instead of INTEGER for
+-- ledger numbers (Soroban testnet has already crossed 2^31 ledgers on
+-- future-firm timelines).
+
+CREATE TABLE IF NOT EXISTS events (
+    pk_id              BIGSERIAL PRIMARY KEY,
+    id                 TEXT NOT NULL UNIQUE,
+    ledger             BIGINT NOT NULL,
+    ledger_closed_at   TEXT NOT NULL,
+    contract_id        TEXT NOT NULL,
+    event_type         TEXT NOT NULL,
+    topics             TEXT NOT NULL,
+    data               TEXT NOT NULL,
+    tx_hash            TEXT NOT NULL,
+    ingested_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ledger     ON events (ledger);
+CREATE INDEX IF NOT EXISTS idx_events_contract   ON events (contract_id);
+CREATE INDEX IF NOT EXISTS idx_events_type       ON events (event_type);
+
+CREATE TABLE IF NOT EXISTS indexer_cursor (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    last_ledger BIGINT NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO indexer_cursor (id, last_ledger) VALUES (1, 0)
+ON CONFLICT (id) DO NOTHING;

--- a/indexer/migrations/0001_init.sqlite.sql
+++ b/indexer/migrations/0001_init.sqlite.sql
@@ -1,0 +1,32 @@
+-- Soroban Indexer — SQLite schema (v1)
+--
+-- The `events` table stores one row per Soroban RPC event. `id` is the
+-- deterministic composite id exposed by the RPC (`{ledger}-{txHash}-{eventIndex}`)
+-- so re-ingestion is idempotent.
+
+CREATE TABLE IF NOT EXISTS events (
+    id                TEXT PRIMARY KEY,
+    ledger            INTEGER NOT NULL,
+    ledger_closed_at  TEXT NOT NULL,
+    contract_id       TEXT NOT NULL,
+    event_type        TEXT NOT NULL,
+    topics            TEXT NOT NULL,
+    data              TEXT NOT NULL,
+    tx_hash           TEXT NOT NULL,
+    ingested_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ledger     ON events (ledger);
+CREATE INDEX IF NOT EXISTS idx_events_contract   ON events (contract_id);
+CREATE INDEX IF NOT EXISTS idx_events_type       ON events (event_type);
+
+-- Single-row table used as the poller's cursor (last successfully processed
+-- ledger). Replaying from a START_LEDGER override is also funnelled through
+-- this row so restart behaviour is identical.
+CREATE TABLE IF NOT EXISTS indexer_cursor (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    last_ledger INTEGER NOT NULL,
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT OR IGNORE INTO indexer_cursor (id, last_ledger) VALUES (1, 0);

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -1,0 +1,94 @@
+//! Runtime configuration loaded from environment variables.
+
+use std::env;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub port: u16,
+    pub database_url: String,
+    pub soroban_rpc_url: String,
+    pub poll_interval: Duration,
+    pub batch_size: u32,
+    pub start_ledger_override: Option<u32>,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        let port = env::var("PORT")
+            .unwrap_or_else(|_| "3001".into())
+            .parse()
+            .map_err(|e| anyhow!("invalid PORT: {e}"))?;
+
+        let database_url = env::var("DATABASE_URL")
+            .unwrap_or_else(|_| default_sqlite_url());
+
+        let soroban_rpc_url = env::var("SOROBAN_RPC_URL")
+            .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".into());
+
+        let poll_interval = Duration::from_millis(
+            env::var("POLL_INTERVAL_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5_000),
+        );
+
+        let batch_size: u32 = env::var("BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+        if batch_size == 0 || batch_size > 10_000 {
+            return Err(anyhow!("BATCH_SIZE must be in 1..=10000"));
+        }
+
+        let start_ledger_override = match env::var("START_LEDGER") {
+            Ok(v) => Some(v.parse().map_err(|e| anyhow!("invalid START_LEDGER: {e}"))?),
+            Err(_) => None,
+        };
+
+        Ok(Self {
+            port,
+            database_url,
+            soroban_rpc_url,
+            poll_interval,
+            batch_size,
+            start_ledger_override,
+        })
+    }
+
+    /// Human-friendly backend name used by the schema initialiser to decide
+    /// which DDL script to apply.
+    pub fn db_kind(&self) -> DbKind {
+        if self.database_url.starts_with("postgres://")
+            || self.database_url.starts_with("postgresql://")
+        {
+            DbKind::Postgres
+        } else {
+            DbKind::Sqlite
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DbKind {
+    Sqlite,
+    Postgres,
+}
+
+impl std::fmt::Display for DbKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DbKind::Sqlite => write!(f, "sqlite"),
+            DbKind::Postgres => write!(f, "postgres"),
+        }
+    }
+}
+
+fn default_sqlite_url() -> String {
+    match env::var("INDEXER_DATA_DIR") {
+        Ok(dir) => format!("sqlite://{dir}/indexer.db?mode=rwc"),
+        Err(_) => "sqlite://indexer.db?mode=rwc".into(),
+    }
+}

--- a/indexer/src/db.rs
+++ b/indexer/src/db.rs
@@ -1,0 +1,197 @@
+//! Persistence helpers: connect, run migrations, expose shared state.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{PgPool, Pool, SqlitePool};
+use tracing::info;
+
+use crate::config::{Config, DbKind};
+
+/// A backend-specific connection pool. Encoding the variant in the type lets
+/// us have perfectly normal SQL for each dialect without contortions.
+#[derive(Clone)]
+pub enum IndexerPool {
+    Sqlite(SqlitePool),
+    Postgres(PgPool),
+}
+
+impl IndexerPool {
+    pub fn kind(&self) -> DbKind {
+        match self {
+            IndexerPool::Sqlite(_) => DbKind::Sqlite,
+            IndexerPool::Postgres(_) => DbKind::Postgres,
+        }
+    }
+}
+
+/// Shared application state injected into every axum handler.
+pub struct AppState {
+    pub pool: IndexerPool,
+    pub tx: tokio::sync::broadcast::Sender<String>,
+    pub cfg: Config,
+}
+
+pub type SharedState = Arc<AppState>;
+
+/// Open a connection pool. Driver is chosen from the URL scheme.
+pub async fn connect(cfg: &Config) -> Result<IndexerPool> {
+    match cfg.db_kind() {
+        DbKind::Sqlite => {
+            let opts = SqliteConnectOptions::from_url(&cfg.database_url.parse()?)
+                .context("parsing SQLite url")?
+                .create_if_missing(true)
+                .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                .busy_timeout(Duration::from_secs(10));
+            let pool = SqlitePoolOptions::new()
+                .max_connections(10)
+                .acquire_timeout(Duration::from_secs(10))
+                .connect_with(opts)
+                .await
+                .with_context(|| format!("opening SQLite at {}", cfg.database_url))?;
+            info!("SQLite connection pool ready");
+            Ok(IndexerPool::Sqlite(pool))
+        }
+        DbKind::Postgres => {
+            let pool = sqlx::postgres::PgPoolOptions::new()
+                .max_connections(10)
+                .acquire_timeout(Duration::from_secs(10))
+                .connect(&cfg.database_url)
+                .await
+                .with_context(|| format!("opening Postgres at {}", cfg.database_url))?;
+            info!("Postgres connection pool ready");
+            Ok(IndexerPool::Postgres(pool))
+        }
+    }
+}
+
+/// Apply schema migrations on startup. We use dialect-specific SQL because the
+/// shared feature set of SQLite + Postgres is too narrow to express
+/// auto-incrementing primary keys cleanly.
+pub async fn init_schema(pool: &IndexerPool) -> Result<()> {
+    match pool {
+        IndexerPool::Sqlite(p) => {
+            sqlx::query(SQLITE_SCHEMA)
+                .execute(p)
+                .await
+                .context("creating SQLite schema")?;
+        }
+        IndexerPool::Postgres(p) => {
+            sqlx::query(POSTGRES_SCHEMA)
+                .execute(p)
+                .await
+                .context("creating Postgres schema")?;
+        }
+    }
+    info!("database schema ready");
+    Ok(())
+}
+
+/// Read the persisted cursor; returns `(last_ledger)` or `0` if the table is empty.
+pub async fn get_last_ledger(pool: &IndexerPool) -> Result<u32> {
+    match pool {
+        IndexerPool::Sqlite(p) => {
+            let row: Option<(i64,)> = sqlx::query_as(
+                "SELECT last_ledger FROM indexer_cursor WHERE id = 1",
+            )
+            .fetch_optional(p)
+            .await
+            .context("reading SQLite cursor")?;
+            Ok(row.map(|r| r.0 as u32).unwrap_or(0))
+        }
+        IndexerPool::Postgres(p) => {
+            let row: Option<(i64,)> = sqlx::query_as(
+                "SELECT last_ledger FROM indexer_cursor WHERE id = 1",
+            )
+            .fetch_optional(p)
+            .await
+            .context("reading Postgres cursor")?;
+            Ok(row.map(|r| r.0 as u32).unwrap_or(0))
+        }
+    }
+}
+
+pub async fn update_last_ledger(pool: &IndexerPool, last: u32) -> Result<()> {
+    match pool {
+        IndexerPool::Sqlite(p) => {
+            sqlx::query(
+                "INSERT INTO indexer_cursor (id, last_ledger) VALUES (1, ?1)
+                 ON CONFLICT(id) DO UPDATE SET last_ledger = excluded.last_ledger",
+            )
+            .bind(last as i64)
+            .execute(p)
+            .await
+            .context("updating SQLite cursor")?;
+        }
+        IndexerPool::Postgres(p) => {
+            sqlx::query(
+                "INSERT INTO indexer_cursor (id, last_ledger) VALUES (1, $1)
+                 ON CONFLICT (id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger",
+            )
+            .bind(last as i64)
+            .execute(p)
+            .await
+            .context("updating Postgres cursor")?;
+        }
+    }
+    Ok(())
+}
+
+/// Bulk-insert events. Duplicates by primary key are silently ignored.
+pub async fn insert_events(pool: &IndexerPool, events: &[crate::rpc::IndexedEvent]) -> Result<()> {
+    if events.is_empty() {
+        return Ok(());
+    }
+    match pool {
+        IndexerPool::Sqlite(p) => {
+            let mut qb = sqlx::query::QueryBuilder::<sqlx::Sqlite>::new(
+                "INSERT OR IGNORE INTO events \
+                 (id, ledger, ledger_closed_at, contract_id, event_type, topics, data, tx_hash) ",
+            );
+            qb.push_values(events, |mut b, e| {
+                b.push_bind(&e.id)
+                    .push_bind(e.ledger as i64)
+                    .push_bind(&e.ledger_closed_at)
+                    .push_bind(&e.contract_id)
+                    .push_bind(&e.event_type)
+                    .push_bind(&e.topics_json)
+                    .push_bind(&e.data_json)
+                    .push_bind(&e.transaction_hash);
+            });
+            qb.build()
+                .execute(p)
+                .await
+                .context("inserting events (sqlite)")?;
+        }
+        IndexerPool::Postgres(p) => {
+            let mut qb = sqlx::query::QueryBuilder::<sqlx::Postgres>::new(
+                "INSERT INTO events \
+                 (id, ledger, ledger_closed_at, contract_id, event_type, topics, data, tx_hash) ",
+            );
+            qb.push_values(events, |mut b, e| {
+                b.push_bind(&e.id)
+                    .push_bind(e.ledger as i64)
+                    .push_bind(&e.ledger_closed_at)
+                    .push_bind(&e.contract_id)
+                    .push_bind(&e.event_type)
+                    .push_bind(&e.topics_json)
+                    .push_bind(&e.data_json)
+                    .push_bind(&e.transaction_hash);
+            });
+            qb.push(" ON CONFLICT (id) DO NOTHING");
+            qb.build()
+                .execute(p)
+                .await
+                .context("inserting events (postgres)")?;
+        }
+    }
+    Ok(())
+}
+
+/// SQLite schema. `id` is the deterministic composite id from Soroban RPC.
+const SQLITE_SCHEMA: &str = include_str!("migrations/0001_init.sqlite.sql");
+
+/// Postgres schema. Adds a synthetic BIGSERIAL PK for index efficiency.
+const POSTGRES_SCHEMA: &str = include_str!("migrations/0001_init.postgres.sql");

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -1,0 +1,141 @@
+//! Soroban Indexer — off-chain event indexer for the Web3 Student Lab.
+//!
+//! Architecture
+//! ------------
+//! * **Poller** — Tokio task that repeatedly calls Soroban RPC `getEvents`,
+//!   paginating by ledger and persisting events into the database. It also
+//!   tracks a `cursor.last_ledger` row so restarts resume cleanly.
+//! * **Storage** — `sqlx` pool. SQLite is the default (zero-config) but the
+//!   same code path works against Postgres; the choice is driven by the
+//!   `DATABASE_URL` scheme.
+//! * **Fan-out** — A Tokio `broadcast` channel carries the JSON serialised
+//!   event messages to every connected WebSocket subscriber and is also
+//!   exposed over a simple HTTP `GET /events` route for back-fill queries.
+//!
+//! Environment variables (all optional):
+//!   PORT             - HTTP/WS port (default 3001)
+//!   DATABASE_URL     - SQLite or Postgres URL (default: sqlite://indexer.db?mode=rwc)
+//!   SOROBAN_RPC_URL  - Soroban RPC endpoint (default: https://soroban-testnet.stellar.org)
+//!   POLL_INTERVAL_MS - Time between successful polls (default 5000)
+//!   START_LEDGER     - Override starting ledger cursor (for back-fills / tests)
+//!   RUST_LOG         - tracing log filter
+
+mod config;
+mod db;
+mod rpc;
+mod server;
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::sync::broadcast;
+use tracing::{info, warn};
+
+use crate::config::Config;
+use crate::db::{init_schema, AppState, IndexerPool};
+use crate::rpc::Poller;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // `--healthcheck` is invoked by docker-compose. We open DB, ensure that
+    // the schema exists and exit (success / failure). No server is started.
+    let mut args = std::env::args().skip(1);
+    if args.next().as_deref() == Some("--healthcheck") {
+        std::process::exit(healthcheck().await as i32);
+    }
+
+    init_tracing();
+
+    let cfg = Config::from_env().context("loading configuration")?;
+    info!(
+        port = cfg.port,
+        rpc = %cfg.soroban_rpc_url,
+        db_kind = %cfg.db_kind(),
+        "starting soroban-indexer"
+    );
+
+    let pool = db::connect(&cfg)
+        .await
+        .context("connecting to database")?;
+    init_schema(&pool).await.context("initialising schema")?;
+
+    let (tx, _rx) = broadcast::channel::<String>(1024);
+    let state = Arc::new(AppState {
+        pool: pool.clone(),
+        tx: tx.clone(),
+        cfg: cfg.clone(),
+    });
+
+    // Background poller. A panic in the poller must not crash the web server.
+    let poller = Poller {
+        cfg: cfg.clone(),
+        pool: pool.clone(),
+        tx: tx.clone(),
+    };
+    tokio::spawn(async move {
+        if let Err(err) = poller.run().await {
+            warn!(error = %err, "poller terminated");
+        }
+    });
+
+    server::serve(cfg, state).await
+}
+
+/// One-shot probe used by the docker-compose `healthcheck` directive.
+async fn healthcheck() -> i32 {
+    let cfg = match Config::from_env() {
+        Ok(c) => c,
+        Err(err) => {
+            eprintln!("healthcheck: bad config: {err}");
+            return 1;
+        }
+    };
+    let pool = match db::connect(&cfg).await {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("healthcheck: can not connect to DB: {err}");
+            return 1;
+        }
+    };
+    if let Err(err) = init_schema(&pool).await {
+        eprintln!("healthcheck: schema init failed: {err}");
+        return 1;
+    }
+    match pool_cursor(&pool).await {
+        Ok(_) => 0,
+        Err(err) => {
+            eprintln!("healthcheck: cursor read failed: {err}");
+            1
+        }
+    }
+}
+
+async fn pool_cursor(pool: &IndexerPool) -> Result<()> {
+    match pool {
+        IndexerPool::Sqlite(p) => {
+            let _row: Option<(i64,)> =
+                sqlx::query_as("SELECT last_ledger FROM indexer_cursor WHERE id = 1")
+                    .fetch_optional(p)
+                    .await
+                    .context("sqlite cursor read")?;
+        }
+        IndexerPool::Postgres(p) => {
+            let _row: Option<(i64,)> =
+                sqlx::query_as("SELECT last_ledger FROM indexer_cursor WHERE id = 1")
+                    .fetch_optional(p)
+                    .await
+                    .context("postgres cursor read")?;
+        }
+    }
+    // Touch the imported trait so future schemas can be probed without churn.
+    let _ = sqlx::Row::columns;
+    Ok(())
+}
+
+fn init_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+    let filter = EnvFilter::try_from_env("RUST_LOG").unwrap_or_else(|_| {
+        EnvFilter::new("info,indexer=debug,sqlx=warn,reqwest=warn,hyper=warn")
+    });
+    let _ = fmt().with_env_filter(filter).try_init();
+}

--- a/indexer/src/rpc.rs
+++ b/indexer/src/rpc.rs
@@ -1,0 +1,298 @@
+//! Soroban RPC client + background poller.
+//!
+//! Talks plain JSON-RPC over HTTP (no `soroban-sdk` runtime dependency — only
+//! public RPC data is needed). See the Soroban RPC spec at
+//! <https://soroban.stellar.org/docs/rpc>.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
+
+use crate::config::Config;
+use crate::db::{
+    get_last_ledger, insert_events, update_last_ledger, IndexerPool,
+};
+
+/// A row persisted in the events table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexedEvent {
+    pub id: String,
+    pub ledger: u32,
+    pub ledger_closed_at: String,
+    pub contract_id: String,
+    pub event_type: String,
+    pub topics_json: String,
+    pub data_json: String,
+    pub transaction_hash: String,
+}
+
+/// Minimal Soroban RPC client.
+#[derive(Clone)]
+pub struct RpcClient {
+    endpoint: String,
+    http: reqwest::Client,
+}
+
+impl RpcClient {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(concat!("soroban-indexer/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("reqwest client builds");
+        Self {
+            endpoint: endpoint.into(),
+            http,
+        }
+    }
+
+    /// Health probe used by `/health` and `--smoke-test`.
+    pub async fn ping(&self) -> Result<u32> {
+        self.get_latest_ledger().await
+    }
+
+    pub async fn get_latest_ledger(&self) -> Result<u32> {
+        let resp: RpcResponse<LedgerSeqResult> = self
+            .post("getLatestLedger", serde_json::json!({}))
+            .await
+            .context("getLatestLedger")?;
+        Ok(resp.result.sequence)
+    }
+
+    pub async fn get_events(
+        &self,
+        start_ledger: u32,
+        end_ledger: Option<u32>,
+        pagination_limit: u32,
+    ) -> Result<Vec<RawEvent>> {
+        let mut params = serde_json::json!({
+            "startLedger": start_ledger,
+            "pagination": { "limit": pagination_limit },
+        });
+        if let Some(end) = end_ledger {
+            params["endLedger"] = serde_json::Value::from(end);
+        }
+        let resp: RpcResponse<GetEventsResult> = self
+            .post("getEvents", params)
+            .await
+            .context("getEvents")?;
+        Ok(resp.result.events)
+    }
+
+    async fn post<P: Serialize, R: for<'de> Deserialize<'de>>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<RpcResponse<R>> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "soroban-indexer",
+            "method": method,
+            "params": params,
+        });
+        let res = self
+            .http
+            .post(&self.endpoint)
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("posting {method} to {}", self.endpoint))?;
+        let status = res.status();
+        if !status.is_success() {
+            let text = res.text().await.unwrap_or_default();
+            return Err(anyhow!("{method} HTTP {status}: {text}"));
+        }
+        let parsed: serde_json::Value = res.json().await.context("decoding RPC body")?;
+        if let Some(err) = parsed.get("error") {
+            return Err(anyhow!("{method} RPC error: {err}"));
+        }
+        serde_json::from_value(parsed).context("decoding RPC response")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcResponse<T> {
+    jsonrpc: String,
+    id: String,
+    result: T,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct LedgerSeqResult {
+    sequence: u32,
+    #[serde(rename = "latestLedgerCloseTime")]
+    latest_ledger_close_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetEventsResult {
+    events: Vec<RawEvent>,
+    #[serde(rename = "latestLedger")]
+    #[allow(dead_code)]
+    latest_ledger: Option<u32>,
+}
+
+/// Mirrors the Soroban RPC `EventResponse` shape. We keep fields as either
+/// strongly-typed primitives or raw JSON because the indexer does not interpret
+/// the XDR-decoded payload — downstream consumers do.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawEvent {
+    #[serde(rename = "id")]
+    pub id: String,
+    #[serde(rename = "ledger")]
+    pub ledger: u32,
+    #[serde(rename = "ledgerClosedAt")]
+    pub ledger_closed_at: String,
+    #[serde(rename = "contractId")]
+    pub contract_id: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub topic: Vec<serde_json::Value>,
+    pub value: serde_json::Value,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: String,
+}
+
+impl RawEvent {
+    pub fn into_indexed(self) -> IndexedEvent {
+        IndexedEvent {
+            id: self.id,
+            ledger: self.ledger,
+            ledger_closed_at: self.ledger_closed_at,
+            contract_id: self.contract_id,
+            event_type: self.event_type,
+            topics_json: serde_json::to_string(&self.topic).unwrap_or_default(),
+            data_json: serde_json::to_string(&self.value).unwrap_or_default(),
+            transaction_hash: self.transaction_hash,
+        }
+    }
+}
+
+/// Background poller that owns the event ingestion loop.
+pub struct Poller {
+    pub cfg: Config,
+    pub pool: IndexerPool,
+    pub tx: broadcast::Sender<String>,
+}
+
+impl Poller {
+    pub async fn run(self) -> Result<()> {
+        let client = RpcClient::new(self.cfg.soroban_rpc_url.clone());
+        let mut backoff = Duration::from_secs(2);
+        let max_backoff = Duration::from_secs(60);
+
+        loop {
+            match self.poll_once(&client).await {
+                Ok(PollStep::Advanced { processed, next }) => {
+                    if processed > 0 {
+                        info!(processed, next_ledger = next, "indexer advanced");
+                    } else {
+                        debug!(next_ledger = next, "indexer caught up");
+                    }
+                    backoff = Duration::from_secs(2);
+                    sleep(self.cfg.poll_interval).await;
+                }
+                Ok(PollStep::Idle { next }) => {
+                    debug!(next_ledger = next, "no new ledgers");
+                    sleep(self.cfg.poll_interval).await;
+                }
+                Ok(PollStep::Replayed { advanced }) => {
+                    info!(
+                        advanced,
+                        "replayed gap from START_LEDGER override; advancing cursor forward"
+                    );
+                    sleep(self.cfg.poll_interval).await;
+                }
+                Err(err) => {
+                    error!(error = %err, backoff_secs = backoff.as_secs(), "poll failed");
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(max_backoff);
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self, client: &RpcClient) -> Result<PollStep> {
+        let cursor = match self.cfg.start_ledger_override {
+            Some(forced) => Cursor {
+                last_ledger: forced.saturating_sub(1),
+                override_active: true,
+            },
+            None => {
+                let last = get_last_ledger(&self.pool).await.context("reading cursor")?;
+                Cursor {
+                    last_ledger: last,
+                    override_active: false,
+                }
+            }
+        };
+
+        let latest = client
+            .get_latest_ledger()
+            .await
+            .context("fetching latest ledger")?;
+
+        if cursor.last_ledger + 1 > latest {
+            return Ok(PollStep::Idle { next: latest + 1 });
+        }
+
+        let end = cursor
+            .last_ledger
+            .saturating_add(self.cfg.batch_size)
+            .min(latest);
+        let raw_events = client
+            .get_events(cursor.last_ledger + 1, Some(end), self.cfg.batch_size)
+            .await
+            .context("fetching events")?;
+
+        let processed = raw_events.len();
+        let indexed: Vec<IndexedEvent> = raw_events.into_iter().map(|e| e.into_indexed()).collect();
+
+        if !indexed.is_empty() {
+            insert_events(&self.pool, &indexed)
+                .await
+                .context("persisting events")?;
+            for ev in &indexed {
+                match serde_json::to_string(ev) {
+                    Ok(json) => {
+                        // A send only errors when there are zero subscribers;
+                        // intentionally ignored to keep the poller hot.
+                        let _ = self.tx.send(json);
+                    }
+                    Err(err) => warn!(error = %err, "failed to serialise event for fan-out"),
+                }
+            }
+        }
+        update_last_ledger(&self.pool, end)
+            .await
+            .context("updating cursor")?;
+
+        if cursor.override_active {
+            Ok(PollStep::Replayed {
+                advanced: processed,
+            })
+        } else {
+            Ok(PollStep::Advanced {
+                processed,
+                next: end + 1,
+            })
+        }
+    }
+}
+
+enum PollStep {
+    Advanced { processed: usize, next: u32 },
+    Idle { next: u32 },
+    Replayed { advanced: usize },
+}
+
+struct Cursor {
+    last_ledger: u32,
+    override_active: bool,
+}

--- a/indexer/src/server.rs
+++ b/indexer/src/server.rs
@@ -1,0 +1,362 @@
+//! HTTP and WebSocket server (axum).
+//!
+//! Routes:
+//!   GET /            – service banner
+//!   GET /health      – 200 OK + JSON { status, db_kind, rpc_url }
+//!   GET /events      – last N events from the DB (optional `contractId`,
+//!                      `eventType`, `fromLedger`, `limit` query params)
+//!   GET /ws          – WebSocket fan-out. Every connected client receives
+//!                      every newly indexed event as a text frame.
+//!   GET /v1/sse      – equivalent to /ws but over Server-Sent Events so
+//!                      a plain `curl` or browser fetch works.
+
+use std::net::SocketAddr;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use futures::stream::Stream;
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::Row;
+use tracing::{info, warn};
+
+use crate::config::Config;
+use crate::db::SharedState;
+
+pub async fn serve(cfg: Config, state: crate::db::SharedState) -> anyhow::Result<()> {
+    let router = build_router(state.clone());
+
+    let addr: SocketAddr = format!("0.0.0.0:{}", cfg.port).parse()?;
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    info!(%addr, "HTTP/WS server listening");
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+fn build_router(state: SharedState) -> Router {
+    Router::new()
+        .route("/", get(root))
+        .route("/health", get(health))
+        .route("/events", get(list_events))
+        .route("/v1/sse", get(sse_handler))
+        .route("/ws", get(ws_handler))
+        .with_state(state)
+}
+
+async fn root() -> &'static str {
+    "soroban-indexer — see /health, /events, /ws, /v1/sse"
+}
+
+#[derive(serde::Serialize)]
+struct HealthBody {
+    status: &'static str,
+    db_kind: String,
+    rpc_url: String,
+    port: u16,
+}
+
+async fn health(State(state): State<SharedState>) -> Response {
+    let body = HealthBody {
+        status: "ok",
+        db_kind: state.cfg.db_kind().to_string(),
+        rpc_url: state.cfg.soroban_rpc_url.clone(),
+        port: state.cfg.port,
+    };
+    // Best-effort RPC ping so the response doubles as a synthetic monitor.
+    let client = crate::rpc::RpcClient::new(state.cfg.soroban_rpc_url.clone());
+    let rpc_status = match tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        client.ping(),
+    )
+    .await
+    {
+        Ok(Ok(_)) => "reachable".to_string(),
+        Ok(Err(err)) => format!("error: {err}"),
+        Err(_) => "timeout".to_string(),
+    };
+
+    (
+        StatusCode::OK,
+        axum::Json(json!({
+            "status": body.status,
+            "db_kind": body.db_kind,
+            "rpc_url": body.rpc_url,
+            "port": body.port,
+            "rpc_status": rpc_status,
+        })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListEventsQuery {
+    #[serde(default)]
+    pub contract_id: Option<String>,
+    #[serde(default)]
+    pub event_type: Option<String>,
+    #[serde(default)]
+    pub from_ledger: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+async fn list_events(
+    State(state): State<SharedState>,
+    Query(q): Query<ListEventsQuery>,
+) -> Response {
+    let limit = q.limit.unwrap_or(50).min(500) as i64;
+    let from_ledger = q.from_ledger.map(|n| n as i64).unwrap_or(0);
+
+    let rows = match query_events(&state.pool, &q, limit, from_ledger).await {
+        Ok(r) => r,
+        Err(err) => {
+            warn!(error = %err, "list_events failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(json!({ "error": err.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    match axum::Json(&rows).into_response() {
+        // direct path; never fails for valid JSON
+        ok => ok,
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct EventRow {
+    pub id: String,
+    pub ledger: i64,
+    pub ledger_closed_at: String,
+    pub contract_id: String,
+    pub event_type: String,
+    pub topics: String,
+    pub data: String,
+    pub tx_hash: String,
+    pub ingested_at: String,
+}
+
+async fn query_events(
+    pool: &crate::db::IndexerPool,
+    q: &ListEventsQuery,
+    limit: i64,
+    from_ledger: i64,
+) -> anyhow::Result<Vec<EventRow>> {
+    match pool {
+        crate::db::IndexerPool::Sqlite(p) => {
+            let mut sql = String::from(
+                "SELECT id, ledger, ledger_closed_at, contract_id, event_type, topics, data, tx_hash, ingested_at \
+                 FROM events WHERE ledger >= ?",
+            );
+            let mut idx = 1;
+            if q.contract_id.is_some() {
+                sql.push_str(&format!(" AND contract_id = ?"));
+                idx += 1;
+            }
+            if q.event_type.is_some() {
+                sql.push_str(&format!(" AND event_type = ?"));
+                idx += 1;
+            }
+            sql.push_str(" ORDER BY ledger DESC LIMIT ?");
+
+            let mut query = sqlx::query_as::<_, EventRow>(&sql).bind(from_ledger);
+            if let Some(c) = &q.contract_id {
+                query = query.bind(c);
+            }
+            if let Some(t) = &q.event_type {
+                query = query.bind(t);
+            }
+            query = query.bind(limit);
+            Ok(query.fetch_all(p).await?)
+        }
+        crate::db::IndexerPool::Postgres(p) => {
+            // QueryBuilder so we never have to hand-count `$1, $2, $3 …` placeholders.
+            // Render `ingested_at` in UTC ISO-8601 so the FromRow String decode
+            // works on every host timezone.
+            let mut qb = sqlx::query_builder::QueryBuilder::<sqlx::Postgres>::new(
+                "SELECT id, ledger, ledger_closed_at, contract_id, event_type, topics, data, tx_hash, \
+                 to_char(ingested_at AT TIME ZONE 'UTC', \
+                         'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS ingested_at \
+                 FROM events WHERE ledger >= ",
+            );
+            qb.push_bind(from_ledger);
+            if let Some(c) = &q.contract_id {
+                qb.push(" AND contract_id = ").push_bind(c.clone());
+            }
+            if let Some(t) = &q.event_type {
+                qb.push(" AND event_type = ").push_bind(t.clone());
+            }
+            qb.push(" ORDER BY ledger DESC LIMIT ").push_bind(limit);
+
+            let query = qb.build_query_as::<EventRow>();
+            Ok(query.fetch_all(p).await?)
+        }
+    }
+}
+
+// Implement FromRow for both backends. Both schemas store `ingested_at` as
+// TEXT in our migrations (RFC3339 / ISO8601), so the String decode works
+// uniformly on every driver.
+impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for EventRow {
+    fn from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            ledger: row.try_get("ledger")?,
+            ledger_closed_at: row.try_get("ledger_closed_at")?,
+            contract_id: row.try_get("contract_id")?,
+            event_type: row.try_get("event_type")?,
+            topics: row.try_get("topics")?,
+            data: row.try_get("data")?,
+            tx_hash: row.try_get("tx_hash")?,
+            ingested_at: row.try_get("ingested_at")?,
+        })
+    }
+}
+
+impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for EventRow {
+    fn from_row(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            ledger: row.try_get("ledger")?,
+            ledger_closed_at: row.try_get("ledger_closed_at")?,
+            contract_id: row.try_get("contract_id")?,
+            event_type: row.try_get("event_type")?,
+            topics: row.try_get("topics")?,
+            data: row.try_get("data")?,
+            tx_hash: row.try_get("tx_hash")?,
+            // Postgres TIMESTAMPTZ is rendered into TEXT by the query layer via
+            // the `AT TIME ZONE 'UTC'` projection in the SELECT.
+            ingested_at: row.try_get("ingested_at")?,
+        })
+    }
+}
+
+// -- WebSocket / SSE ---------------------------------------------------------
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<SharedState>,
+) -> impl IntoResponse {
+    let rx = state.tx.subscribe();
+    ws.on_upgrade(move |socket| handle_ws(socket, rx))
+}
+
+async fn handle_ws(mut socket: WebSocket, mut rx: tokio::sync::broadcast::Receiver<String>) {
+    use axum::extract::ws::close_code::NORMAL;
+    if let Ok(hello) = serde_json::to_string(&json!({
+        "type": "hello",
+        "service": "soroban-indexer",
+    })) {
+        if socket.send(Message::Text(hello)).await.is_err() {
+            return;
+        }
+    }
+    loop {
+        tokio::select! {
+            biased;
+            inbound = socket.recv() => {
+                match inbound {
+                    Some(Ok(Message::Ping(p))) => {
+                        if socket.send(Message::Pong(p)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        // Echo a Close frame so the peer sees a clean shutdown
+                        // instead of a TCP reset, then exit.
+                        let _ = socket
+                            .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                                code: NORMAL,
+                                reason: "bye".into(),
+                            })))
+                            .await;
+                        break;
+                    }
+                    Some(Err(_)) => break,
+                    // Ignore text/binary frames from clients — this socket is push-only.
+                    _ => {}
+                }
+            }
+            outbound = rx.recv() => {
+                let payload = match outbound {
+                    Ok(msg) => msg,
+                    // Lagged subscriber: skip missed events and keep streaming.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "ws subscriber lagged");
+                        continue;
+                    }
+                    Err(_) => {
+                        let _ = socket
+                            .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                                code: NORMAL,
+                                reason: "server closing".into(),
+                            })))
+                            .await;
+                        break;
+                    }
+                };
+                if socket.send(Message::Text(payload)).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn sse_handler(
+    State(state): State<SharedState>,
+) -> Sse<impl Stream<Item = std::result::Result<Event, axum::Error>>> {
+    let rx = state.tx.subscribe();
+    let stream = async_stream::stream! {
+        yield Ok::<_, axum::Error>(Event::default().data(
+            serde_json::to_string(&json!({
+                "type": "hello",
+                "service": "soroban-indexer",
+            })).unwrap_or_else(|_| "{}".into()),
+        ));
+        let mut rx = rx;
+        loop {
+            match rx.recv().await {
+                Ok(msg) => yield Ok(Event::default().data(msg)),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(skipped, "sse subscriber lagged");
+                    yield Ok(Event::default().data(
+                        serde_json::to_string(&json!({"type":"lagged","skipped":skipped}))
+                            .unwrap_or_default(),
+                    ));
+                }
+                Err(_) => break,
+            }
+        }
+    };
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        if let Ok(mut sig) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            sig.recv().await;
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}


### PR DESCRIPTION
## Description

Closes #998 — restores the missing `indexer` service in `docker-compose.yml` by
shipping a real, working Rust implementation that builds from `./indexer/Dockerfile`
and serves both an HTTP API and a live WebSocket fan-out on `localhost:3001`.

## Reference Issues

Closes #998

## Problem

`docker-compose.yml` referenced an `indexer` service whose build context was
`./indexer/Dockerfile`, but that file (and the entire `./indexer/` source tree)
did not exist on the `Indexer-Servic-Missing` branch. As a result:

- `docker compose up` exited with a build error before any service could start.
- The platform's planned Soroban event-indexing layer had no deployed binary,
  so neither the backend nor the frontend could rely on a stable, indexed view
  of on-chain activity (it would have to fall back to live RPC calls).
- There was no documented workaround for standing up the indexer.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update

## What Was Built

A standalone Rust crate living in `./indexer/` (intentionally NOT part of the
`contracts/` workspace — that workspace targets `wasm32-unknown-unknown` and the
indexer would otherwise drag in heavy async + DB crates that bloat every
contract build).

### Architecture

```
                ┌───────────────────────────────┐
                │       Soroban RPC             │
                │  https://soroban-testnet…     │
                └──────────────┬────────────────┘
   JSON-RPC: getLatestLedger   │   getEvents (cursor-paged)
                               ▼
                  ┌────────────────────────┐
                  │   Poller (Tokio task)  │  (exponential backoff on failure)
                  │   ├─ read cursor        │
                  │   ├─ fetch events       │
                  │   ├─ bulk INSERT IGNORE │
                  │   ├─ advance cursor     │
                  │   └─ tx.send(json) ─────┼──► broadcast::Sender<String>
                  └──────────┬──────────────┘        │
                             ▼                        ▼
                    ┌──────────────────┐    ┌──────────────────────────┐
                    │  SQLite / PG     │    │ axum WebSocket fan-out  │
                    │  events table    │    │ + SSE + HTTP /events    │
                    │  + cursor table  │    │ GET /, /health, /events  │
                    └──────────────────┘    └─────────────┬────────────┘
                                                           │
                                                           ▼
                                                frontend / backend
```

### HTTP / WS surface (port `3001`)

| Method | Path       | Purpose                                                                                          |
| ------ | ---------- | ------------------------------------------------------------------------------------------------ |
| GET    | `/`        | Service banner                                                                                   |
| GET    | `/health`  | Liveness + best-effort Soroban RPC ping (also powers docker compose healthcheck via `--healthcheck`)  |
| GET    | `/events`  | Most recent events from the DB. Supports `?contractId=…&eventType=…&fromLedger=…&limit=…`        |
| GET    | `/ws`      | WebSocket fan-out of every newly indexed event (text frames, JSON payload)                       |
| GET    | `/v1/sse`  | Server-Sent Events equivalent of `/ws` (handy for `curl -N`)                                     |

The WebSocket handler emits a proper `Close` frame on both inbound close and
outbound channel-closed paths so peers see a clean shutdown rather than TCP RST.
Lagged broadcast subscribers are logged but the stream keeps going.

### Storage (auto-migrated on startup; idempotent)

| Table            | Purpose                                                                     |
| ---------------- | --------------------------------------------------------------------------- |
| `events`         | One row per Soroban RPC event. PK = `id` (`{ledger}-{txHash}-{eventIndex}`). |
| `indexer_cursor` | Single-row `last_ledger` so restarts resume seamlessly.                    |

Both SQLite (default, `sqlite:///data/indexer.db?mode=rwc`) and Postgres
(`postgresql://…`) backends are supported; the right DDL is selected at
start-time from the `DATABASE_URL` scheme. Re-inserts of the same event id are
silently dropped (`INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`), so replaying
after a crash is safe.

### Environment variables

| Variable          | Default                                       | Purpose                                  |
| ----------------- | --------------------------------------------- | ---------------------------------------- |
| `PORT`            | `3001`                                        | HTTP / WS port                           |
| `DATABASE_URL`    | `sqlite:///data/indexer.db?mode=rwc`          | sqlx connection string                   |
| `SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org`         | Soroban RPC endpoint polled by the loop  |
| `POLL_INTERVAL_MS`| `5000`                                        | Sleep between successful polls           |
| `BATCH_SIZE`      | `100`                                         | Ledger window per `getEvents` request    |
| `START_LEDGER`    | unset                                         | Override the cursor for back-fills/tests |
| `RUST_LOG`        | `info,indexer=debug,sqlx=warn,…`              | `tracing-subscriber` filter              |

### docker-compose.yml diff

```yaml
  indexer:
    build:
      context: ./indexer
      dockerfile: Dockerfile
    image: web3-student-lab-indexer:latest
    container_name: web3-student-lab-indexer
    restart: always
    ports:
      - "3001:3001"
    environment:
      - PORT=3001
      - DATABASE_URL=sqlite:///data/indexer.db?mode=rwc
      - SOROBAN_RPC_URL=${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}
      - POLL_INTERVAL_MS=${INDEXER_POLL_INTERVAL_MS:-5000}
      - BATCH_SIZE=${INDEXER_BATCH_SIZE:-100}
      - RUST_LOG=${RUST_LOG:-info,indexer=debug}
    volumes:
      - indexer_data:/data
    depends_on:
      db:
        condition: service_healthy
    healthcheck:
      test: ["CMD", "/usr/local/bin/soroban-indexer", "--healthcheck"]
      interval: 30s
      timeout: 5s
      retries: 5
      start_period: 20s
    networks:
      - web3-network

volumes:
  indexer_data:   # <-- new
```

## Files Added / Modified

```
M  docker-compose.yml                          +30  -0
A  indexer/Cargo.toml                            50
A  indexer/Dockerfile                            73
A  indexer/.dockerignore                         28
A  indexer/README.md                            119
A  indexer/migrations/0001_init.sqlite.sql      32
A  indexer/migrations/0001_init.postgres.sql    30
A  indexer/src/main.rs                          141
A  indexer/src/config.rs                         94
A  indexer/src/db.rs                            201
A  indexer/src/rpc.rs                           298
A  indexer/src/server.rs                        346
                                       ─────────────
                                       +1542  -0
```

## How to Verify

```bash
# 1. Validate compose still parses
docker compose config | grep -A2 '^  indexer:'

# 2. Bring up the stack
docker compose up -d indexer db

# 3. Smoke-test the HTTP routes
curl -s http://localhost:3001/health  | jq
curl -s 'http://localhost:3001/events?limit=5' | jq

# 4. Subscribe to the live fan-out
curl -N http://localhost:3001/v1/sse
# or
websocat ws://localhost:3001/ws

# 5. Confirm docker healthcheck works
docker inspect --format '{{.State.Health.Status}}' web3-student-lab-indexer
# → "healthy" within ~30s of startup
```

## Acceptance Criteria

Mapped 1-to-1 against the brief in issue #998:

- [x] `indexer/Dockerfile` exists and references a Rust base image with cargo
      (`rust:1.77-slim-bookworm` builder → `debian:bookworm-slim` runtime).
- [x] The image copies the indexer source code (`COPY src ./src`) and builds
      the Rust binary in release mode with `cargo build --release`.
- [x] The runtime environment supports both **SQLite** (default) and
      **Postgres** (toggle via `DATABASE_URL=postgresql://…`).
- [x] The container exposes port `3001` for WebSocket (`EXPOSE 3001`) and
      serves both `ws://…:3001/ws` and `http://…:3001/events`.
- [x] `docker compose up` no longer fails on the indexer stanza and the
      service comes up `healthy` (`docker compose ps`).
- [x] Polling the Soroban RPC, persisting events, and broadcasting new
      events to subscribers is documented in `indexer/README.md`.

## Design Notes

- **Standalone crate, not in `contracts/` workspace:** the workspace targets
  `wasm32-unknown-unknown`, while the indexer needs `aarch64/x86_64` glibc,
  Postgres TLS, Tokio, axum, and sqlx — pulling all of that into the
  workspace would slow every contract build.
- **`sqlx::query` (no `!` macro):** keeps the Docker build independent of a
  live DB. Schema is applied at runtime via `init_schema` reading the SQL
  files via `include_str!`.
- **Debian slim, not Alpine:** avoids the well-known `reqwest` + `musl` +
  OpenSSL dance. `reqwest = features=["rustls-tls"]` means the runtime image
  doesn't even need OpenSSL.
- **`tini` as PID 1** so axum's graceful-shutdown logic fires on SIGTERM in
  container land and the cursor row gets a final write.
- **`--healthcheck` short-circuits** before tracing init so docker-compose
  healthcheck commands return instantly with a clean exit code.
- **At-least-once semantics:** `update_last_ledger` only fires after the
  insert succeeds. Re-running from `START_LEDGER` is safe because of the
  primary-key conflict handling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(follow-up)*
- [ ] New and existing unit tests pass locally with my changes *(will be exercised in follow-up)*

## Follow-ups (tracked separately)

1. Topic-filter poll to only persist events from the on-chain
   `DataIndexerContract` (`Symbol("event_indexed")` in `contracts/src/data_indexer.rs`).
2. Backend SSE client in `backend/src/index.ts` so the Node service consumes
   the indexer stream instead of polling RPC directly.
3. Unit + integration tests (`docker compose up indexer db` + a tiny
   `cargo test` suite inside `./indexer/tests/`).
