### PR TITLE
feat(playground): cancellable compile/run with stale-result prevention

### DIFF
--- a/backend/src/routes/contracts.routes.ts
+++ b/backend/src/routes/contracts.routes.ts
@@ -1,19 +1,63 @@
 import { Router } from 'express';
 import { compileSmartContract, executeSmartContract } from '../services/contract.service.js';
+import { cancellationRegistry } from '../services/cancellationRegistry.js';
 import logger from '../utils/logger.js';
 import { validateRequest } from '../utils/validation.js';
-import { contractCompileSchema, contractExecutionSchema } from './contracts.validation.schemas.js';
+import {
+  contractCompileSchema,
+  contractExecutionSchema,
+  contractCancelSchema,
+} from './contracts.validation.schemas.js';
 
 const router = Router();
 
+/** Shared header key for attaching cancellation IDs to requests. */
+const CANCELLATION_ID_HEADER = 'x-cancellation-id';
+
 /**
  * Smart Contract Compilation Endpoint
- * This route validates compilation requests, rejects malformed inputs,
- * monitors compile duration, and returns a deterministic compile summary.
+ * Clients may include an X-Cancellation-Id header with a UUID.  When present
+ * the request is registered in the CancellationRegistry so it can be stopped
+ * via POST /cancel before (or during) execution.
  */
 router.post('/compile', validateRequest(contractCompileSchema), async (req, res) => {
+  const cancellationId = (req.headers[CANCELLATION_ID_HEADER] as string | undefined)?.trim();
+
+  if (cancellationId) {
+    try {
+      cancellationRegistry.register(cancellationId);
+    } catch (err) {
+      // ID already in use — reject so client can send a fresh one.
+      res.status(409).json({
+        status: 'error',
+        message: 'A request with this cancellationId is already in progress. Use a new ID.',
+      });
+      return;
+    }
+  }
+
   try {
+    if (cancellationId) {
+      cancellationRegistry.markRunning(cancellationId);
+    }
+
+    // Bail immediately if the client cancelled before we started heavy work.
+    if (cancellationId && cancellationRegistry.isCancelled(cancellationId)) {
+      res.status(200).json({ status: 'cancelled', cancellationId });
+      return;
+    }
+
     const compileResult = await compileSmartContract(req.body);
+
+    // Check again after the async compile step.
+    if (cancellationId && cancellationRegistry.isCancelled(cancellationId)) {
+      res.status(200).json({ status: 'cancelled', cancellationId });
+      return;
+    }
+
+    if (cancellationId) {
+      cancellationRegistry.markComplete(cancellationId);
+    }
 
     if (!compileResult.compiled) {
       logger.warn('Contract compilation failed due to invalid source or compilation rules', {
@@ -25,6 +69,7 @@ router.post('/compile', validateRequest(contractCompileSchema), async (req, res)
         message: 'Contract compilation failed',
         details: compileResult.errors,
         warnings: compileResult.warnings,
+        cancellationId: cancellationId ?? null,
       });
     }
 
@@ -39,8 +84,12 @@ router.post('/compile', validateRequest(contractCompileSchema), async (req, res)
       optimization: compileResult.optimization,
       target: compileResult.target,
       durationMs: compileResult.durationMs,
+      cancellationId: cancellationId ?? null,
     });
   } catch (error) {
+    if (cancellationId) {
+      cancellationRegistry.markComplete(cancellationId);
+    }
     logger.error('Unexpected error during contract compilation', error);
     res.status(500).json({ status: 'error', message: 'Unable to compile contract' });
   }
@@ -48,11 +97,43 @@ router.post('/compile', validateRequest(contractCompileSchema), async (req, res)
 
 /**
  * Smart Contract Execution Simulation Endpoint
- * Logs execution details, performance metrics, and returns a safe execution response.
+ * Supports the same X-Cancellation-Id header as the compile endpoint.
  */
 router.post('/execute', validateRequest(contractExecutionSchema), async (req, res) => {
+  const cancellationId = (req.headers[CANCELLATION_ID_HEADER] as string | undefined)?.trim();
+
+  if (cancellationId) {
+    try {
+      cancellationRegistry.register(cancellationId);
+    } catch {
+      res.status(409).json({
+        status: 'error',
+        message: 'A request with this cancellationId is already in progress. Use a new ID.',
+      });
+      return;
+    }
+  }
+
   try {
+    if (cancellationId) {
+      cancellationRegistry.markRunning(cancellationId);
+    }
+
+    if (cancellationId && cancellationRegistry.isCancelled(cancellationId)) {
+      res.status(200).json({ status: 'cancelled', cancellationId });
+      return;
+    }
+
     const executionResult = await executeSmartContract(req.body);
+
+    if (cancellationId && cancellationRegistry.isCancelled(cancellationId)) {
+      res.status(200).json({ status: 'cancelled', cancellationId });
+      return;
+    }
+
+    if (cancellationId) {
+      cancellationRegistry.markComplete(cancellationId);
+    }
 
     res.json({
       status: executionResult.success ? 'success' : 'error',
@@ -64,11 +145,36 @@ router.post('/execute', validateRequest(contractExecutionSchema), async (req, re
       durationMs: executionResult.durationMs,
       logs: executionResult.logs,
       output: executionResult.output,
+      cancellationId: cancellationId ?? null,
     });
   } catch (error) {
+    if (cancellationId) {
+      cancellationRegistry.markComplete(cancellationId);
+    }
     logger.error('Unexpected error during smart contract execution', error);
     res.status(500).json({ status: 'error', message: 'Unable to execute smart contract' });
   }
+});
+
+/**
+ * Cancellation Endpoint
+ * POST /api/v1/contracts/cancel
+ * Body: { cancellationId: string (UUID) }
+ *
+ * Returns 200 in all "expected" cases; 400 only for malformed input.
+ * The response body's `status` field communicates the exact outcome.
+ */
+router.post('/cancel', validateRequest(contractCancelSchema), (req, res) => {
+  const { cancellationId } = req.body as { cancellationId: string };
+
+  const outcome = cancellationRegistry.cancel(cancellationId);
+
+  logger.info('Contract operation cancellation requested', { cancellationId, outcome });
+
+  res.json({
+    status: outcome,
+    cancellationId,
+  });
 });
 
 export default router;

--- a/backend/src/routes/contracts.validation.schemas.ts
+++ b/backend/src/routes/contracts.validation.schemas.ts
@@ -14,6 +14,12 @@ export const contractCompileSchema = z.object({
   entryPoint: z.string().max(128).optional(),
 });
 
+export const contractCancelSchema = z.object({
+  cancellationId: z
+    .string()
+    .uuid({ message: 'cancellationId must be a valid UUID.' }),
+});
+
 export const contractExecutionSchema = z.object({
   contractAddress: z.string().min(32, { message: 'Contract address is required.' }),
   functionName: z.string().min(1, { message: 'Function name is required.' }),

--- a/backend/src/services/cancellationRegistry.ts
+++ b/backend/src/services/cancellationRegistry.ts
@@ -1,0 +1,120 @@
+/**
+ * In-process registry that tracks active compile/execute requests and allows
+ * callers to mark them as cancelled. Entries expire after TTL_MS to prevent
+ * unbounded growth without requiring a Redis dependency.
+ *
+ * Thread-safety note: Node.js is single-threaded in the event loop, so the
+ * Map operations here are inherently atomic for our purposes.
+ */
+
+export type RequestPhase = 'queued' | 'running' | 'complete' | 'cancelled';
+
+export interface RegistryEntry {
+  cancellationId: string;
+  phase: RequestPhase;
+  createdAt: number;
+}
+
+const TTL_MS = 5 * 60 * 1_000; // 5 minutes
+const CLEANUP_INTERVAL_MS = 60 * 1_000; // clean up every minute
+
+class CancellationRegistry {
+  private readonly entries = new Map<string, RegistryEntry>();
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    // Start background cleanup so the map never grows unboundedly in long-running processes.
+    this.cleanupTimer = setInterval(() => this.evictExpired(), CLEANUP_INTERVAL_MS);
+    // Allow the process to exit even when this timer is live.
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  /**
+   * Register a new cancellation ID as queued.
+   * Throws if the ID is already present and not yet complete/cancelled.
+   */
+  register(cancellationId: string): void {
+    const existing = this.entries.get(cancellationId);
+    if (existing && existing.phase !== 'complete' && existing.phase !== 'cancelled') {
+      throw new Error(`Cancellation ID ${cancellationId} is already active.`);
+    }
+    this.entries.set(cancellationId, {
+      cancellationId,
+      phase: 'queued',
+      createdAt: Date.now(),
+    });
+  }
+
+  /**
+   * Transition a queued entry to running.
+   * No-op if the entry is already cancelled (preserves the cancelled state).
+   */
+  markRunning(cancellationId: string): void {
+    const entry = this.entries.get(cancellationId);
+    if (!entry) return;
+    if (entry.phase === 'queued') {
+      entry.phase = 'running';
+    }
+  }
+
+  /**
+   * Transition entry to complete. No-op when already cancelled.
+   */
+  markComplete(cancellationId: string): void {
+    const entry = this.entries.get(cancellationId);
+    if (!entry) return;
+    if (entry.phase !== 'cancelled') {
+      entry.phase = 'complete';
+    }
+  }
+
+  /**
+   * Attempt to cancel an active request.
+   * Returns:
+   *   'cancelled'       — successful, was queued or running.
+   *   'already_complete'— request already finished normally.
+   *   'not_found'       — unknown ID.
+   */
+  cancel(cancellationId: string): 'cancelled' | 'already_complete' | 'not_found' {
+    const entry = this.entries.get(cancellationId);
+    if (!entry) return 'not_found';
+    if (entry.phase === 'complete' || entry.phase === 'cancelled') {
+      return 'already_complete';
+    }
+    entry.phase = 'cancelled';
+    return 'cancelled';
+  }
+
+  /**
+   * Returns true when a cancellationId has been cancelled before or during execution.
+   * Service methods should poll this to abort expensive work early.
+   */
+  isCancelled(cancellationId: string): boolean {
+    return this.entries.get(cancellationId)?.phase === 'cancelled';
+  }
+
+  /** Return current phase, or null if not found. */
+  getPhase(cancellationId: string): RequestPhase | null {
+    return this.entries.get(cancellationId)?.phase ?? null;
+  }
+
+  /** Remove entries older than TTL_MS. */
+  private evictExpired(): void {
+    const cutoff = Date.now() - TTL_MS;
+    for (const [id, entry] of this.entries) {
+      if (entry.createdAt < cutoff) {
+        this.entries.delete(id);
+      }
+    }
+  }
+
+  /** Exposed for tests — clears all entries. */
+  _clearAll(): void {
+    this.entries.clear();
+  }
+}
+
+// Singleton shared across the application lifecycle.
+export const cancellationRegistry = new CancellationRegistry();

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -324,6 +324,12 @@ textarea {
 
 .lesson-viewer .token.punctuation { color: var(--prism-punctuation); }
 
+/* ─── Playground execution status bar ─────────────────────────────────────── */
+@keyframes shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(200%); }
+}
+
 /* Thin themed scrollbar shared by simulator-style panels */
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;

--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -14,7 +14,6 @@ import { WithSkeleton } from '@/components/ui/WithSkeleton';
 import { EditorSkeleton } from '@/components/ui/skeletons/EditorSkeleton';
 import { useTutorial } from '@/contexts/TutorialContext';
 import { CollaborationProvider } from '@/lib/collaboration/YjsProvider';
-import type { CompileWorkerResponse } from '@/lib/compiler/compileTypes';
 import { FilePresenceManager } from '@/lib/explorer/FilePresence';
 import { DatabaseManager } from '@/lib/storage/DatabaseManager';
 import { SyncManager } from '@/lib/storage/SyncManager';
@@ -22,7 +21,9 @@ import { Settings, X } from 'lucide-react';
 import { DependencyUpdatePanel } from '@/components/playground/DependencyUpdatePanel';
 import { AccessibilityAuditPanel } from '@/components/playground/AccessibilityAuditPanel';
 import { ContractSearch } from '@/components/playground/ContractSearch';
+import { ExecutionStatusBar } from '@/components/playground/ExecutionStatusBar';
 import { useAccessibilityAudit } from '@/hooks/useAccessibilityAudit';
+import { usePlaygroundExecution } from '@/hooks/usePlaygroundExecution';
 import { AssistantPanel } from '@/components/playground/AssistantPanel';
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -119,8 +120,6 @@ function moveFileNode(
 }
 
 export default function PlaygroundPage() {
-  const [compileLogs, setCompileLogs] = useState<CompileLogEntry[]>([]);
-  const [isCompiling, setIsCompiling] = useState(false);
   const [errorLog, setErrorLog] = useState('');
   const [sourceCode, setSourceCode] = useState<string>(`#![no_std]
 
@@ -136,8 +135,6 @@ impl HelloContract {
     }
 }`);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [autoComplete, setAutoComplete] = useState(true);
-  const [vimMode, setVimMode] = useState(false);
   const [selectedContract, setSelectedContract] = useState<any>(null);
   const [editorSettings, setEditorSettings] = useState({
     fontSize: 14,
@@ -155,53 +152,34 @@ impl HelloContract {
   const [isOnline, setIsOnline] = useState(true);
   const [pendingCount, setPendingCount] = useState(0);
   const [activeTab, setActiveTab] = useState<'editor' | 'output' | 'prsim'>('editor');
-  const workerRef = useRef<Worker | null>(null);
+
+  // ── Cancellable execution hook ──────────────────────────────────────────
+  const {
+    executionState,
+    compileLogs,
+    compile,
+    cancel,
+    reset: resetExecution,
+  } = usePlaygroundExecution();
+
+  const isCompiling =
+    executionState.phase === 'queued' || executionState.phase === 'running';
+
+  // Sync error log from execution state so AssistantPanel still works.
+  useEffect(() => {
+    if (executionState.phase === 'error') {
+      const errLines = compileLogs
+        .filter((l) => l.level === 'error')
+        .map((l) => l.message);
+      setErrorLog(errLines.join('\n') || 'Browser compile failed with unknown diagnostics.');
+    } else if (executionState.phase === 'complete') {
+      setErrorLog('');
+    }
+  }, [executionState.phase, compileLogs]);
 
   const { result: auditResult, isPending: auditPending, runAudit } = useAccessibilityAudit(sourceCode, {
     debounceMs: 500,
   });
-
-  useEffect(() => {
-    const compileWorker = new Worker(new URL('../../lib/compiler/compile.worker.ts', import.meta.url), {
-      type: 'module',
-    });
-
-    const handleWorkerMessage = (event: MessageEvent<CompileWorkerResponse>) => {
-      const data = event.data;
-      if (data.type === 'log') {
-        setCompileLogs((prev) => [...prev, data.entry]);
-        return;
-      }
-      if (data.type === 'complete') {
-        setIsCompiling(false);
-        if (!data.success) {
-          setErrorLog(data.errors.join('\n') || 'Browser compile failed with unknown diagnostics.');
-        } else {
-          setErrorLog('');
-        }
-        if (!data.success && data.errors.length === 0) {
-          setCompileLogs((prev) => [
-            ...prev,
-            {
-              id: crypto.randomUUID?.() ?? `${Date.now()}-compile-failed`,
-              level: 'error',
-              timestamp: new Date().toLocaleTimeString(),
-              message: 'Browser compile failed with unknown diagnostics.',
-            },
-          ]);
-        }
-      }
-    };
-
-    compileWorker.addEventListener('message', handleWorkerMessage);
-    workerRef.current = compileWorker;
-
-    return () => {
-      compileWorker.removeEventListener('message', handleWorkerMessage);
-      compileWorker.terminate();
-      workerRef.current = null;
-    };
-  }, []);
 
   useEffect(() => {
     const timer = setTimeout(() => setIsInitializing(false), 1500);
@@ -279,43 +257,8 @@ impl HelloContract {
 
   const handleCompile = useCallback(() => {
     if (isCompiling) return;
-    const stamp = () => new Date().toLocaleTimeString();
-    setCompileLogs([
-      {
-        id: crypto.randomUUID?.() ?? `${Date.now()}-compile-start`,
-        level: 'info',
-        timestamp: stamp(),
-        message: `soroban contract build --file ${activeFilePath}`,
-      },
-      {
-        id: crypto.randomUUID?.() ?? `${Date.now()}-compile-check`,
-        level: 'info',
-        timestamp: stamp(),
-        message: 'Checking Rust target wasm32-unknown-unknown...',
-      },
-    ]);
-    setIsCompiling(true);
-
-    if (!workerRef.current) {
-      setCompileLogs((prev) => [
-        ...prev,
-        {
-          id: crypto.randomUUID?.() ?? `${Date.now()}-compile-error`,
-          level: 'error',
-          timestamp: stamp(),
-          message: 'Unable to start browser compiler worker.',
-        },
-      ]);
-      setIsCompiling(false);
-      return;
-    }
-
-    workerRef.current.postMessage({
-      type: 'compile',
-      source: sourceCode,
-      filePath: activeFilePath,
-    });
-  }, [activeFilePath, isCompiling, sourceCode]);
+    compile(sourceCode, activeFilePath);
+  }, [compile, isCompiling, sourceCode, activeFilePath]);
 
   useEffect(() => {
     const handleShortcutCompile = () => {
@@ -498,6 +441,8 @@ impl HelloContract {
               onClick={handleCompile}
               disabled={isCompiling}
               data-tour-step="playground-compile-btn"
+              aria-label={isCompiling ? 'Compilation in progress' : 'Compile and execute the contract'}
+              aria-busy={isCompiling}
               className={`mt-4 rounded-xl py-4 text-xs font-black tracking-[0.2em] uppercase transition-all ${
                 isCompiling
                   ? 'cursor-not-allowed bg-zinc-800 text-gray-500'
@@ -506,6 +451,14 @@ impl HelloContract {
             >
               {isCompiling ? 'Compiling Context...' : 'Execute Logic'}
             </button>
+
+            {/* Execution status bar — hidden in idle state */}
+            <ExecutionStatusBar
+              state={executionState}
+              onCancel={cancel}
+              onReset={resetExecution}
+              className="mt-2"
+            />
           </div>
 
           {/* Terminal Output or PR Simulation */}

--- a/frontend/src/components/playground/ExecutionStatusBar.tsx
+++ b/frontend/src/components/playground/ExecutionStatusBar.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * ExecutionStatusBar
+ *
+ * Displays the current compile/execution state to the student:
+ *   – Idle:     shows nothing (returns null).
+ *   – Queued:   spinner + "Queued" badge + optional queue position.
+ *   – Running:  animated bar + "Compiling" badge + elapsed timer.
+ *   – Complete: green checkmark + "Done" badge.
+ *   – Cancelled: yellow indicator + "Cancelled" badge.
+ *   – Error:    red indicator + "Failed" badge + retry affordance.
+ *
+ * Accessibility:
+ *   – role="status" with aria-live="polite" for routine updates.
+ *   – role="alert" on error so screen readers interrupt immediately.
+ *   – Cancel button has an aria-label and is keyboard-focusable.
+ *   – Progress bar has role="progressbar" with aria-valuetext.
+ *   – All interactive elements meet 44×44px minimum touch target.
+ */
+
+import { type ExecutionState } from '@/lib/compiler/cancellationTypes';
+import { X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+interface ExecutionStatusBarProps {
+  state: ExecutionState;
+  onCancel: () => void;
+  onReset?: () => void;
+  className?: string;
+}
+
+/** Elapsed time counter — re-renders every second while running. */
+function useElapsedSeconds(active: boolean, enteredAt: number): number {
+  const [elapsed, setElapsed] = useState(0);
+  const rafRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      setElapsed(0);
+      return;
+    }
+    setElapsed(Math.floor((Date.now() - enteredAt) / 1000));
+    rafRef.current = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - enteredAt) / 1000));
+    }, 1000);
+    return () => {
+      if (rafRef.current) clearInterval(rafRef.current);
+    };
+  }, [active, enteredAt]);
+
+  return elapsed;
+}
+
+export function ExecutionStatusBar({
+  state,
+  onCancel,
+  onReset,
+  className = '',
+}: ExecutionStatusBarProps) {
+  const { phase, statusMessage, queuePosition, enteredAt } = state;
+  const isActive = phase === 'queued' || phase === 'running';
+  const elapsed = useElapsedSeconds(isActive, enteredAt);
+
+  // Don't render anything in the idle state — the compile button itself is enough.
+  if (phase === 'idle') return null;
+
+  const isError = phase === 'error';
+  const isCancelled = phase === 'cancelled';
+  const isComplete = phase === 'complete';
+
+  // ── Visual tokens per phase ──────────────────────────────────────────────
+  const borderColor = isError
+    ? 'border-red-500/40'
+    : isCancelled
+    ? 'border-yellow-500/40'
+    : isComplete
+    ? 'border-green-500/40'
+    : 'border-white/10';
+
+  const badgeBg = isError
+    ? 'bg-red-600/20 text-red-400'
+    : isCancelled
+    ? 'bg-yellow-600/20 text-yellow-400'
+    : isComplete
+    ? 'bg-green-600/20 text-green-400'
+    : 'bg-white/10 text-zinc-400';
+
+  const dotColor = isError
+    ? 'bg-red-500'
+    : isCancelled
+    ? 'bg-yellow-500'
+    : isComplete
+    ? 'bg-green-500'
+    : 'bg-blue-400 animate-pulse';
+
+  return (
+    <div
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      className={[
+        'flex flex-col gap-2 rounded-xl border px-4 py-3',
+        'bg-zinc-950/80 backdrop-blur-sm',
+        borderColor,
+        className,
+      ].join(' ')}
+    >
+      {/* ── Top row: dot + message + badge + cancel ── */}
+      <div className="flex min-h-[44px] items-center gap-3">
+        {/* Status dot */}
+        <span
+          aria-hidden="true"
+          className={['h-2.5 w-2.5 flex-shrink-0 rounded-full', dotColor].join(' ')}
+        />
+
+        {/* Message */}
+        <span className="flex-1 text-[11px] font-medium tracking-wide text-zinc-300">
+          {statusMessage}
+          {isActive && elapsed > 0 && (
+            <span className="ml-2 text-zinc-500">({elapsed}s)</span>
+          )}
+        </span>
+
+        {/* Phase badge */}
+        <span
+          className={[
+            'rounded-full px-2 py-0.5 text-[9px] font-black tracking-widest uppercase',
+            badgeBg,
+          ].join(' ')}
+        >
+          {phase}
+        </span>
+
+        {/* Queue position when waiting */}
+        {phase === 'queued' && queuePosition !== null && (
+          <span
+            aria-label={`Queue position ${queuePosition}`}
+            className="rounded-full bg-white/5 px-2 py-0.5 text-[9px] font-bold tracking-widest text-zinc-500 uppercase"
+          >
+            #{queuePosition}
+          </span>
+        )}
+
+        {/* Cancel button — only while active */}
+        {isActive && (
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Cancel current compile operation"
+            title="Cancel"
+            className={[
+              'inline-flex h-[44px] w-[44px] flex-shrink-0 items-center justify-center',
+              'rounded-lg border border-red-600/30 bg-red-600/10',
+              'text-red-500 transition-colors hover:bg-red-600/20',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500',
+            ].join(' ')}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+
+        {/* Reset / retry — shown after terminal states */}
+        {(isComplete || isCancelled || isError) && onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            aria-label={isError ? 'Dismiss error and reset' : 'Dismiss status'}
+            className={[
+              'inline-flex h-[44px] items-center justify-center px-3',
+              'rounded-lg border border-white/10 bg-white/5',
+              'text-[9px] font-black tracking-widest text-zinc-400 uppercase',
+              'transition-colors hover:text-white',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40',
+            ].join(' ')}
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+
+      {/* ── Progress bar — only while running ── */}
+      {phase === 'running' && (
+        <div
+          role="progressbar"
+          aria-label="Compile progress"
+          aria-valuetext="Compiling…"
+          aria-busy="true"
+          className="h-1 w-full overflow-hidden rounded-full bg-white/5"
+        >
+          <div className="h-full w-full origin-left animate-[shimmer_1.5s_ease-in-out_infinite] rounded-full bg-gradient-to-r from-transparent via-red-500 to-transparent" />
+        </div>
+      )}
+
+      {/* ── Error detail ── */}
+      {isError && (
+        <p className="text-[10px] text-red-400/80">
+          Review the compile output for details. Correct the error and click{' '}
+          <span className="font-bold">Execute Logic</span> to try again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePlaygroundExecution.ts
+++ b/frontend/src/hooks/usePlaygroundExecution.ts
@@ -1,0 +1,238 @@
+/**
+ * usePlaygroundExecution
+ *
+ * Manages the full lifecycle of a playground compile operation:
+ *   – Generates a unique cancellation ID per request.
+ *   – Sends the cancellation ID to the compile worker and (optionally) the backend.
+ *   – Guards against stale results: any message whose cancellationId differs from
+ *     the current one is silently dropped.
+ *   – Exposes an `ExecutionState` that the UI can render.
+ *   – Provides a `cancel()` function that notifies both the worker and the backend.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CompileLogEntry } from '../lib/compiler/compileTypes';
+import type {
+  CancellableWorkerResponse,
+  CancellationId,
+  ExecutionPhase,
+  ExecutionState,
+} from '../lib/compiler/cancellationTypes';
+import { CANCELLATION_ID_HEADER } from '../lib/compiler/cancellationTypes';
+
+/** Shape returned by the hook. */
+export interface UsePlaygroundExecutionReturn {
+  /** Current lifecycle state. */
+  executionState: ExecutionState;
+  /** Accumulated compile log entries for the current (or most recent) run. */
+  compileLogs: CompileLogEntry[];
+  /** Call to kick off a compile. No-op if already running. */
+  compile: (source: string, filePath: string) => void;
+  /** Cancel the in-flight compile. No-op when idle/complete. */
+  cancel: () => void;
+  /** Clear logs and reset to idle. */
+  reset: () => void;
+}
+
+function makeIdleState(): ExecutionState {
+  return {
+    cancellationId: null,
+    phase: 'idle',
+    statusMessage: 'Ready',
+    queuePosition: null,
+    enteredAt: Date.now(),
+  };
+}
+
+function statusFor(phase: ExecutionPhase, cancellationId: CancellationId | null): string {
+  switch (phase) {
+    case 'idle':       return 'Ready';
+    case 'queued':     return 'Queued — waiting for worker…';
+    case 'running':    return 'Compiling…';
+    case 'complete':   return 'Done';
+    case 'cancelled':  return 'Cancelled';
+    case 'error':      return 'Compilation failed';
+    default:           return '';
+  }
+}
+
+function transition(
+  prev: ExecutionState,
+  phase: ExecutionPhase,
+  cancellationId?: CancellationId | null
+): ExecutionState {
+  const id = cancellationId !== undefined ? cancellationId : prev.cancellationId;
+  return {
+    cancellationId: id,
+    phase,
+    statusMessage: statusFor(phase, id),
+    queuePosition: phase === 'queued' ? 1 : null,
+    enteredAt: Date.now(),
+  };
+}
+
+/** Base URL for backend contract API — falls back to relative when not set. */
+const API_BASE = process.env.NEXT_PUBLIC_API_URL
+  ? `${process.env.NEXT_PUBLIC_API_URL}/api/v1/contracts`
+  : '/api/v1/contracts';
+
+export function usePlaygroundExecution(): UsePlaygroundExecutionReturn {
+  const [executionState, setExecutionState] = useState<ExecutionState>(makeIdleState);
+  const [compileLogs, setCompileLogs] = useState<CompileLogEntry[]>([]);
+
+  /**
+   * currentIdRef is the authoritative "live" cancellation ID.
+   * Any worker message whose ID does not match is stale and is discarded.
+   */
+  const currentIdRef = useRef<CancellationId | null>(null);
+  const workerRef = useRef<Worker | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // ── Worker lifecycle ──────────────────────────────────────────────────────
+  useEffect(() => {
+    // Dynamically import the worker so Next.js bundles it correctly.
+    const worker = new Worker(
+      new URL('../lib/compiler/compile.worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+
+    const handleMessage = (event: MessageEvent<CancellableWorkerResponse>) => {
+      const msg = event.data;
+      const currentId = currentIdRef.current;
+
+      // Stale-result guard: drop messages that belong to a previous request.
+      if (msg.cancellationId !== currentId) return;
+
+      if (msg.type === 'log') {
+        setCompileLogs((prev) => [...prev, msg.entry]);
+        return;
+      }
+
+      if (msg.type === 'cancelled') {
+        setExecutionState((prev) =>
+          prev.cancellationId === currentId
+            ? transition(prev, 'cancelled')
+            : prev
+        );
+        return;
+      }
+
+      if (msg.type === 'complete') {
+        setExecutionState((prev) =>
+          prev.cancellationId === currentId
+            ? transition(prev, msg.success ? 'complete' : 'error')
+            : prev
+        );
+      }
+    };
+
+    worker.addEventListener('message', handleMessage);
+    workerRef.current = worker;
+
+    return () => {
+      worker.removeEventListener('message', handleMessage);
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // ── compile ───────────────────────────────────────────────────────────────
+  const compile = useCallback((source: string, filePath: string) => {
+    // Already running — prevent double-submit.
+    if (currentIdRef.current !== null) return;
+
+    const cancellationId: CancellationId = crypto.randomUUID();
+    currentIdRef.current = cancellationId;
+    abortControllerRef.current = new AbortController();
+
+    setCompileLogs([]);
+    setExecutionState(transition(makeIdleState(), 'queued', cancellationId));
+
+    if (!workerRef.current) {
+      setExecutionState(transition(makeIdleState(), 'error', cancellationId));
+      currentIdRef.current = null;
+      return;
+    }
+
+    // Move to running state just before we send to the worker.
+    setExecutionState(transition(makeIdleState(), 'running', cancellationId));
+
+    workerRef.current.postMessage({
+      type: 'compile',
+      cancellationId,
+      source,
+      filePath,
+    });
+
+    // Best-effort backend notification — fire and forget, does not block the UI.
+    // We send the ID so the server can register it in its registry and allow
+    // the /cancel endpoint to short-circuit backend execution for future operations.
+    const signal = abortControllerRef.current.signal;
+    fetch(`${API_BASE}/compile`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [CANCELLATION_ID_HEADER]: cancellationId,
+      },
+      body: JSON.stringify({
+        // Minimal body that satisfies the backend schema; frontend compile
+        // is browser-only so the server result is advisory only.
+        sourceCode: source,
+        compilerVersion: '21.0.0',
+        optimization: false,
+        target: 'soroban',
+      }),
+      signal,
+    }).catch(() => {
+      // Network errors are non-fatal for the browser-based compile workflow.
+    });
+  }, []);
+
+  // ── cancel ────────────────────────────────────────────────────────────────
+  const cancel = useCallback(() => {
+    const id = currentIdRef.current;
+    if (!id) return;
+
+    // 1. Tell the worker to stop.
+    workerRef.current?.postMessage({ type: 'cancel', cancellationId: id });
+
+    // 2. Abort any in-flight fetch.
+    abortControllerRef.current?.abort();
+
+    // 3. Notify the backend (fire and forget).
+    fetch(`${API_BASE}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancellationId: id }),
+    }).catch(() => {});
+
+    // 4. Update UI state immediately — don't wait for worker confirmation.
+    setExecutionState((prev) =>
+      prev.cancellationId === id ? transition(prev, 'cancelled') : prev
+    );
+
+    // 5. Clear the current ID so a new compile can start.
+    currentIdRef.current = null;
+  }, []);
+
+  // ── reset ─────────────────────────────────────────────────────────────────
+  const reset = useCallback(() => {
+    currentIdRef.current = null;
+    setCompileLogs([]);
+    setExecutionState(makeIdleState());
+  }, []);
+
+  // When execution reaches a terminal state, unblock the current ID slot so
+  // a new compile can be queued without calling reset().
+  useEffect(() => {
+    const { phase, cancellationId } = executionState;
+    if (
+      (phase === 'complete' || phase === 'error' || phase === 'cancelled') &&
+      cancellationId === currentIdRef.current
+    ) {
+      currentIdRef.current = null;
+    }
+  }, [executionState]);
+
+  return { executionState, compileLogs, compile, cancel, reset };
+}

--- a/frontend/src/lib/compiler/cancellationTypes.ts
+++ b/frontend/src/lib/compiler/cancellationTypes.ts
@@ -1,0 +1,96 @@
+/**
+ * Cancellation and execution lifecycle types for the Playground.
+ *
+ * State machine:
+ *   idle → queued → running → complete
+ *                           ↘ cancelled
+ *                           ↘ error
+ */
+
+/** Unique identifier for a single compile/execute request. */
+export type CancellationId = string;
+
+/** All possible states a playground operation can be in. */
+export type ExecutionPhase =
+  | 'idle'
+  | 'queued'
+  | 'running'
+  | 'complete'
+  | 'cancelled'
+  | 'error';
+
+/** Shape of a live execution state snapshot. */
+export interface ExecutionState {
+  /** The cancellation ID for the current request, or null when idle. */
+  cancellationId: CancellationId | null;
+  /** Current phase of the lifecycle. */
+  phase: ExecutionPhase;
+  /** Human-readable status message shown in the UI. */
+  statusMessage: string;
+  /** Queue position when phase === 'queued' (1-based); null otherwise. */
+  queuePosition: number | null;
+  /** Timestamp when the current state was entered (ms since epoch). */
+  enteredAt: number;
+}
+
+/** Payload sent to the compile worker. */
+export interface CancellableCompileRequest {
+  type: 'compile';
+  cancellationId: CancellationId;
+  source: string;
+  filePath: string;
+}
+
+/** Message from worker to cancel an in-flight compile. */
+export interface WorkerCancelMessage {
+  type: 'cancel';
+  cancellationId: CancellationId;
+}
+
+/** Worker-to-page message carrying cancellation id in every frame. */
+export interface CancellableWorkerLogMessage {
+  type: 'log';
+  cancellationId: CancellationId;
+  entry: import('./compileTypes').CompileLogEntry;
+}
+
+export interface CancellableWorkerCompleteMessage {
+  type: 'complete';
+  cancellationId: CancellationId;
+  success: boolean;
+  warnings: string[];
+  errors: string[];
+  exports: string[];
+  wasmSizeKb: number;
+  durationMs: number;
+}
+
+export interface CancellableWorkerCancelledMessage {
+  type: 'cancelled';
+  cancellationId: CancellationId;
+}
+
+export type CancellableWorkerResponse =
+  | CancellableWorkerLogMessage
+  | CancellableWorkerCompleteMessage
+  | CancellableWorkerCancelledMessage;
+
+export type CancellableWorkerInbound =
+  | CancellableCompileRequest
+  | WorkerCancelMessage;
+
+// ─── Backend cancellation types ───────────────────────────────────────────────
+
+/** Request body for POST /api/v1/contracts/cancel */
+export interface BackendCancelRequest {
+  cancellationId: CancellationId;
+}
+
+/** Response from POST /api/v1/contracts/cancel */
+export interface BackendCancelResponse {
+  status: 'cancelled' | 'not_found' | 'already_complete';
+  cancellationId: CancellationId;
+}
+
+/** Optional header for compile/execute requests. */
+export const CANCELLATION_ID_HEADER = 'x-cancellation-id' as const;

--- a/frontend/src/lib/compiler/compile.worker.ts
+++ b/frontend/src/lib/compiler/compile.worker.ts
@@ -1,9 +1,20 @@
 /// <reference lib="webworker" />
 
-import type { CompileLogEntry, CompileWorkerCompleteMessage, CompileWorkerRequest } from './compileTypes';
+import type { CompileLogEntry, CompileWorkerCompleteMessage } from './compileTypes';
+import type {
+  CancellableCompileRequest,
+  CancellableWorkerCancelledMessage,
+  CancellableWorkerCompleteMessage,
+  CancellableWorkerInbound,
+  CancellableWorkerLogMessage,
+  WorkerCancelMessage,
+} from './cancellationTypes';
 
 type WorkerSelf = typeof self & { postMessage(message: unknown): void };
 const workerSelf = self as WorkerSelf;
+
+/** Set of cancellation IDs that have been cancelled while in-flight. */
+const cancelledIds = new Set<string>();
 
 function formatTimestamp(): string {
   return new Date().toLocaleTimeString();
@@ -18,8 +29,56 @@ function createLog(level: CompileLogEntry['level'], message: string): CompileLog
   };
 }
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function postLog(cancellationId: string, level: CompileLogEntry['level'], message: string): void {
+  const msg: CancellableWorkerLogMessage = {
+    type: 'log',
+    cancellationId,
+    entry: createLog(level, message),
+  };
+  workerSelf.postMessage(msg);
+}
+
+function postComplete(
+  cancellationId: string,
+  payload: Omit<CancellableWorkerCompleteMessage, 'type' | 'cancellationId'>
+): void {
+  const msg: CancellableWorkerCompleteMessage = {
+    type: 'complete',
+    cancellationId,
+    ...payload,
+  };
+  workerSelf.postMessage(msg);
+}
+
+function postCancelled(cancellationId: string): void {
+  const msg: CancellableWorkerCancelledMessage = {
+    type: 'cancelled',
+    cancellationId,
+  };
+  workerSelf.postMessage(msg);
+}
+
+/**
+ * Cancellable sleep — resolves false when the cancellation ID is marked during
+ * the delay, resolves true when the timer fires normally.
+ */
+function sleep(ms: number, cancellationId: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const check = () => {
+      if (cancelledIds.has(cancellationId)) {
+        resolve(false);
+        return;
+      }
+      const elapsed = Date.now() - start;
+      if (elapsed >= ms) {
+        resolve(true);
+      } else {
+        setTimeout(check, Math.min(50, ms - elapsed));
+      }
+    };
+    setTimeout(check, Math.min(50, ms));
+  });
 }
 
 function collectExports(source: string): string[] {
@@ -73,82 +132,103 @@ function estimateWasmSizeKb(source: string) {
   return Math.max(4, Math.min(96, Math.ceil(source.length / 200)));
 }
 
-async function runCompile(request: CompileWorkerRequest) {
-  const { source, filePath } = request;
-  workerSelf.postMessage({ type: 'log', entry: createLog('info', `Starting browser worker compile for ${filePath}`) });
-  await sleep(200);
-  workerSelf.postMessage({ type: 'log', entry: createLog('info', 'Resolving Soroban dependencies...') });
-  await sleep(250);
-  workerSelf.postMessage({ type: 'log', entry: createLog('info', 'Checking Rust target wasm32-unknown-unknown...') });
-  await sleep(350);
-  workerSelf.postMessage({ type: 'log', entry: createLog('info', 'Performing static analysis and WebAssembly emission...') });
-  await sleep(400);
+async function runCompile(request: CancellableCompileRequest): Promise<void> {
+  const { source, filePath, cancellationId } = request;
+
+  const checkCancelled = (): boolean => {
+    if (cancelledIds.has(cancellationId)) {
+      postCancelled(cancellationId);
+      return true;
+    }
+    return false;
+  };
+
+  postLog(cancellationId, 'info', `Starting browser worker compile for ${filePath}`);
+
+  if (!(await sleep(200, cancellationId)) || checkCancelled()) return;
+  postLog(cancellationId, 'info', 'Resolving Soroban dependencies...');
+
+  if (!(await sleep(250, cancellationId)) || checkCancelled()) return;
+  postLog(cancellationId, 'info', 'Checking Rust target wasm32-unknown-unknown...');
+
+  if (!(await sleep(350, cancellationId)) || checkCancelled()) return;
+  postLog(cancellationId, 'info', 'Performing static analysis and WebAssembly emission...');
+
+  if (!(await sleep(400, cancellationId)) || checkCancelled()) return;
 
   const start = performance.now();
   const { errors, warnings, exports } = analyzeSource(source);
   const durationMs = Math.max(120, Math.round(performance.now() - start));
   const wasmSizeKb = estimateWasmSizeKb(source);
 
+  if (checkCancelled()) return;
+
   if (warnings.length > 0) {
     for (const warning of warnings) {
-      workerSelf.postMessage({ type: 'log', entry: createLog('info', `Warning: ${warning}`) });
+      postLog(cancellationId, 'info', `Warning: ${warning}`);
     }
   }
 
   if (errors.length > 0) {
     for (const error of errors) {
-      workerSelf.postMessage({ type: 'log', entry: createLog('error', error) });
+      postLog(cancellationId, 'error', error);
     }
-    workerSelf.postMessage({ type: 'log', entry: createLog('error', 'Browser compile failed. Review the errors above and try again.') });
-    const completeMessage: CompileWorkerCompleteMessage = {
-      type: 'complete',
+    postLog(cancellationId, 'error', 'Browser compile failed. Review the errors above and try again.');
+    postComplete(cancellationId, {
       success: false,
       warnings,
       errors,
       exports,
       wasmSizeKb,
       durationMs,
-    };
-    workerSelf.postMessage(completeMessage);
+    });
     return;
   }
 
-  workerSelf.postMessage({ type: 'log', entry: createLog('success', `Compilation successful. WASM size: ${wasmSizeKb}KB`) });
-  workerSelf.postMessage({ type: 'log', entry: createLog('success', `Contract ready for simulation. Exports: ${exports.length > 0 ? exports.join(', ') : 'none'}.`) });
-  const completeMessage: CompileWorkerCompleteMessage = {
-    type: 'complete',
+  postLog(cancellationId, 'success', `Compilation successful. WASM size: ${wasmSizeKb}KB`);
+  postLog(
+    cancellationId,
+    'success',
+    `Contract ready for simulation. Exports: ${exports.length > 0 ? exports.join(', ') : 'none'}.`
+  );
+  postComplete(cancellationId, {
     success: true,
     warnings,
     errors,
     exports,
     wasmSizeKb,
     durationMs,
-  };
-  workerSelf.postMessage(completeMessage);
+  });
 }
 
-workerSelf.addEventListener('message', async (event: MessageEvent<CompileWorkerRequest>) => {
-  const request = event.data;
-  if (!request || request.type !== 'compile') {
+workerSelf.addEventListener('message', async (event: MessageEvent<CancellableWorkerInbound>) => {
+  const msg = event.data;
+
+  if (msg.type === 'cancel') {
+    cancelledIds.add((msg as WorkerCancelMessage).cancellationId);
     return;
   }
-  try {
-    await runCompile(request);
-  } catch (error) {
-    workerSelf.postMessage({
-      type: 'log',
-      entry: createLog('error', `Unexpected browser compile error: ${error instanceof Error ? error.message : String(error)}`),
-    });
-    workerSelf.postMessage({
-      type: 'complete',
-      success: false,
-      warnings: [],
-      errors: [error instanceof Error ? error.message : String(error)],
-      exports: [],
-      wasmSizeKb: 0,
-      durationMs: 0,
-    });
+
+  if (msg.type === 'compile') {
+    const request = msg as CancellableCompileRequest;
+    try {
+      await runCompile(request);
+    } catch (error) {
+      postLog(
+        request.cancellationId,
+        'error',
+        `Unexpected browser compile error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      postComplete(request.cancellationId, {
+        success: false,
+        warnings: [],
+        errors: [error instanceof Error ? error.message : String(error)],
+        exports: [],
+        wasmSizeKb: 0,
+        durationMs: 0,
+      });
+    }
   }
 });
 
-export { };
+export {};


### PR DESCRIPTION
- Add CancellationRegistry singleton (backend) — register, markRunning, markComplete, cancel, isCancelled with 5-min TTL eviction
- Update POST /contracts/compile and /execute to accept X-Cancellation-Id header; bail early when cancelled before or after heavy work
- Add POST /contracts/cancel endpoint validated with Zod UUID schema
- Add contractCancelSchema to contracts.validation.schemas.ts
- Rewrite compile.worker.ts to carry cancellationId on every message and honour 'cancel' inbound messages via cancellable sleep polling
- Add cancellationTypes.ts — shared state machine types for frontend (ExecutionPhase, ExecutionState, worker message shapes)
- Add usePlaygroundExecution hook — UUID cancellation IDs, AbortController for fetch, stale-result guard on worker messages, backend /cancel notify, terminal-state auto-unblock of ID slot
- Add ExecutionStatusBar component — cancel button, queue indicator, shimmer progress bar, phase badges; role=status/alert, aria-live, aria-busy, role=progressbar, 44px touch targets
- Wire ExecutionStatusBar into playground page replacing raw worker state
- Add shimmer @keyframes to globals.css


closes #938