### PR TITLE
fix(ci/backend): mandatory migration verification, curriculum validation, storage integrity, typed blockchain errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build
         working-directory: ./backend
         run: npm run build
+      - name: Validate curriculum content
+        working-directory: ./backend
+        run: npm run validate:curriculum
       - name: Create shadow database
         # Rollback verification and drift detection (below) both need a
         # scratch "shadow" database distinct from test_db, on the same

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,42 @@ jobs:
       - name: Build
         working-directory: ./backend
         run: npm run build
+      - name: Create shadow database
+        # Rollback verification and drift detection (below) both need a
+        # scratch "shadow" database distinct from test_db, on the same
+        # Postgres service.
+        run: |
+          PGPASSWORD=test psql -h localhost -U test -d test_db \
+            -c "CREATE DATABASE shadow_db;"
       - name: Prisma Generate & Migrate
         working-directory: ./backend
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db
         run: |
           npx prisma generate
-          npx prisma migrate deploy || true
+          npx prisma migrate deploy
       - name: Test Migration Rollbacks
         working-directory: ./backend
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db
+          SHADOW_DATABASE_URL: postgresql://test:test@localhost:5432/shadow_db
         run: npm run test:migrations
+      - name: Detect schema/migration drift
+        # Reporting only, not yet a merge gate: schema.prisma has
+        # substantial pre-existing drift from the migration history
+        # (see PR description) that a single PR shouldn't be blocked on
+        # resolving. Once that backlog is cleared with a dedicated
+        # migration, remove `continue-on-error` so future drift fails CI.
+        working-directory: ./backend
+        continue-on-error: true
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test_db
+          SHADOW_DATABASE_URL: postgresql://test:test@localhost:5432/shadow_db
+        run: |
+          npx prisma migrate diff \
+            --from-config-datasource \
+            --to-schema prisma/schema.prisma \
+            --exit-code
       - name: Run tests
         working-directory: ./backend
         env:
@@ -71,6 +95,10 @@ jobs:
           GITHUB_CLIENT_SECRET: test-github-client-secret
           GITHUB_REDIRECT_URI: http://localhost:8080/api/v1/oauth/github/callback
           FRONTEND_URL: http://localhost:3000
+        # Pre-existing test failures unrelated to migrations (12 failing
+        # suites as of this PR) — out of scope here; `|| true` intentionally
+        # left in place rather than silently making this bypass narrower
+        # without fixing what it's bypassing.
         run: npm run test:coverage || true
 
   frontend:

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "test": "jest --runInBand --forceExit",
     "test:coverage": "jest --coverage --runInBand --forceExit",
-    "test:migrations": "echo 'No migrations tests'",
+    "test:migrations": "bash scripts/test-migration-rollback.sh",
 
     "bench": "tsx benchmarks/runBenchmarks.ts",
     "collaboration": "tsx src/collaborationServer.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "test": "jest --runInBand --forceExit",
     "test:coverage": "jest --coverage --runInBand --forceExit",
     "test:migrations": "bash scripts/test-migration-rollback.sh",
+    "validate:curriculum": "tsx scripts/validate-curriculum.ts",
 
     "bench": "tsx benchmarks/runBenchmarks.ts",
     "collaboration": "tsx src/collaborationServer.ts",

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
     url: connectionString,
+    // Required for `prisma migrate diff --from-migrations`/rollback
+    // verification (scripts/test-migration-rollback.sh). Falls back to
+    // undefined (Prisma's own default behavior) when unset, so this is a
+    // no-op for anyone not running the rollback check.
+    shadowDatabaseUrl: process.env.SHADOW_DATABASE_URL,
   },
   migrations: {
     path: 'prisma/migrations',

--- a/backend/prisma/migrations/20260504165248_init/migration.sql
+++ b/backend/prisma/migrations/20260504165248_init/migration.sql
@@ -7,8 +7,8 @@ CREATE TABLE "students" (
     "firstName" TEXT NOT NULL,
     "lastName" TEXT NOT NULL,
     "walletAddress" TEXT,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
 );
 
 -- CreateTable
@@ -18,8 +18,8 @@ CREATE TABLE "courses" (
     "description" TEXT,
     "instructor" TEXT NOT NULL,
     "credits" INTEGER NOT NULL DEFAULT 3,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
 );
 
 -- CreateTable
@@ -28,7 +28,7 @@ CREATE TABLE "certificates" (
     "studentId" TEXT NOT NULL,
     "courseId" TEXT NOT NULL,
     "tokenId" TEXT NOT NULL,
-    "issuedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "certificateHash" TEXT,
     "status" TEXT NOT NULL DEFAULT 'pending',
     "did" TEXT,
@@ -36,13 +36,13 @@ CREATE TABLE "certificates" (
     "contractAddress" TEXT,
     "network" TEXT,
     "grade" TEXT,
-    "revokedAt" DATETIME,
+    "revokedAt" TIMESTAMP(3),
     "revocationReason" TEXT,
     "revokedBy" TEXT,
     "previousVersionId" TEXT,
     "transactionHash" TEXT,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "certificates_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "certificates_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "courses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
@@ -52,7 +52,7 @@ CREATE TABLE "enrollments" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "studentId" TEXT NOT NULL,
     "courseId" TEXT NOT NULL,
-    "enrolledAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "enrolledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "status" TEXT NOT NULL DEFAULT 'active',
     CONSTRAINT "enrollments_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "enrollments_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "courses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
@@ -65,8 +65,8 @@ CREATE TABLE "feedback" (
     "courseId" TEXT NOT NULL,
     "rating" INTEGER NOT NULL,
     "review" TEXT,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "feedback_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "feedback_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "courses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
@@ -80,10 +80,10 @@ CREATE TABLE "learning_progress" (
     "currentModuleId" TEXT,
     "percentage" INTEGER NOT NULL DEFAULT 0,
     "status" TEXT NOT NULL DEFAULT 'not_started',
-    "lastAccessedAt" DATETIME,
-    "completedAt" DATETIME,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL,
+    "lastAccessedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "learning_progress_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "learning_progress_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "courses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
@@ -99,7 +99,7 @@ CREATE TABLE "audit_logs" (
     "details" JSONB,
     "ipAddress" TEXT,
     "userAgent" TEXT,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- CreateTable
@@ -107,9 +107,9 @@ CREATE TABLE "auth_nonces" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "walletAddress" TEXT NOT NULL,
     "nonce" TEXT NOT NULL,
-    "expiresAt" DATETIME NOT NULL,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
 );
 
 -- CreateTable
@@ -120,7 +120,7 @@ CREATE TABLE "analytics_data" (
     "region" TEXT,
     "value" REAL,
     "category" TEXT,
-    "timestamp" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "metadata" JSONB
 );
 
@@ -134,10 +134,10 @@ CREATE TABLE "canvases" (
     "data" JSONB,
     "isPublic" BOOLEAN NOT NULL DEFAULT false,
     "collaborators" JSONB NOT NULL,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
     "lastModifiedBy" TEXT,
-    "lastModifiedAt" DATETIME,
+    "lastModifiedAt" TIMESTAMP(3),
     CONSTRAINT "canvases_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/backend/prisma/migrations/20260626151500_notification_preferences/migration.sql
+++ b/backend/prisma/migrations/20260626151500_notification_preferences/migration.sql
@@ -13,8 +13,8 @@ CREATE TABLE "notification_preferences" (
     "frequency" TEXT NOT NULL DEFAULT 'immediate',
     "quietHoursStart" TEXT,
     "quietHoursEnd" TEXT,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
 );
 
 -- CreateIndex

--- a/backend/scripts/test-migration-rollback.sh
+++ b/backend/scripts/test-migration-rollback.sh
@@ -49,13 +49,13 @@ cat down.sql
 
 # Execute the DOWN migration
 echo "Executing down migration..."
-npx prisma db execute --file down.sql --schema prisma/schema.prisma
+npx prisma db execute --file down.sql
 
 # Verify the database schema matches state N-1
 echo "Verifying database schema integrity post-rollback..."
 # diff DB vs N-1 migrations. Exit code 0 means no differences (schema matches perfectly).
 npx prisma migrate diff \
-  --from-schema-datasource prisma/schema.prisma \
+  --from-config-datasource \
   --to-migrations prisma/migrations_prev \
   --exit-code
 

--- a/backend/scripts/validate-curriculum.ts
+++ b/backend/scripts/validate-curriculum.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+/**
+ * Curriculum content validator (#909).
+ *
+ * Validates backend/src/routes/learning/curriculum.data.ts (the
+ * authoritative course/module/lesson structure served by the learning
+ * API) the same way application data would be validated: required
+ * fields, unique identifiers, and correct navigation ordering. Exits
+ * non-zero with the specific course/module/lesson identifier and field
+ * that failed, so a CI failure or local run points directly at the
+ * problem instead of just saying "curriculum is invalid".
+ *
+ * Run locally: `npx tsx scripts/validate-curriculum.ts` (see
+ * package.json's `validate:curriculum` script).
+ */
+import { curriculumByCourseId } from '../src/routes/learning/curriculum.data.js';
+import type { Module, Lesson } from '../src/routes/learning/types.js';
+
+const ALLOWED_DIFFICULTIES = new Set(['beginner', 'intermediate', 'advanced']);
+
+interface ValidationIssue {
+  location: string;
+  message: string;
+}
+
+const issues: ValidationIssue[] = [];
+
+function fail(location: string, message: string): void {
+  issues.push({ location, message });
+}
+
+function requireNonEmptyString(location: string, field: string, value: unknown): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    fail(location, `field '${field}' must be a non-empty string, got ${JSON.stringify(value)}`);
+  }
+}
+
+function requireFiniteNumber(location: string, field: string, value: unknown): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(location, `field '${field}' must be a finite number, got ${JSON.stringify(value)}`);
+  }
+}
+
+/**
+ * Checks that `order` values form a contiguous 1..N sequence with no
+ * duplicates and no gaps — anything else means navigation (next/previous,
+ * progress percentage math) will behave incorrectly.
+ */
+function validateOrdering(location: string, items: Array<{ id: string; order: number }>): void {
+  const seenOrders = new Map<number, string>();
+  for (const item of items) {
+    const existing = seenOrders.get(item.order);
+    if (existing) {
+      fail(location, `duplicate order=${item.order} on '${item.id}' and '${existing}'`);
+    } else {
+      seenOrders.set(item.order, item.id);
+    }
+  }
+
+  const sortedOrders = [...seenOrders.keys()].sort((a, b) => a - b);
+  for (let i = 0; i < sortedOrders.length; i++) {
+    const expected = i + 1;
+    if (sortedOrders[i] !== expected) {
+      fail(
+        location,
+        `order sequence has a gap or does not start at 1 — expected ${expected}, found ${sortedOrders[i]} ` +
+          `(full sequence: [${sortedOrders.join(', ')}])`
+      );
+      break;
+    }
+  }
+}
+
+function validateLesson(location: string, lesson: Lesson, allLessonIds: Map<string, string>): void {
+  requireNonEmptyString(location, 'id', lesson.id);
+  requireNonEmptyString(location, 'title', lesson.title);
+  requireNonEmptyString(location, 'description', lesson.description);
+  requireFiniteNumber(location, 'order', lesson.order);
+
+  if (!ALLOWED_DIFFICULTIES.has(lesson.difficulty)) {
+    fail(
+      location,
+      `field 'difficulty' must be one of ${[...ALLOWED_DIFFICULTIES].join('/')}, got ${JSON.stringify(lesson.difficulty)}`
+    );
+  }
+
+  if (lesson.id) {
+    const existing = allLessonIds.get(lesson.id);
+    if (existing) {
+      fail(location, `duplicate lesson id '${lesson.id}' (also used at ${existing})`);
+    } else {
+      allLessonIds.set(lesson.id, location);
+    }
+  }
+}
+
+function validateModule(
+  courseId: string,
+  module: Module,
+  allModuleIds: Map<string, string>,
+  allLessonIds: Map<string, string>
+): void {
+  const location = `course '${courseId}' > module '${module.id ?? '<missing id>'}'`;
+
+  requireNonEmptyString(location, 'id', module.id);
+  requireNonEmptyString(location, 'title', module.title);
+  requireNonEmptyString(location, 'description', module.description);
+  requireFiniteNumber(location, 'order', module.order);
+
+  if (module.id) {
+    const existing = allModuleIds.get(module.id);
+    if (existing) {
+      fail(location, `duplicate module id '${module.id}' (also used at ${existing})`);
+    } else {
+      allModuleIds.set(module.id, location);
+    }
+  }
+
+  if (!Array.isArray(module.lessons) || module.lessons.length === 0) {
+    fail(location, `must have at least one lesson`);
+    return;
+  }
+
+  for (const lesson of module.lessons) {
+    validateLesson(`${location} > lesson '${lesson.id ?? '<missing id>'}'`, lesson, allLessonIds);
+  }
+
+  validateOrdering(`${location} (lesson ordering)`, module.lessons);
+}
+
+function validateCurriculum(): void {
+  const allModuleIds = new Map<string, string>();
+  const allLessonIds = new Map<string, string>();
+
+  const courseIds = Object.keys(curriculumByCourseId);
+  if (courseIds.length === 0) {
+    fail('curriculumByCourseId', 'must define at least one course');
+  }
+
+  for (const courseId of courseIds) {
+    const modules = curriculumByCourseId[courseId];
+    const location = `course '${courseId}'`;
+
+    if (!Array.isArray(modules) || modules.length === 0) {
+      fail(location, 'must have at least one module');
+      continue;
+    }
+
+    for (const module of modules) {
+      validateModule(courseId, module, allModuleIds, allLessonIds);
+    }
+
+    validateOrdering(`${location} (module ordering)`, modules);
+  }
+}
+
+validateCurriculum();
+
+if (issues.length > 0) {
+  console.error(`\n✗ Curriculum validation failed with ${issues.length} issue(s):\n`);
+  for (const issue of issues) {
+    console.error(`  [${issue.location}] ${issue.message}`);
+  }
+  console.error('');
+  process.exit(1);
+}
+
+console.log('✓ Curriculum validation passed.');

--- a/backend/src/blockchain/CertificateBlockchainService.ts
+++ b/backend/src/blockchain/CertificateBlockchainService.ts
@@ -2,6 +2,41 @@ import { NetworkError } from '@stellar/stellar-sdk';
 import logger from '../utils/logger.js';
 import { cbManager } from '../lib/circuit-breaker/CircuitBreakerManager.js';
 
+export type BlockchainMode = 'simulation' | 'live';
+
+/**
+ * Thrown when a live-mode operation is attempted but no real Soroban
+ * client is configured (#910). Live-mode Soroban RPC integration requires
+ * a deployed certificate contract — none exists in this repository yet
+ * (no contracts/certificate_* Soroban package defines a mint/verify/
+ * getOwner/revoke interface to call). This is distinct from a
+ * NetworkError: it means "not wired up", not "the network is down".
+ */
+export class BlockchainNotConfiguredError extends Error {
+  readonly code = 'BLOCKCHAIN_NOT_CONFIGURED' as const;
+
+  constructor(operation: string) {
+    super(
+      `Cannot perform '${operation}': live Soroban integration is not configured. ` +
+        `Set BLOCKCHAIN_SIMULATION_MODE=true (or leave CERTIFICATE_CONTRACT_ID unset) to use ` +
+        `simulation mode, or deploy a certificate contract and wire up a real Soroban RPC client.`
+    );
+    this.name = 'BlockchainNotConfiguredError';
+  }
+}
+
+/**
+ * Re-thrown for genuine Soroban RPC/network failures, so callers can
+ * distinguish "the network call itself failed" from
+ * BlockchainNotConfiguredError ("there was no real call to make").
+ * Reuses the Stellar SDK's own NetworkError type rather than inventing a
+ * parallel one.
+ */
+export function wrapAsNetworkError(operation: string, cause: unknown): NetworkError {
+  const message = `Soroban RPC call failed for '${operation}': ${(cause as Error)?.message ?? String(cause)}`;
+  return new NetworkError(message, {});
+}
+
 /**
  * Certificate Blockchain Service
  * Interfaces with Soroban/Soroban network for certificate NFTs
@@ -29,18 +64,40 @@ export class CertificateBlockchainService {
       this.initializeClient();
     }
 
-    logger.info(
-      `Blockchain service initialized in ${this.isSimulationMode ? 'simulation' : 'live'} mode`
-    );
+    logger.info(`Blockchain service initialized in ${this.getMode()} mode`, {
+      mode: this.getMode(),
+      network: this.network,
+      contractConfigured: Boolean(this.contractId),
+    });
   }
 
   /**
-   * Initializes the Soroban client
+   * Returns the service's current mode explicitly — 'simulation' or
+   * 'live' — rather than callers having to infer it from side effects
+   * (#910's "simulation mode is explicit" requirement).
+   */
+  getMode(): BlockchainMode {
+    return this.isSimulationMode ? 'simulation' : 'live';
+  }
+
+  /**
+   * Initializes the Soroban client.
+   *
+   * There is currently no deployed certificate Soroban contract in this
+   * repository for a real client to call — no contracts/certificate_*
+   * package defines the mint/verify/getOwner/revoke ABI this service
+   * would need to invoke. Rather than fabricate calls against a contract
+   * that doesn't exist, this falls back to simulation mode explicitly and
+   * logs why, so operators aren't misled into thinking live mode is
+   * active when BLOCKCHAIN_SIMULATION_MODE=false and a CERTIFICATE_CONTRACT_ID
+   * is set.
    */
   private initializeClient(): void {
-    // In production, would initialize Soroban RPC client
-    // For now, we operate in simulation mode
-    logger.warn('Blockchain client not fully implemented - using simulation mode');
+    logger.warn(
+      'Live Soroban client requested (CERTIFICATE_CONTRACT_ID set, BLOCKCHAIN_SIMULATION_MODE=false) ' +
+        'but no certificate contract integration exists yet — falling back to simulation mode. ' +
+        'Live-mode operations will throw BlockchainNotConfiguredError instead of silently succeeding.'
+    );
     this.isSimulationMode = true;
   }
 
@@ -59,11 +116,10 @@ export class CertificateBlockchainService {
           return this.simulateMint(metadata);
         }
 
-        // Production implementation would call Soroban contract
-        throw new Error('Live blockchain integration not yet implemented');
+        throw new BlockchainNotConfiguredError('mintCertificate');
       },
       (error) => {
-        logger.error('Circuit breaker fallback for mintCertificate triggered', error);
+        logger.error('Circuit breaker fallback for mintCertificate triggered', error as Error);
         return {
           success: false,
           tokenId: metadata.verification?.tokenId || 'error-token-id',
@@ -83,7 +139,7 @@ export class CertificateBlockchainService {
         if (this.isSimulationMode) {
           return this.simulateVerifyOnChain(tokenId);
         }
-        return false;
+        throw new BlockchainNotConfiguredError('verifyOnChain');
       },
       () => false // Fallback: assume not verified if service is down
     );
@@ -98,7 +154,7 @@ export class CertificateBlockchainService {
         if (this.isSimulationMode) {
           return this.simulateGetOwner(tokenId);
         }
-        return '';
+        throw new BlockchainNotConfiguredError('getOwner');
       },
       () => 'N/A (Circuit Breaker)' // Fallback owner
     );
@@ -113,7 +169,7 @@ export class CertificateBlockchainService {
         logger.info(`Simulated revocation of token ${tokenId}: ${reason}`);
         return;
       }
-      throw new Error('Live blockchain integration not yet implemented');
+      throw new BlockchainNotConfiguredError('revokeCertificate');
     });
   }
 
@@ -121,7 +177,10 @@ export class CertificateBlockchainService {
    * Gets transaction history for a token
    */
   async getTransactionHistory(tokenId: string): Promise<any[]> {
-    return [];
+    if (this.isSimulationMode) {
+      return this.simulateGetTransactionHistory(tokenId);
+    }
+    throw new BlockchainNotConfiguredError('getTransactionHistory');
   }
 
   /**
@@ -133,7 +192,7 @@ export class CertificateBlockchainService {
         if (this.isSimulationMode) {
           return this.simulateGetOnChainData(tokenId);
         }
-        return null;
+        throw new BlockchainNotConfiguredError('getCertificateData');
       },
       () => null // Fallback: no data
     );
@@ -190,6 +249,11 @@ export class CertificateBlockchainService {
   private async simulateGetOwner(tokenId: string): Promise<string> {
     await new Promise((resolve) => setTimeout(resolve, 50));
     return 'GBST4SW5DKCK3SN5EQQYQA4SDSF4NYVZ647YV6NA5PHWJ2N2UJNAPNAI';
+  }
+
+  private async simulateGetTransactionHistory(_tokenId: string): Promise<any[]> {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return [];
   }
 
   private async simulateGetOnChainData(tokenId: string): Promise<any | null> {

--- a/backend/src/services/storage/queue.ts
+++ b/backend/src/services/storage/queue.ts
@@ -31,9 +31,6 @@ const createQueue = <T>(name: string, defaultJobOptions?: JobsOptions) => {
     } as unknown as Queue<T>;
   }
 
-  const redisUrl = new URL(process.env.REDIS_URL || (() => {
-    throw new Error('REDIS_URL environment variable is required');
-  })());
   const redisUrl = new URL(process.env.REDIS_URL || 'redis://localhost:6379');
 
   return new Queue<T>(name, {

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { storageGcQueue, storagePinQueue } from './queue.js';
 import { createStorageProvider } from './provider.js';
-import { buildGatewayUrl, buildIpfsUri } from './utils.js';
+import { buildGatewayUrl, buildIpfsUri, canonicalizeJson, sha256Hex } from './utils.js';
 import * as defaultRepository from './asset.repository.js';
 import type {
   StoragePinRequest,
@@ -18,11 +18,46 @@ export interface StorageRepository {
   markAssetsUnreferenced: typeof defaultRepository.markAssetsUnreferenced;
 }
 
+/** Fetches the raw bytes stored at a gateway URL, for post-upload content
+ * integrity verification (#912). */
+export type ContentFetcher = (url: string) => Promise<Buffer>;
+
+const defaultContentFetcher: ContentFetcher = async (url: string): Promise<Buffer> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Content fetch failed with status ${response.status} for ${url}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+};
+
+/**
+ * Thrown when the content a storage provider returns for a CID doesn't
+ * match what was uploaded — the provider's response is treated as
+ * untrusted until this check passes (#912).
+ */
+export class ContentIntegrityError extends Error {
+  constructor(
+    public readonly resourceType: string,
+    public readonly resourceId: string,
+    public readonly cid: string,
+    public readonly expectedDigest: string,
+    public readonly actualDigest: string
+  ) {
+    super(
+      `Content integrity check failed for ${resourceType}/${resourceId} (cid=${cid}): ` +
+        `expected digest ${expectedDigest}, provider served ${actualDigest}`
+    );
+    this.name = 'ContentIntegrityError';
+  }
+}
+
 export interface StorageServiceDependencies {
   provider?: StorageProvider;
   repository?: StorageRepository;
   pinQueue?: typeof storagePinQueue;
   gcQueue?: typeof storageGcQueue;
+  contentFetcher?: ContentFetcher;
 }
 
 export class StorageService {
@@ -31,6 +66,7 @@ export class StorageService {
   private readonly repository: StorageRepository;
   private readonly pinQueue: typeof storagePinQueue;
   private readonly gcQueue: typeof storageGcQueue;
+  private readonly contentFetcher: ContentFetcher;
 
   constructor(dependencies: StorageServiceDependencies | StorageProvider = {}) {
     if (this.isStorageProvider(dependencies)) {
@@ -38,6 +74,7 @@ export class StorageService {
       this.repository = defaultRepository;
       this.pinQueue = storagePinQueue;
       this.gcQueue = storageGcQueue;
+      this.contentFetcher = defaultContentFetcher;
       return;
     }
 
@@ -45,6 +82,7 @@ export class StorageService {
     this.repository = dependencies.repository ?? defaultRepository;
     this.pinQueue = dependencies.pinQueue ?? storagePinQueue;
     this.gcQueue = dependencies.gcQueue ?? storageGcQueue;
+    this.contentFetcher = dependencies.contentFetcher ?? defaultContentFetcher;
   }
 
   static getInstance(): StorageService {
@@ -62,6 +100,7 @@ export class StorageService {
       metadata: request.metadata,
     });
 
+    await this.verifyJsonIntegrity(request, result);
     await this.persistResult(request, result);
     return result;
   }
@@ -76,8 +115,115 @@ export class StorageService {
       metadata: request.metadata,
     });
 
+    await this.verifyFileIntegrity(request, result);
     await this.persistResult(request, result);
     return result;
+  }
+
+  /**
+   * Verifies a JSON pin's returned CID actually serves back the content we
+   * uploaded (#912). Compares canonicalized-JSON digests (not raw bytes)
+   * so differing whitespace/key-order between what we sent and what the
+   * provider re-serializes doesn't produce a false-positive mismatch.
+   * On mismatch, marks the asset failed and throws — the caller must not
+   * treat the pin as successful or persist it as 'pinned'.
+   */
+  private async verifyJsonIntegrity(
+    request: Omit<StoragePinRequest, 'mode'>,
+    result: StoragePinResult
+  ): Promise<void> {
+    const expectedDigest = sha256Hex(canonicalizeJson(request.content));
+
+    let fetched: Buffer;
+    try {
+      fetched = await this.contentFetcher(result.gatewayUrl);
+    } catch (error) {
+      await this.repository.markAssetFailed(
+        request.resourceType,
+        request.resourceId,
+        request.name,
+        `Content integrity check could not fetch pinned content: ${(error as Error).message}`
+      );
+      throw error;
+    }
+
+    let actualDigest: string;
+    try {
+      actualDigest = sha256Hex(canonicalizeJson(JSON.parse(fetched.toString('utf-8'))));
+    } catch (error) {
+      await this.repository.markAssetFailed(
+        request.resourceType,
+        request.resourceId,
+        request.name,
+        `Content integrity check: provider response was not valid JSON: ${(error as Error).message}`
+      );
+      throw new ContentIntegrityError(
+        request.resourceType,
+        request.resourceId,
+        result.cid,
+        expectedDigest,
+        'invalid-json'
+      );
+    }
+
+    if (actualDigest !== expectedDigest) {
+      await this.repository.markAssetFailed(
+        request.resourceType,
+        request.resourceId,
+        request.name,
+        `Content integrity check failed: expected ${expectedDigest}, got ${actualDigest}`
+      );
+      throw new ContentIntegrityError(
+        request.resourceType,
+        request.resourceId,
+        result.cid,
+        expectedDigest,
+        actualDigest
+      );
+    }
+  }
+
+  /**
+   * Verifies a file pin's returned CID actually serves back the exact
+   * bytes we uploaded (#912). Unlike JSON, file content is opaque, so this
+   * compares raw-byte digests directly rather than a semantic comparison.
+   */
+  private async verifyFileIntegrity(
+    request: Omit<StoragePinRequest, 'mode' | 'content'> & { content: Buffer },
+    result: StoragePinResult
+  ): Promise<void> {
+    const expectedDigest = sha256Hex(request.content);
+
+    let fetched: Buffer;
+    try {
+      fetched = await this.contentFetcher(result.gatewayUrl);
+    } catch (error) {
+      await this.repository.markAssetFailed(
+        request.resourceType,
+        request.resourceId,
+        request.name,
+        `Content integrity check could not fetch pinned content: ${(error as Error).message}`
+      );
+      throw error;
+    }
+
+    const actualDigest = sha256Hex(fetched);
+
+    if (actualDigest !== expectedDigest) {
+      await this.repository.markAssetFailed(
+        request.resourceType,
+        request.resourceId,
+        request.name,
+        `Content integrity check failed: expected ${expectedDigest}, got ${actualDigest}`
+      );
+      throw new ContentIntegrityError(
+        request.resourceType,
+        request.resourceId,
+        result.cid,
+        expectedDigest,
+        actualDigest
+      );
+    }
   }
 
   async queueJsonPin(request: Omit<StoragePinRequest, 'mode'>): Promise<{ jobId?: string | number }> {

--- a/backend/src/services/storage/utils.ts
+++ b/backend/src/services/storage/utils.ts
@@ -36,3 +36,17 @@ export const createDeterministicCid = (input: string): string => {
   return `bafy${crypto.createHash('sha256').update(input).digest('hex').slice(0, 56)}`;
 };
 
+/**
+ * SHA-256 digest of `input`, hex-encoded. Used for post-upload content
+ * integrity verification (#912) — not a CID: computing a real IPFS CID
+ * would require replicating the exact UnixFS/DAG-PB wrapping a provider
+ * like Pinata applies before hashing, which needs a full multiformats
+ * implementation this codebase doesn't currently depend on. A direct
+ * digest comparison of "what we sent" vs. "what the provider will serve
+ * back" catches the same class of problem (corrupted transfer, provider
+ * bug, tampering) without needing to reimplement IPFS's addressing scheme.
+ */
+export const sha256Hex = (input: string | Buffer): string => {
+  return crypto.createHash('sha256').update(input).digest('hex');
+};
+

--- a/backend/tests/CertificateBlockchainService.test.ts
+++ b/backend/tests/CertificateBlockchainService.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
+import {
+  CertificateBlockchainService,
+  BlockchainNotConfiguredError,
+} from '../src/blockchain/CertificateBlockchainService.js';
+
+const ENV_KEYS = ['BLOCKCHAIN_SIMULATION_MODE', 'CERTIFICATE_CONTRACT_ID'] as const;
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+describe('CertificateBlockchainService', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  describe('simulation mode (explicit)', () => {
+    it('defaults to simulation mode when no contract ID is configured', () => {
+      delete process.env.CERTIFICATE_CONTRACT_ID;
+      delete process.env.BLOCKCHAIN_SIMULATION_MODE;
+
+      const service = new CertificateBlockchainService();
+
+      expect(service.getMode()).toBe('simulation');
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('mints a simulated certificate with a success result and mock transaction hash', async () => {
+      delete process.env.CERTIFICATE_CONTRACT_ID;
+
+      const service = new CertificateBlockchainService();
+      const result = await service.mintCertificate({ verification: { tokenId: 'tok-1' } });
+
+      expect(result.success).toBe(true);
+      expect(result.tokenId).toBe('tok-1');
+      expect(result.transactionHash).toMatch(/^0x[0-9a-f]{64}$/);
+    });
+
+    it('verifies, reads owner, and reads certificate data in simulation mode', async () => {
+      delete process.env.CERTIFICATE_CONTRACT_ID;
+      const service = new CertificateBlockchainService();
+
+      await expect(service.verifyOnChain('tok-1')).resolves.toBe(true);
+      await expect(service.getOwner('tok-1')).resolves.toMatch(/^G[A-Z0-9]{55}$/);
+
+      const data = await service.getCertificateData('tok-1');
+      expect(data).toMatchObject({ tokenId: 'tok-1', network: expect.any(String) });
+    });
+
+    it('returns an empty transaction history array in simulation mode', async () => {
+      delete process.env.CERTIFICATE_CONTRACT_ID;
+      const service = new CertificateBlockchainService();
+
+      await expect(service.getTransactionHistory('tok-1')).resolves.toEqual([]);
+    });
+
+    it('does not throw when revoking in simulation mode', async () => {
+      delete process.env.CERTIFICATE_CONTRACT_ID;
+      const service = new CertificateBlockchainService();
+
+      await expect(service.revokeCertificate('tok-1', 'test reason')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('live mode requested but no contract integration exists (explicit failure, not silent success)', () => {
+    it('falls back to simulation mode and logs why, rather than silently pretending to be live', () => {
+      process.env.CERTIFICATE_CONTRACT_ID = 'CCERTIFICATECONTRACTID';
+      process.env.BLOCKCHAIN_SIMULATION_MODE = 'false';
+
+      const service = new CertificateBlockchainService();
+
+      // initializeClient() falls back to simulation mode since there's no
+      // real Soroban certificate contract integration to call yet — this
+      // is the documented, honest behavior (see class docs), not a bug.
+      expect(service.getMode()).toBe('simulation');
+    });
+
+    it('getTransactionHistory throws BlockchainNotConfiguredError in true live mode (bypasses the circuit breaker, so this is deterministic)', async () => {
+      process.env.CERTIFICATE_CONTRACT_ID = 'CCERTIFICATECONTRACTID';
+      process.env.BLOCKCHAIN_SIMULATION_MODE = 'false';
+      const service = new CertificateBlockchainService();
+
+      // Force live mode past the constructor's automatic simulation
+      // fallback, to exercise the "genuinely no client configured" path
+      // that would apply once initializeClient() is replaced with a real
+      // Soroban client in the future.
+      (service as unknown as { isSimulationMode: boolean }).isSimulationMode = false;
+
+      await expect(service.getTransactionHistory('tok-1')).rejects.toThrow(
+        BlockchainNotConfiguredError
+      );
+      await expect(service.getTransactionHistory('tok-1')).rejects.toMatchObject({
+        code: 'BLOCKCHAIN_NOT_CONFIGURED',
+      });
+    });
+
+    it('revokeCertificate rejects rather than silently succeeding when forced into live mode', async () => {
+      process.env.CERTIFICATE_CONTRACT_ID = 'CCERTIFICATECONTRACTID';
+      process.env.BLOCKCHAIN_SIMULATION_MODE = 'false';
+      const service = new CertificateBlockchainService();
+      (service as unknown as { isSimulationMode: boolean }).isSimulationMode = false;
+
+      await expect(service.revokeCertificate('tok-1', 'test')).rejects.toThrow(Error);
+    });
+
+    it('mintCertificate degrades to a typed failure response via the circuit breaker fallback rather than throwing an untyped error', async () => {
+      process.env.CERTIFICATE_CONTRACT_ID = 'CCERTIFICATECONTRACTID';
+      process.env.BLOCKCHAIN_SIMULATION_MODE = 'false';
+      const service = new CertificateBlockchainService();
+      (service as unknown as { isSimulationMode: boolean }).isSimulationMode = false;
+
+      const result = await service.mintCertificate({ verification: { tokenId: 'tok-2' } });
+
+      // The circuit breaker's fallback swallows the thrown error into a
+      // graceful `success: false` response by design (existing behavior,
+      // preserved here) — the point of BlockchainNotConfiguredError is
+      // that it's now a distinguishable, loggable type rather than a bare
+      // Error, not that it always propagates to the caller.
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/backend/tests/storage.service.test.ts
+++ b/backend/tests/storage.service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import { StorageService } from '../src/services/storage/storage.service.js';
+import { StorageService, ContentIntegrityError } from '../src/services/storage/storage.service.js';
 import { MockStorageProvider } from '../src/services/storage/providers/mock.provider.js';
-import type { StorageServiceDependencies } from '../src/services/storage/storage.service.js';
+import type { StorageServiceDependencies, ContentFetcher } from '../src/services/storage/storage.service.js';
 
 const createRepository = (): NonNullable<StorageServiceDependencies['repository']> => ({
   upsertStorageAsset: jest.fn(),
@@ -11,18 +11,27 @@ const createRepository = (): NonNullable<StorageServiceDependencies['repository'
   markAssetsUnreferenced: jest.fn(),
 });
 
+/** A fetcher that echoes back exactly what was uploaded — simulates a
+ * provider correctly serving the content it was given. */
+const echoJsonFetcher = (content: unknown): ContentFetcher => async () =>
+  Buffer.from(JSON.stringify(content));
+
+const echoBufferFetcher = (content: Buffer): ContentFetcher => async () => content;
+
 describe('storage service', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('pins JSON and persists the CID', async () => {
+  it('pins JSON, verifies the returned CID serves back the exact content, and persists it', async () => {
     const repository = createRepository();
     repository.upsertStorageAsset.mockResolvedValue({} as never);
+    const content = { hello: 'world' };
 
     const storageService = new StorageService({
       provider: new MockStorageProvider(),
       repository,
+      contentFetcher: echoJsonFetcher(content),
     });
 
     const result = await storageService.pinJsonNow({
@@ -30,20 +39,23 @@ describe('storage service', () => {
       resourceId: 'project-1',
       name: 'example',
       kind: 'generic',
-      content: { hello: 'world' },
+      content,
     });
 
     expect(result.provider).toBe('mock');
     expect(repository.upsertStorageAsset).toHaveBeenCalledTimes(1);
+    expect(repository.markAssetFailed).not.toHaveBeenCalled();
   });
 
-  it('pins files and persists the CID', async () => {
+  it('pins files, verifies the returned CID serves back the exact bytes, and persists it', async () => {
     const repository = createRepository();
     repository.upsertStorageAsset.mockResolvedValue({} as never);
+    const content = Buffer.from('<svg />');
 
     const storageService = new StorageService({
       provider: new MockStorageProvider(),
       repository,
+      contentFetcher: echoBufferFetcher(content),
     });
 
     const result = await storageService.pinFileNow({
@@ -51,12 +63,149 @@ describe('storage service', () => {
       resourceId: 'cert-1',
       name: 'cert.svg',
       kind: 'certificate-image',
-      content: Buffer.from('<svg />'),
+      content,
       mimeType: 'image/svg+xml',
     });
 
     expect(result.provider).toBe('mock');
     expect(repository.upsertStorageAsset).toHaveBeenCalledTimes(1);
+    expect(repository.markAssetFailed).not.toHaveBeenCalled();
+  });
+
+  it('does not persist a JSON pin when the provider serves back different content, and marks the asset failed', async () => {
+    const repository = createRepository();
+    repository.upsertStorageAsset.mockResolvedValue({} as never);
+    repository.markAssetFailed.mockResolvedValue(undefined as never);
+
+    const storageService = new StorageService({
+      provider: new MockStorageProvider(),
+      repository,
+      // Simulates a corrupted/tampered response: the gateway serves back
+      // content that doesn't match what was uploaded.
+      contentFetcher: async () => Buffer.from(JSON.stringify({ hello: 'TAMPERED' })),
+    });
+
+    await expect(
+      storageService.pinJsonNow({
+        resourceType: 'project',
+        resourceId: 'project-1',
+        name: 'example',
+        kind: 'generic',
+        content: { hello: 'world' },
+      })
+    ).rejects.toThrow(ContentIntegrityError);
+
+    expect(repository.upsertStorageAsset).not.toHaveBeenCalled();
+    expect(repository.markAssetFailed).toHaveBeenCalledTimes(1);
+    expect(repository.markAssetFailed).toHaveBeenCalledWith(
+      'project',
+      'project-1',
+      'example',
+      expect.stringContaining('Content integrity check failed')
+    );
+  });
+
+  it('does not persist a file pin when the provider serves back different bytes, and marks the asset failed', async () => {
+    const repository = createRepository();
+    repository.upsertStorageAsset.mockResolvedValue({} as never);
+    repository.markAssetFailed.mockResolvedValue(undefined as never);
+
+    const storageService = new StorageService({
+      provider: new MockStorageProvider(),
+      repository,
+      contentFetcher: async () => Buffer.from('<svg>tampered</svg>'),
+    });
+
+    await expect(
+      storageService.pinFileNow({
+        resourceType: 'certificate',
+        resourceId: 'cert-1',
+        name: 'cert.svg',
+        kind: 'certificate-image',
+        content: Buffer.from('<svg />'),
+        mimeType: 'image/svg+xml',
+      })
+    ).rejects.toThrow(ContentIntegrityError);
+
+    expect(repository.upsertStorageAsset).not.toHaveBeenCalled();
+    expect(repository.markAssetFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the asset failed (and does not persist) when the provider response is not valid JSON', async () => {
+    const repository = createRepository();
+    repository.markAssetFailed.mockResolvedValue(undefined as never);
+
+    const storageService = new StorageService({
+      provider: new MockStorageProvider(),
+      repository,
+      contentFetcher: async () => Buffer.from('not-json{{{'),
+    });
+
+    await expect(
+      storageService.pinJsonNow({
+        resourceType: 'project',
+        resourceId: 'project-1',
+        name: 'example',
+        kind: 'generic',
+        content: { hello: 'world' },
+      })
+    ).rejects.toThrow(ContentIntegrityError);
+
+    expect(repository.upsertStorageAsset).not.toHaveBeenCalled();
+    expect(repository.markAssetFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the asset failed and rethrows when fetching the pinned content itself fails', async () => {
+    const repository = createRepository();
+    repository.markAssetFailed.mockResolvedValue(undefined as never);
+    const fetchError = new Error('network unreachable');
+
+    const storageService = new StorageService({
+      provider: new MockStorageProvider(),
+      repository,
+      contentFetcher: async () => {
+        throw fetchError;
+      },
+    });
+
+    await expect(
+      storageService.pinJsonNow({
+        resourceType: 'project',
+        resourceId: 'project-1',
+        name: 'example',
+        kind: 'generic',
+        content: { hello: 'world' },
+      })
+    ).rejects.toThrow('network unreachable');
+
+    expect(repository.upsertStorageAsset).not.toHaveBeenCalled();
+    expect(repository.markAssetFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats semantically-identical JSON with different key order/whitespace as matching (canonical comparison)', async () => {
+    const repository = createRepository();
+    repository.upsertStorageAsset.mockResolvedValue({} as never);
+
+    const storageService = new StorageService({
+      provider: new MockStorageProvider(),
+      repository,
+      // Same data, different key order and formatting — a real provider's
+      // re-serialization commonly differs this way without being corrupt.
+      contentFetcher: async () => Buffer.from('{"world":"!","hello":"world"}'),
+    });
+
+    await expect(
+      storageService.pinJsonNow({
+        resourceType: 'project',
+        resourceId: 'project-1',
+        name: 'example',
+        kind: 'generic',
+        content: { hello: 'world', world: '!' },
+      })
+    ).resolves.toBeDefined();
+
+    expect(repository.upsertStorageAsset).toHaveBeenCalledTimes(1);
+    expect(repository.markAssetFailed).not.toHaveBeenCalled();
   });
 
   it('queues pin and gc jobs', async () => {

--- a/docs/backend/CURRICULUM_AUTHORING.md
+++ b/docs/backend/CURRICULUM_AUTHORING.md
@@ -1,0 +1,43 @@
+# Adding or Editing a Curriculum Lesson
+
+Course content lives in
+`backend/src/routes/learning/curriculum.data.ts` — a
+`Record<courseId, Module[]>` map. Each `Module` has an ordered list of
+`Lesson`s (types in `backend/src/routes/learning/types.ts`).
+
+## Adding a lesson
+
+1. Find the course/module you're adding to in `curriculum.data.ts`.
+2. Add a new lesson object with a **globally unique** `id` (convention:
+   `<course-id>-lesson-<n>`), a non-empty `title`/`description`, a
+   `difficulty` of `'beginner' | 'intermediate' | 'advanced'`, and an
+   `order` that continues the module's existing 1..N sequence with no
+   gaps or duplicates.
+3. If you're adding a new module, give it its own unique `id`
+   (`<course-id>-module-<n>`) and an `order` that continues the course's
+   module sequence the same way.
+
+## Validating locally before opening a PR
+
+```bash
+cd backend
+npm run validate:curriculum
+```
+
+This is the same command CI runs (`.github/workflows/ci.yml`, "Validate
+curriculum content" step, right after the build — before any database
+services are needed). It checks, failing with the specific
+course/module/lesson identifier and field that's wrong:
+
+- Every course/module/lesson has the required non-empty fields.
+- Module IDs are unique across the whole curriculum; lesson IDs are
+  unique across the whole curriculum (not just within their own module).
+- `difficulty` is one of the three allowed values.
+- `order` values within a module (lessons) and within a course (modules)
+  form a contiguous `1, 2, 3, ...` sequence — a duplicate or a gap means
+  the module/course was edited without updating every sibling's `order`,
+  which breaks "next lesson" navigation and progress-percentage math.
+
+The validator (`backend/scripts/validate-curriculum.ts`) is a plain
+script, not a test file — run it directly with `tsx`, no test runner or
+database required.

--- a/docs/backend/DATABASE_MIGRATIONS.md
+++ b/docs/backend/DATABASE_MIGRATIONS.md
@@ -1,0 +1,69 @@
+# Database Migrations
+
+## Creating a migration
+
+```bash
+cd backend
+npx prisma migrate dev --name <descriptive_name>
+```
+
+This applies the migration to your local dev database and generates
+`prisma/migrations/<timestamp>_<name>/migration.sql`. Review the generated
+SQL before committing it — Prisma's diff is usually right, but it can't know
+your intent for a rename vs. a drop-and-recreate.
+
+## Verifying a migration locally (matches CI exactly)
+
+CI runs three checks against a real PostgreSQL instance, in this order.
+Reproduce all three locally before opening a PR that touches
+`prisma/schema.prisma` or `prisma/migrations/`:
+
+```bash
+cd backend
+
+# 1. Migrations must apply cleanly to a fresh database.
+export DATABASE_URL=postgresql://<user>@localhost:5432/<scratch_db>
+npx prisma generate
+npx prisma migrate deploy
+
+# 2. The latest migration must be safely reversible (rollback verification).
+#    Needs a second, empty "shadow" database.
+export SHADOW_DATABASE_URL=postgresql://<user>@localhost:5432/<scratch_shadow_db>
+npm run test:migrations
+
+# 3. schema.prisma must not have drifted from the migration history.
+npx prisma migrate diff \
+  --from-config-datasource \
+  --to-schema prisma/schema.prisma \
+  --exit-code
+```
+
+Step 3 currently reports a large amount of pre-existing drift (dozens of
+tables/columns present in `schema.prisma` with no corresponding migration —
+see the PR that added this doc for the full list). CI runs this step with
+`continue-on-error: true` for now rather than blocking every PR on
+resolving that backlog; **once it's cleared with a dedicated migration**,
+remove `continue-on-error` from `.github/workflows/ci.yml` so future drift
+fails CI as intended. Don't let *new* drift accumulate on top of the
+existing gap in the meantime — if step 3 reports differences you
+introduced, generate a migration for them before merging.
+
+## What "rollback verification" actually checks
+
+`scripts/test-migration-rollback.sh`:
+1. Diffs the latest migration against the migration history without it,
+   generating a `DOWN` SQL script.
+2. Applies all migrations (including the latest) to a scratch database.
+3. Executes the generated `DOWN` script.
+4. Diffs the now-rolled-back database against the pre-latest-migration
+   schema state — a clean diff means the rollback is exact.
+
+This catches migrations that are irreversible in practice (e.g. a
+`DROP COLUMN` with no default that would lose data on a real rollback) or
+whose generated `DOWN` script doesn't fully undo the `UP` script.
+
+## Prerequisites
+
+Both `DATABASE_URL` and `SHADOW_DATABASE_URL` must point at databases on the
+**same** Postgres server/role — only the database name differs. Neither
+script requires network access beyond that Postgres instance.

--- a/docs/governance/CONTRIBUTING.md
+++ b/docs/governance/CONTRIBUTING.md
@@ -43,6 +43,11 @@ at first.
 > [CI/CD Pipeline Guide](docs/CICD_GUIDE.md) before making any changes related to secrets, sensitive
 > data, or smart contracts.
 
+Adding or editing a course lesson? See
+[docs/backend/CURRICULUM_AUTHORING.md](../backend/CURRICULUM_AUTHORING.md)
+for the required fields and the `npm run validate:curriculum` command CI
+runs on every PR.
+
 ## 5. Make a Pull Request
 
 At this point, you should switch back to your master branch and make sure it's up to date with Web3


### PR DESCRIPTION
Addresses all 4 assigned issues. Found and fixed several genuine pre-existing bugs along the way — verified everything against a real local Postgres instance and the actual test suite rather than just reading the code.

## #907 — Prisma migration verification was a bypass, and migrations never actually worked
`npx prisma migrate deploy || true` in CI was masking a real bug: the initial migration used `DATETIME` (SQLite/MySQL syntax) for every timestamp column — invalid on this repo's actual Postgres datasource. **Migrations have apparently never successfully applied against real Postgres in this repo's CI history.** Fixed the two affected migration files (`DATETIME` → `TIMESTAMP(3)`, matching every later migration's own convention).

The rollback-verification script already existed (`scripts/test-migration-rollback.sh`) but `test:migrations` was a stub (`echo 'No migrations tests'`). Wired it up, which then surfaced two Prisma 7 CLI flags the script used that were removed in that major version (`db execute --schema`, `migrate diff --from-schema-datasource`) — fixed both. Verified the full chain end-to-end locally: migrate deploy → rollback verification → drift check, all against a real database.

Also added drift detection (`prisma migrate diff`), which surfaced **substantial pre-existing schema drift** (~20 tables/columns in `schema.prisma` with no corresponding migration). Generating a migration to close a gap that size blind risks real data loss (dropped tables/columns, index/FK changes) — left as `continue-on-error: true` (reporting only) with the finding documented, rather than rushing a mega-migration or blocking every future PR on a backlog this PR didn't create.

## #909 — Curriculum content validation
New `backend/scripts/validate-curriculum.ts` validates `curriculumByCourseId`: required fields, lesson/module ID uniqueness across the *entire* curriculum (not just per-parent), difficulty enum, and — the part that actually matters for navigation — that `order` values form a contiguous 1..N sequence with no gaps/duplicates. Verified detection works by deliberately introducing a duplicate ID and an order gap into the real data and confirming both get caught with the exact location, then restoring the file. Wired into CI right after the build step (`npm run validate:curriculum`), no DB needed.

## #910 — CertificateBlockchainService
No Soroban certificate contract exists anywhere in this repo to integrate against (no `contracts/certificate_*` package defines a mint/verify/getOwner/revoke ABI), and `NetworkError` was imported from `@stellar/stellar-sdk` but never used — evidence of an abandoned attempt. Faking live RPC calls against a contract that doesn't exist would be worse than the honest simulation-only status quo. Implemented what's safely implementable: explicit `getMode(): 'simulation' | 'live'`, a new typed `BlockchainNotConfiguredError` replacing generic `Error('not yet implemented')` throws so callers can distinguish "not wired up" from a transient network failure, and fixed `getTransactionHistory` (previously ignored simulation mode entirely). 9 new tests. Full live RPC integration is flagged as needing an actual deployed contract first.

## #912 — Content integrity verification after storage uploads
`storage.service.ts` previously persisted whatever CID a provider (Pinata) returned with zero verification. Now computes a local digest before upload, fetches the content back from the provider's gateway URL, and compares (canonical-JSON digest for JSON pins so re-serialization whitespace/key-order doesn't false-positive; raw-byte digest for files). Mismatches mark the asset failed and throw `ContentIntegrityError` rather than persisting a bad reference. Found and fixed a hard syntax error in `queue.ts` (two conflicting `const redisUrl` declarations) that was preventing the entire storage module from being imported by Jest at all. 5 new tests plus the 2 existing tests updated to inject a matching fetcher (they used a non-fetchable mock gatewayUrl and would hang/fail once verification runs by default).

## Test plan
- [x] `npx prisma migrate deploy` locally against real Postgres — was failing with "type \"datetime\" does not exist", now applies all 8 migrations cleanly
- [x] `npm run test:migrations` — was a no-op stub, now runs the real rollback check end-to-end ("No difference detected")
- [x] `npm run validate:curriculum` — passes on real data; manually verified it catches injected duplicate-ID and ordering-gap errors
- [x] `npx jest tests/storage.service.test.ts tests/storage.provider.test.ts tests/storage.worker.test.ts tests/storage.utils.test.ts tests/CertificateBlockchainService.test.ts` — 24/24 passing
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in other files reproduce without this change)
- [x] All modified YAML validated with `yaml.safe_load_all`

Closes #907
Closes #909
Closes #910
Closes #912