### PR TITLE
Connect bridge tracker to live SEP status endpoints

### DIFF
--- a/frontend/src/app/bridge-tracker/page.tsx
+++ b/frontend/src/app/bridge-tracker/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
@@ -10,43 +10,19 @@ import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Progress } from '@/components/ui/Progress';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { useBridgeTracker } from '@/lib/bridge/useBridgeTracker';
+import type { BridgeStatus, BridgeTransaction } from '@/lib/bridge/types';
 import {
-  ArrowRightLeft,
-  Clock,
-  CheckCircle,
-  XCircle,
   AlertTriangle,
+  ArrowRightLeft,
+  CheckCircle,
+  Clock,
   ExternalLink,
-  RefreshCw,
   HelpCircle,
   Loader2,
+  RefreshCw,
+  XCircle,
 } from 'lucide-react';
-
-type BridgeStatus =
-  | 'initiated'
-  | 'pending_anchor'
-  | 'on_chain'
-  | 'completed'
-  | 'failed'
-  | 'refunded';
-
-interface BridgeTransaction {
-  id: string;
-  sourceChain: string;
-  targetChain: string;
-  amount: string;
-  asset: string;
-  sender: string;
-  recipient: string;
-  status: BridgeStatus;
-  timestamp: Date;
-  sourceTxHash?: string;
-  targetTxHash?: string;
-  anchorId?: string;
-  errorMessage?: string;
-  refundTxHash?: string;
-  estimatedCompletion?: Date;
-}
 
 interface BridgeStep {
   key: string;
@@ -58,323 +34,85 @@ interface BridgeStep {
   explorerUrl?: string;
 }
 
-const MOCK_TRANSACTIONS: BridgeTransaction[] = [
-  {
-    id: 'bridge_001',
-    sourceChain: 'Stellar',
-    targetChain: 'Ethereum',
-    amount: '100.00',
-    asset: 'USDC',
-    sender: 'GBX...123',
-    recipient: '0x742d...892',
-    status: 'completed',
-    timestamp: new Date(Date.now() - 3600000),
-    sourceTxHash: 'stellar_tx_hash_001',
-    targetTxHash: '0xabcdef123456789',
-    estimatedCompletion: new Date(Date.now() - 1800000),
-  },
-  {
-    id: 'bridge_002',
-    sourceChain: 'Ethereum',
-    targetChain: 'Stellar',
-    amount: '0.5',
-    asset: 'ETH',
-    sender: '0x1234...5678',
-    recipient: 'GDX...456',
-    status: 'on_chain',
-    timestamp: new Date(Date.now() - 1800000),
-    sourceTxHash: '0x123456789abcdef',
-    estimatedCompletion: new Date(Date.now() + 900000),
-  },
-  {
-    id: 'bridge_003',
-    sourceChain: 'Stellar',
-    targetChain: 'Polygon',
-    amount: '250.00',
-    asset: 'USDC',
-    sender: 'GAX...789',
-    recipient: '0x9876...5432',
-    status: 'pending_anchor',
-    timestamp: new Date(Date.now() - 600000),
-    sourceTxHash: 'stellar_tx_hash_003',
-    estimatedCompletion: new Date(Date.now() + 2400000),
-  },
-  {
-    id: 'bridge_004',
-    sourceChain: 'Stellar',
-    targetChain: 'Ethereum',
-    amount: '50.00',
-    asset: 'USDC',
-    sender: 'GTX...321',
-    recipient: '0x5555...6666',
-    status: 'failed',
-    timestamp: new Date(Date.now() - 7200000),
-    sourceTxHash: 'stellar_tx_hash_004',
-    errorMessage: 'Anchor timeout - no response received',
-    refundTxHash: 'stellar_refund_hash_004',
-  },
-];
-
 export default function BridgeTransactionTracker() {
-  const [transactions, setTransactions] = useState<BridgeTransaction[]>(MOCK_TRANSACTIONS);
   const [selectedTransaction, setSelectedTransaction] = useState<BridgeTransaction | null>(null);
   const [searchId, setSearchId] = useState('');
-  const [loading, setLoading] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [showHelpDialog, setShowHelpDialog] = useState(false);
+  const {
+    transactions,
+    loading,
+    refreshing,
+    error,
+    configured,
+    usingLocalFixtures,
+    refresh,
+  } = useBridgeTracker({ autoRefresh });
 
-  // Auto-refresh functionality
   useEffect(() => {
-    if (!autoRefresh) return;
+    if (!selectedTransaction) return;
+    const nextSelected = transactions.find((tx) => tx.id === selectedTransaction.id);
+    if (nextSelected) setSelectedTransaction(nextSelected);
+  }, [selectedTransaction, transactions]);
 
-    const interval = setInterval(async () => {
-      await refreshTransactions();
-    }, 10000); // Refresh every 10 seconds
-
-    return () => clearInterval(interval);
-  }, [autoRefresh]);
-
-  const refreshTransactions = async () => {
-    setLoading(true);
-    try {
-      // TODO: Replace with actual API calls to bridge service
-      // This would poll SEP-24/SEP-6 endpoints for status updates
-
-      // Simulate API call with random status changes
-      setTransactions((prev) =>
-        prev.map((tx) => {
-          if (tx.status === 'pending_anchor' && Math.random() > 0.7) {
-            return { ...tx, status: 'on_chain' as BridgeStatus };
-          }
-          if (tx.status === 'on_chain' && Math.random() > 0.8) {
-            return {
-              ...tx,
-              status: 'completed' as BridgeStatus,
-              targetTxHash: '0x' + Math.random().toString(16).substring(2, 66),
-            };
-          }
-          return tx;
-        })
-      );
-    } catch (error) {
-      console.error('Error refreshing transactions:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const getBridgeSteps = (transaction: BridgeTransaction): BridgeStep[] => {
-    const steps: BridgeStep[] = [
-      {
-        key: 'initiated',
-        title: 'Transaction Initiated',
-        description: 'Bridge transaction started on source chain',
-        status: transaction.status !== 'initiated' ? 'completed' : 'active',
-        timestamp: transaction.timestamp,
-        txHash: transaction.sourceTxHash,
-        explorerUrl: transaction.sourceTxHash
-          ? getExplorerUrl(transaction.sourceChain, transaction.sourceTxHash)
-          : undefined,
-      },
-      {
-        key: 'pending_anchor',
-        title: 'Pending Anchor',
-        description: 'Waiting for anchor to process the transfer',
-        status: getStepStatus(transaction, 'pending_anchor'),
-        timestamp: transaction.status === 'pending_anchor' ? new Date() : undefined,
-      },
-      {
-        key: 'on_chain',
-        title: 'On Target Chain',
-        description: 'Transaction submitted to target chain',
-        status: getStepStatus(transaction, 'on_chain'),
-        txHash: transaction.targetTxHash,
-        explorerUrl: transaction.targetTxHash
-          ? getExplorerUrl(transaction.targetChain, transaction.targetTxHash)
-          : undefined,
-      },
-      {
-        key: 'completed',
-        title: 'Completed',
-        description: 'Bridge transaction completed successfully',
-        status:
-          transaction.status === 'completed'
-            ? 'completed'
-            : transaction.status === 'failed' || transaction.status === 'refunded'
-              ? 'error'
-              : 'pending',
-      },
-    ];
-
-    // Add error step if failed
-    if (transaction.status === 'failed' || transaction.status === 'refunded') {
-      steps.push({
-        key: 'error',
-        title: transaction.status === 'refunded' ? 'Refunded' : 'Failed',
-        description: transaction.errorMessage || 'Transaction failed',
-        status: 'error',
-        txHash: transaction.refundTxHash,
-        explorerUrl: transaction.refundTxHash
-          ? getExplorerUrl(transaction.sourceChain, transaction.refundTxHash)
-          : undefined,
-      });
-    }
-
-    return steps;
-  };
-
-  const getStepStatus = (transaction: BridgeTransaction, stepKey: string): BridgeStep['status'] => {
-    const statusOrder: Record<BridgeStatus, number> = {
-      initiated: 0,
-      pending_anchor: 1,
-      on_chain: 2,
-      completed: 3,
-      failed: -1,
-      refunded: -1,
-    };
-
-    const currentStatusIndex = statusOrder[transaction.status];
-    const stepIndex = statusOrder[stepKey as BridgeStatus] || 0;
-
-    if (transaction.status === 'failed' || transaction.status === 'refunded') {
-      return 'error';
-    }
-
-    if (currentStatusIndex > stepIndex) {
-      return 'completed';
-    } else if (currentStatusIndex === stepIndex) {
-      return 'active';
-    } else {
-      return 'pending';
-    }
-  };
-
-  const getExplorerUrl = (chain: string, txHash: string): string => {
-    const explorers: Record<string, string> = {
-      Stellar: `https://stellar.expert/explorer/testnet/tx/${txHash}`,
-      Ethereum: `https://sepolia.etherscan.io/tx/${txHash}`,
-      Polygon: `https://mumbai.polygonscan.com/tx/${txHash}`,
-      Arbitrum: `https://sepolia.arbiscan.io/tx/${txHash}`,
-      Optimism: `https://sepolia-optimism.etherscan.io/tx/${txHash}`,
-    };
-    return explorers[chain] || '#';
-  };
-
-  const getStatusColor = (status: BridgeStatus): string => {
-    switch (status) {
-      case 'completed':
-        return 'bg-green-500';
-      case 'on_chain':
-        return 'bg-blue-500';
-      case 'pending_anchor':
-        return 'bg-yellow-500';
-      case 'initiated':
-        return 'bg-gray-500';
-      case 'failed':
-        return 'bg-red-500';
-      case 'refunded':
-        return 'bg-orange-500';
-      default:
-        return 'bg-gray-500';
-    }
-  };
-
-  const getStatusIcon = (status: BridgeStatus) => {
-    switch (status) {
-      case 'completed':
-        return <CheckCircle className="h-4 w-4 text-green-600" />;
-      case 'on_chain':
-        return <Loader2 className="h-4 w-4 text-blue-600 animate-spin" />;
-      case 'pending_anchor':
-        return <Clock className="h-4 w-4 text-yellow-600" />;
-      case 'initiated':
-        return <Clock className="h-4 w-4 text-gray-600" />;
-      case 'failed':
-        return <XCircle className="h-4 w-4 text-red-600" />;
-      case 'refunded':
-        return <AlertTriangle className="h-4 w-4 text-orange-600" />;
-      default:
-        return <Clock className="h-4 w-4 text-gray-600" />;
-    }
-  };
-
-  const getProgressPercentage = (transaction: BridgeTransaction): number => {
-    const statusProgress: Record<BridgeStatus, number> = {
-      initiated: 25,
-      pending_anchor: 50,
-      on_chain: 75,
-      completed: 100,
-      failed: 0,
-      refunded: 0,
-    };
-    return statusProgress[transaction.status];
-  };
-
-  const filteredTransactions = transactions.filter(
-    (tx) =>
-      tx.id.toLowerCase().includes(searchId.toLowerCase()) ||
-      tx.sender.toLowerCase().includes(searchId.toLowerCase()) ||
-      tx.recipient.toLowerCase().includes(searchId.toLowerCase())
-  );
+  const filteredTransactions = transactions.filter((tx) => {
+    const query = searchId.toLowerCase();
+    return (
+      tx.id.toLowerCase().includes(query) ||
+      tx.sender.toLowerCase().includes(query) ||
+      tx.recipient.toLowerCase().includes(query)
+    );
+  });
 
   const selectedSteps = selectedTransaction ? getBridgeSteps(selectedTransaction) : [];
 
   return (
     <div className="container mx-auto py-8 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
           <h1 className="text-3xl font-bold">Cross-Chain Bridge Tracker</h1>
           <p className="text-muted-foreground">
-            Monitor the status of your cross-chain bridge transactions
+            Monitor live bridge status data from configured SEP-6, SEP-24, or compatible endpoints
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setAutoRefresh(!autoRefresh)}>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setAutoRefresh((value) => !value)}>
             <RefreshCw className={`mr-2 h-4 w-4 ${autoRefresh ? 'animate-spin' : ''}`} />
             {autoRefresh ? 'Auto-refreshing' : 'Auto-refresh'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => void refresh()} disabled={refreshing}>
+            {refreshing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            Refresh
+          </Button>
+          <Button variant="ghost" size="icon" onClick={() => setShowHelpDialog(true)}>
+            <HelpCircle className="h-4 w-4" />
           </Button>
           <Dialog open={showHelpDialog} onOpenChange={setShowHelpDialog}>
             <DialogContent>
               <DialogHeader>
                 <DialogTitle>Bridge Transaction Help</DialogTitle>
                 <p className="text-sm text-muted-foreground mt-2">
-                  Learn how to track your cross-chain bridge transactions
+                  Track transactions from anchor `/transactions` and `/transaction` endpoints.
                 </p>
               </DialogHeader>
               <div className="space-y-4">
                 <div>
-                  <h4 className="font-semibold">Transaction Statuses</h4>
+                  <h4 className="font-semibold">Status Mapping</h4>
                   <ul className="text-sm text-muted-foreground space-y-1">
-                    <li>
-                      • <strong>Initiated:</strong> Transaction started on source chain
-                    </li>
-                    <li>
-                      • <strong>Pending Anchor:</strong> Waiting for anchor processing
-                    </li>
-                    <li>
-                      • <strong>On Chain:</strong> Submitted to target chain
-                    </li>
-                    <li>
-                      • <strong>Completed:</strong> Successfully bridged
-                    </li>
-                    <li>
-                      • <strong>Failed:</strong> Transaction failed
-                    </li>
-                    <li>
-                      • <strong>Refunded:</strong> Funds were refunded
-                    </li>
+                    <li>Pending anchor statuses map to Pending Anchor.</li>
+                    <li>Pending Stellar or external network statuses map to On Chain.</li>
+                    <li>Completed, failed, and refunded statuses map directly.</li>
                   </ul>
                 </div>
                 <div>
-                  <h4 className="font-semibold">Explorer Links</h4>
+                  <h4 className="font-semibold">Configuration</h4>
                   <p className="text-sm text-muted-foreground">
-                    Click on transaction hashes to view them on the respective blockchain explorers.
-                  </p>
-                </div>
-                <div>
-                  <h4 className="font-semibold">Estimated Completion</h4>
-                  <p className="text-sm text-muted-foreground">
-                    Completion times are estimates based on network conditions and may vary.
+                    Set NEXT_PUBLIC_BRIDGE_ENDPOINTS to a JSON array of bridge endpoint configs.
+                    Local fixtures are only shown during development when no endpoints are present.
                   </p>
                 </div>
               </div>
@@ -383,8 +121,23 @@ export default function BridgeTransactionTracker() {
         </div>
       </div>
 
+      {!configured && usingLocalFixtures && (
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Local development fixtures are shown because no bridge endpoint is configured.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <XCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Transaction List */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -400,49 +153,62 @@ export default function BridgeTransactionTracker() {
                 id="search"
                 placeholder="Transaction ID or address..."
                 value={searchId}
-                onChange={(e) => setSearchId(e.target.value)}
+                onChange={(event) => setSearchId(event.target.value)}
               />
             </div>
 
             <div className="space-y-2 max-h-96 overflow-y-auto">
-              {filteredTransactions.map((transaction) => (
-                <div
-                  key={transaction.id}
-                  className={`p-3 border rounded-lg cursor-pointer transition-colors ${
-                    selectedTransaction?.id === transaction.id
-                      ? 'border-primary bg-primary/5'
-                      : 'border-border hover:bg-muted/50'
-                  }`}
-                  onClick={() => setSelectedTransaction(transaction)}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      {getStatusIcon(transaction.status)}
-                      <span className="font-semibold text-sm">{transaction.id}</span>
-                    </div>
-                    <Badge variant="secondary" className="text-xs">
-                      {transaction.status.replace('_', ' ')}
-                    </Badge>
-                  </div>
-                  <div className="text-xs text-muted-foreground space-y-1">
-                    <div>
-                      {transaction.amount} {transaction.asset}
-                    </div>
-                    <div>
-                      {transaction.sourceChain} → {transaction.targetChain}
-                    </div>
-                    <div>{transaction.timestamp.toLocaleTimeString()}</div>
-                  </div>
-                  <div className="mt-2">
-                    <Progress value={getProgressPercentage(transaction)} className="h-1" />
-                  </div>
+              {loading ? (
+                <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading live bridge statuses
                 </div>
-              ))}
+              ) : filteredTransactions.length === 0 ? (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  {transactions.length === 0
+                    ? 'No bridge transactions found.'
+                    : 'No bridge transactions match your search.'}
+                </div>
+              ) : (
+                filteredTransactions.map((transaction) => (
+                  <div
+                    key={transaction.id}
+                    className={`p-3 border rounded-lg cursor-pointer transition-colors ${
+                      selectedTransaction?.id === transaction.id
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:bg-muted/50'
+                    }`}
+                    onClick={() => setSelectedTransaction(transaction)}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        {getStatusIcon(transaction.status)}
+                        <span className="font-semibold text-sm">{transaction.id}</span>
+                      </div>
+                      <Badge variant="secondary" className="text-xs">
+                        {transaction.status.replace('_', ' ')}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground space-y-1">
+                      <div>
+                        {transaction.amount} {transaction.asset}
+                      </div>
+                      <div>
+                        {transaction.sourceChain} to {transaction.targetChain}
+                      </div>
+                      {transaction.serviceName && <div>{transaction.serviceName}</div>}
+                      <div>{transaction.timestamp.toLocaleTimeString()}</div>
+                    </div>
+                    <div className="mt-2">
+                      <Progress value={getProgressPercentage(transaction)} className="h-1" />
+                    </div>
+                  </div>
+                ))
+              )}
             </div>
           </CardContent>
         </Card>
 
-        {/* Transaction Details */}
         <div className="lg:col-span-2">
           {selectedTransaction ? (
             <Card>
@@ -454,6 +220,7 @@ export default function BridgeTransactionTracker() {
                 <CardDescription>
                   {selectedTransaction.amount} {selectedTransaction.asset} from{' '}
                   {selectedTransaction.sourceChain} to {selectedTransaction.targetChain}
+                  {selectedTransaction.rawStatus ? ` (${selectedTransaction.rawStatus})` : ''}
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -506,7 +273,7 @@ export default function BridgeTransactionTracker() {
                                 {step.timestamp.toLocaleString()}
                               </div>
                             )}
-                            {step.txHash && (
+                            {step.txHash && step.explorerUrl && (
                               <div className="mt-2">
                                 <Button variant="outline" size="sm" asChild>
                                   <a
@@ -530,7 +297,7 @@ export default function BridgeTransactionTracker() {
                       <Alert>
                         <Clock className="h-4 w-4" />
                         <AlertDescription>
-                          Estimated completion:{' '}
+                          User action required by:{' '}
                           {selectedTransaction.estimatedCompletion.toLocaleString()}
                         </AlertDescription>
                       </Alert>
@@ -538,11 +305,8 @@ export default function BridgeTransactionTracker() {
                   </TabsContent>
 
                   <TabsContent value="details" className="space-y-4">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <Label>Transaction ID</Label>
-                        <p className="font-mono text-sm">{selectedTransaction.id}</p>
-                      </div>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <Detail label="Transaction ID" value={selectedTransaction.id} mono />
                       <div>
                         <Label>Status</Label>
                         <div className="flex items-center gap-2">
@@ -552,32 +316,21 @@ export default function BridgeTransactionTracker() {
                           </span>
                         </div>
                       </div>
-                      <div>
-                        <Label>Amount</Label>
-                        <p className="font-semibold">
-                          {selectedTransaction.amount} {selectedTransaction.asset}
-                        </p>
-                      </div>
-                      <div>
-                        <Label>Started</Label>
-                        <p>{selectedTransaction.timestamp.toLocaleString()}</p>
-                      </div>
-                      <div>
-                        <Label>Source Chain</Label>
-                        <p>{selectedTransaction.sourceChain}</p>
-                      </div>
-                      <div>
-                        <Label>Target Chain</Label>
-                        <p>{selectedTransaction.targetChain}</p>
-                      </div>
-                      <div>
-                        <Label>Sender</Label>
-                        <p className="font-mono text-sm">{selectedTransaction.sender}</p>
-                      </div>
-                      <div>
-                        <Label>Recipient</Label>
-                        <p className="font-mono text-sm">{selectedTransaction.recipient}</p>
-                      </div>
+                      {selectedTransaction.serviceName && (
+                        <Detail label="Bridge Service" value={selectedTransaction.serviceName} />
+                      )}
+                      {selectedTransaction.protocol && (
+                        <Detail label="Protocol" value={selectedTransaction.protocol.toUpperCase()} />
+                      )}
+                      <Detail
+                        label="Amount"
+                        value={`${selectedTransaction.amount} ${selectedTransaction.asset}`}
+                      />
+                      <Detail label="Started" value={selectedTransaction.timestamp.toLocaleString()} />
+                      <Detail label="Source Chain" value={selectedTransaction.sourceChain} />
+                      <Detail label="Target Chain" value={selectedTransaction.targetChain} />
+                      <Detail label="Sender" value={selectedTransaction.sender} mono />
+                      <Detail label="Recipient" value={selectedTransaction.recipient} mono />
                     </div>
 
                     {selectedTransaction.errorMessage && (
@@ -589,97 +342,28 @@ export default function BridgeTransactionTracker() {
                   </TabsContent>
 
                   <TabsContent value="explorers" className="space-y-4">
-                    <div className="space-y-3">
-                      {selectedTransaction.sourceTxHash && (
-                        <div className="flex items-center justify-between p-3 border rounded-lg">
-                          <div>
-                            <div className="font-semibold">Source Transaction</div>
-                            <div className="text-sm text-muted-foreground">
-                              {selectedTransaction.sourceChain}
-                            </div>
-                            <div className="font-mono text-xs mt-1">
-                              {selectedTransaction.sourceTxHash}
-                            </div>
-                          </div>
-                          {selectedTransaction.sourceTxHash && selectedTransaction.sourceChain && (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                const url = getExplorerUrl(
-                                  selectedTransaction.sourceChain,
-                                  selectedTransaction.sourceTxHash ?? ''
-                                );
-                                if (url) window.open(url, '_blank');
-                              }}
-                            >
-                              <ExternalLink className="h-4 w-4 mr-2" />
-                              View
-                            </Button>
-                          )}
+                    <ExplorerRow
+                      label="Source Transaction"
+                      chain={selectedTransaction.sourceChain}
+                      txHash={selectedTransaction.sourceTxHash}
+                    />
+                    <ExplorerRow
+                      label="Target Transaction"
+                      chain={selectedTransaction.targetChain}
+                      txHash={selectedTransaction.targetTxHash}
+                    />
+                    <ExplorerRow
+                      label="Refund Transaction"
+                      chain={selectedTransaction.sourceChain}
+                      txHash={selectedTransaction.refundTxHash}
+                    />
+                    {!selectedTransaction.sourceTxHash &&
+                      !selectedTransaction.targetTxHash &&
+                      !selectedTransaction.refundTxHash && (
+                        <div className="py-6 text-center text-sm text-muted-foreground">
+                          No explorer transactions are available yet.
                         </div>
                       )}
-
-                      {selectedTransaction.targetTxHash && selectedTransaction.targetChain && (
-                        <div className="flex items-center justify-between p-3 border rounded-lg">
-                          <div>
-                            <div className="font-semibold">Target Transaction</div>
-                            <div className="text-sm text-muted-foreground">
-                              {selectedTransaction.targetChain}
-                            </div>
-                            <div className="font-mono text-xs mt-1">
-                              {selectedTransaction.targetTxHash}
-                            </div>
-                          </div>
-                          {selectedTransaction.targetTxHash && selectedTransaction.targetChain && (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                const url = getExplorerUrl(
-                                  selectedTransaction.targetChain,
-                                  selectedTransaction.targetTxHash ?? ''
-                                );
-                                if (url) window.open(url, '_blank');
-                              }}
-                            >
-                              <ExternalLink className="h-4 w-4 mr-2" />
-                              View
-                            </Button>
-                          )}
-                        </div>
-                      )}
-
-                      {selectedTransaction.refundTxHash && selectedTransaction.sourceChain && (
-                        <div className="flex items-center justify-between p-3 border rounded-lg">
-                          <div>
-                            <div className="font-semibold">Refund Transaction</div>
-                            <div className="text-sm text-muted-foreground">
-                              {selectedTransaction.sourceChain}
-                            </div>
-                            <div className="font-mono text-xs mt-1">
-                              {selectedTransaction.refundTxHash}
-                            </div>
-                          </div>
-                          {selectedTransaction.refundTxHash && selectedTransaction.sourceChain && (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                const url = getExplorerUrl(
-                                  selectedTransaction.sourceChain,
-                                  selectedTransaction.refundTxHash ?? ''
-                                );
-                                if (url) window.open(url, '_blank');
-                              }}
-                            >
-                              <ExternalLink className="h-4 w-4 mr-2" />
-                              View
-                            </Button>
-                          )}
-                        </div>
-                      )}
-                    </div>
                   </TabsContent>
                 </Tabs>
               </CardContent>
@@ -698,4 +382,165 @@ export default function BridgeTransactionTracker() {
       </div>
     </div>
   );
+}
+
+function Detail({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <Label>{label}</Label>
+      <p className={mono ? 'font-mono text-sm break-all' : 'text-sm'}>{value}</p>
+    </div>
+  );
+}
+
+function ExplorerRow({
+  label,
+  chain,
+  txHash,
+}: {
+  label: string;
+  chain: string;
+  txHash?: string;
+}) {
+  if (!txHash) return null;
+
+  const url = getExplorerUrl(chain, txHash);
+
+  return (
+    <div className="flex items-center justify-between gap-3 p-3 border rounded-lg">
+      <div className="min-w-0">
+        <div className="font-semibold">{label}</div>
+        <div className="text-sm text-muted-foreground">{chain}</div>
+        <div className="font-mono text-xs mt-1 break-all">{txHash}</div>
+      </div>
+      <Button variant="outline" size="sm" asChild>
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          <ExternalLink className="h-4 w-4 mr-2" />
+          View
+        </a>
+      </Button>
+    </div>
+  );
+}
+
+function getBridgeSteps(transaction: BridgeTransaction): BridgeStep[] {
+  const steps: BridgeStep[] = [
+    {
+      key: 'initiated',
+      title: 'Transaction Initiated',
+      description: 'Bridge transaction was created by the anchor or bridge service',
+      status: transaction.status !== 'initiated' ? 'completed' : 'active',
+      timestamp: transaction.timestamp,
+      txHash: transaction.sourceTxHash,
+      explorerUrl: transaction.sourceTxHash
+        ? getExplorerUrl(transaction.sourceChain, transaction.sourceTxHash)
+        : undefined,
+    },
+    {
+      key: 'pending_anchor',
+      title: 'Pending Anchor',
+      description: 'Waiting for anchor or bridge processing',
+      status: getStepStatus(transaction, 'pending_anchor'),
+    },
+    {
+      key: 'on_chain',
+      title: 'On Chain',
+      description: 'Waiting for Stellar or external-network settlement',
+      status: getStepStatus(transaction, 'on_chain'),
+      txHash: transaction.targetTxHash,
+      explorerUrl: transaction.targetTxHash
+        ? getExplorerUrl(transaction.targetChain, transaction.targetTxHash)
+        : undefined,
+    },
+    {
+      key: 'completed',
+      title: 'Completed',
+      description: 'Bridge transaction completed successfully',
+      status:
+        transaction.status === 'completed'
+          ? 'completed'
+          : transaction.status === 'failed' || transaction.status === 'refunded'
+            ? 'error'
+            : 'pending',
+    },
+  ];
+
+  if (transaction.status === 'failed' || transaction.status === 'refunded') {
+    steps.push({
+      key: 'error',
+      title: transaction.status === 'refunded' ? 'Refunded' : 'Failed',
+      description: transaction.errorMessage || 'Transaction did not complete successfully',
+      status: 'error',
+      txHash: transaction.refundTxHash,
+      explorerUrl: transaction.refundTxHash
+        ? getExplorerUrl(transaction.sourceChain, transaction.refundTxHash)
+        : undefined,
+    });
+  }
+
+  return steps;
+}
+
+function getStepStatus(transaction: BridgeTransaction, stepKey: BridgeStatus): BridgeStep['status'] {
+  const statusOrder: Record<BridgeStatus, number> = {
+    initiated: 0,
+    pending_anchor: 1,
+    on_chain: 2,
+    completed: 3,
+    failed: -1,
+    refunded: -1,
+  };
+
+  if (transaction.status === 'failed' || transaction.status === 'refunded') {
+    return 'error';
+  }
+
+  const currentStatusIndex = statusOrder[transaction.status];
+  const stepIndex = statusOrder[stepKey];
+
+  if (currentStatusIndex > stepIndex) return 'completed';
+  if (currentStatusIndex === stepIndex) return 'active';
+  return 'pending';
+}
+
+function getExplorerUrl(chain: string, txHash: string): string {
+  const explorers: Record<string, string> = {
+    Stellar: `https://stellar.expert/explorer/testnet/tx/${txHash}`,
+    Ethereum: `https://sepolia.etherscan.io/tx/${txHash}`,
+    Polygon: `https://mumbai.polygonscan.com/tx/${txHash}`,
+    Arbitrum: `https://sepolia.arbiscan.io/tx/${txHash}`,
+    Optimism: `https://sepolia-optimism.etherscan.io/tx/${txHash}`,
+  };
+  return explorers[chain] || '#';
+}
+
+function getStatusIcon(status: BridgeStatus) {
+  switch (status) {
+    case 'completed':
+      return <CheckCircle className="h-4 w-4 text-green-600" />;
+    case 'on_chain':
+      return <Loader2 className="h-4 w-4 text-blue-600 animate-spin" />;
+    case 'pending_anchor':
+      return <Clock className="h-4 w-4 text-yellow-600" />;
+    case 'initiated':
+      return <Clock className="h-4 w-4 text-gray-600" />;
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-red-600" />;
+    case 'refunded':
+      return <AlertTriangle className="h-4 w-4 text-orange-600" />;
+    default:
+      return <Clock className="h-4 w-4 text-gray-600" />;
+  }
+}
+
+function getProgressPercentage(transaction: BridgeTransaction): number {
+  const statusProgress: Record<BridgeStatus, number> = {
+    initiated: 25,
+    pending_anchor: 50,
+    on_chain: 75,
+    completed: 100,
+    failed: 0,
+    refunded: 0,
+  };
+  return statusProgress[transaction.status];
 }

--- a/frontend/src/lib/bridge/__tests__/bridgeService.test.ts
+++ b/frontend/src/lib/bridge/__tests__/bridgeService.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapRawBridgeTransaction,
+  mapSepStatusToBridgeStatus,
+  parseBridgeEndpointConfig,
+  validateTransactionId,
+} from '../bridgeService';
+
+const endpoint = {
+  id: 'test-anchor',
+  label: 'Test Anchor',
+  protocol: 'sep24' as const,
+  baseUrl: 'https://anchor.example',
+  assetCode: 'USDC',
+  network: 'Test bridge',
+};
+
+describe('bridge service status mapping', () => {
+  it('maps SEP pending, completed, failed, and refunded states', () => {
+    expect(mapSepStatusToBridgeStatus('pending_anchor')).toBe('pending_anchor');
+    expect(mapSepStatusToBridgeStatus('pending_external')).toBe('on_chain');
+    expect(mapSepStatusToBridgeStatus('completed')).toBe('completed');
+    expect(mapSepStatusToBridgeStatus('error')).toBe('failed');
+    expect(mapSepStatusToBridgeStatus('expired')).toBe('failed');
+    expect(mapSepStatusToBridgeStatus('refunded')).toBe('refunded');
+  });
+
+  it('maps SEP transaction payloads into tracker transactions', () => {
+    const transaction = mapRawBridgeTransaction(
+      {
+        id: 'tx-123',
+        kind: 'withdrawal',
+        status: 'pending_external',
+        amount_in: '25',
+        asset_code: 'USDC',
+        from: 'GABC',
+        to: '0xabc',
+        started_at: '2026-07-30T12:00:00Z',
+        stellar_transaction_id: 'stellar-hash',
+        external_transaction_id: 'external-hash',
+      },
+      endpoint
+    );
+
+    expect(transaction).toMatchObject({
+      id: 'tx-123',
+      status: 'on_chain',
+      amount: '25',
+      asset: 'USDC',
+      sourceChain: 'Stellar',
+      targetChain: 'Test bridge',
+      sourceTxHash: 'stellar-hash',
+      targetTxHash: 'external-hash',
+    });
+  });
+
+  it('rejects invalid transaction identifiers', () => {
+    expect(() => validateTransactionId('../../../etc/passwd')).toThrow(
+      /Invalid bridge transaction identifier/
+    );
+  });
+
+  it('parses JSON bridge endpoint configuration', () => {
+    const config = parseBridgeEndpointConfig(
+      JSON.stringify([
+        {
+          id: 'anchor',
+          label: 'Anchor',
+          protocol: 'sep6',
+          baseUrl: 'https://anchor.example/',
+          assetCode: 'USDC',
+        },
+      ])
+    );
+
+    expect(config).toEqual([
+      {
+        id: 'anchor',
+        label: 'Anchor',
+        protocol: 'sep6',
+        baseUrl: 'https://anchor.example',
+        assetCode: 'USDC',
+        authToken: undefined,
+        network: undefined,
+        pollIntervalMs: undefined,
+      },
+    ]);
+  });
+});

--- a/frontend/src/lib/bridge/__tests__/useBridgeTracker.test.tsx
+++ b/frontend/src/lib/bridge/__tests__/useBridgeTracker.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBridgeTracker } from '../useBridgeTracker';
+import type { BridgeStatusService, BridgeTransaction } from '../types';
+
+const endpoint = {
+  id: 'anchor',
+  label: 'Anchor',
+  protocol: 'sep24' as const,
+  baseUrl: 'https://anchor.example',
+  pollIntervalMs: 5000,
+};
+
+const transaction: BridgeTransaction = {
+  id: 'tx-1',
+  sourceChain: 'Anchor',
+  targetChain: 'Stellar',
+  amount: '10',
+  asset: 'USDC',
+  sender: 'sender',
+  recipient: 'recipient',
+  status: 'pending_anchor',
+  timestamp: new Date('2026-07-30T12:00:00Z'),
+};
+
+describe('useBridgeTracker polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls configured bridge services and skips duplicate in-flight requests', async () => {
+    let resolveFirst: (value: BridgeTransaction[]) => void = () => {};
+    const firstRequest = new Promise<BridgeTransaction[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const service: BridgeStatusService = {
+      listTransactions: vi.fn(() => firstRequest),
+      getTransactionStatus: vi.fn(),
+    };
+    const endpoints = [endpoint];
+
+    const { result } = renderHook(() =>
+      useBridgeTracker({ endpoints, service, autoRefresh: true })
+    );
+
+    const initialCalls = vi.mocked(service.listTransactions).mock.calls.length;
+    expect(initialCalls).toBeGreaterThan(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(service.listTransactions).toHaveBeenCalledTimes(initialCalls);
+
+    await act(async () => {
+      resolveFirst([transaction]);
+      await firstRequest;
+    });
+    expect(result.current.transactions).toHaveLength(1);
+
+    vi.mocked(service.listTransactions).mockResolvedValue([transaction]);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(service.listTransactions).toHaveBeenCalledTimes(initialCalls + 1);
+  });
+
+  it('aborts polling requests on unmount', () => {
+    const signals: AbortSignal[] = [];
+    const service: BridgeStatusService = {
+      listTransactions: vi.fn((_endpoints, signal) => {
+        if (signal) signals.push(signal);
+        return new Promise<BridgeTransaction[]>(() => {});
+      }),
+      getTransactionStatus: vi.fn(),
+    };
+    const endpoints = [endpoint];
+
+    const { unmount } = renderHook(() =>
+      useBridgeTracker({ endpoints, service, autoRefresh: true })
+    );
+
+    unmount();
+
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+});

--- a/frontend/src/lib/bridge/bridgeService.ts
+++ b/frontend/src/lib/bridge/bridgeService.ts
@@ -1,0 +1,323 @@
+import type {
+  BridgeEndpointConfig,
+  BridgeProtocol,
+  BridgeStatus,
+  BridgeStatusService,
+  BridgeTransaction,
+} from './types';
+
+type RawBridgeTransaction = Record<string, unknown>;
+
+const DEFAULT_POLL_INTERVAL_MS = 15000;
+const SUPPORTED_PROTOCOLS = new Set<BridgeProtocol>(['sep6', 'sep24', 'compatible']);
+const VALID_TRANSACTION_ID = /^[A-Za-z0-9:_-]{3,128}$/;
+
+const FAILED_STATUSES = new Set([
+  'error',
+  'expired',
+  'no_market',
+  'too_small',
+  'too_large',
+]);
+
+const PENDING_ANCHOR_STATUSES = new Set([
+  'pending_anchor',
+  'pending_trust',
+  'pending_user',
+  'pending_user_transfer_start',
+  'pending_user_transfer_complete',
+  'pending_sender',
+  'pending_receiver',
+  'pending_transaction_info_update',
+  'pending_customer_info_update',
+]);
+
+export class BridgeServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'invalid_config'
+      | 'invalid_transaction_id'
+      | 'unsupported_network'
+      | 'service_unavailable'
+      | 'invalid_response'
+  ) {
+    super(message);
+  }
+}
+
+export function getDefaultPollIntervalMs(endpoints: BridgeEndpointConfig[]): number {
+  const configured = endpoints
+    .map((endpoint) => endpoint.pollIntervalMs)
+    .filter((value): value is number => typeof value === 'number' && value >= 5000);
+
+  return configured.length > 0 ? Math.min(...configured) : DEFAULT_POLL_INTERVAL_MS;
+}
+
+export function parseBridgeEndpointConfig(raw = process.env.NEXT_PUBLIC_BRIDGE_ENDPOINTS || '') {
+  if (!raw.trim()) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as BridgeEndpointConfig[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(normalizeEndpointConfig).filter(Boolean) as BridgeEndpointConfig[];
+  } catch {
+    return raw
+      .split(';')
+      .map((entry, index) => {
+        const [protocol, baseUrl, assetCode, label] = entry.split('|').map((part) => part.trim());
+        if (!protocol || !baseUrl) return null;
+        return normalizeEndpointConfig({
+          id: `bridge-${index + 1}`,
+          label: label || baseUrl,
+          protocol,
+          baseUrl,
+          assetCode,
+        });
+      })
+      .filter(Boolean) as BridgeEndpointConfig[];
+  }
+}
+
+function normalizeEndpointConfig(config: Partial<BridgeEndpointConfig>): BridgeEndpointConfig | null {
+  if (!config.protocol || !SUPPORTED_PROTOCOLS.has(config.protocol as BridgeProtocol)) {
+    return null;
+  }
+
+  if (!config.baseUrl) return null;
+
+  return {
+    id: config.id || `${config.protocol}:${config.baseUrl}`,
+    label: config.label || config.baseUrl,
+    protocol: config.protocol as BridgeProtocol,
+    baseUrl: config.baseUrl.replace(/\/+$/, ''),
+    assetCode: config.assetCode,
+    network: config.network,
+    authToken: config.authToken,
+    pollIntervalMs: config.pollIntervalMs,
+  };
+}
+
+export function mapSepStatusToBridgeStatus(status: string | undefined): BridgeStatus {
+  const normalized = status?.toLowerCase();
+
+  if (!normalized || normalized === 'incomplete') return 'initiated';
+  if (normalized === 'completed') return 'completed';
+  if (normalized === 'refunded') return 'refunded';
+  if (normalized === 'pending_external' || normalized === 'pending_stellar') return 'on_chain';
+  if (FAILED_STATUSES.has(normalized)) return 'failed';
+  if (PENDING_ANCHOR_STATUSES.has(normalized)) return 'pending_anchor';
+
+  return 'pending_anchor';
+}
+
+export function validateTransactionId(transactionId: string) {
+  if (!VALID_TRANSACTION_ID.test(transactionId)) {
+    throw new BridgeServiceError('Invalid bridge transaction identifier.', 'invalid_transaction_id');
+  }
+}
+
+export function mapRawBridgeTransaction(
+  raw: RawBridgeTransaction,
+  endpoint: BridgeEndpointConfig
+): BridgeTransaction {
+  const id = stringValue(raw.id) || stringValue(raw.transaction_id) || stringValue(raw.memo);
+  if (!id) {
+    throw new BridgeServiceError('Bridge endpoint returned a transaction without an id.', 'invalid_response');
+  }
+
+  const kind = stringValue(raw.kind) || 'transfer';
+  const rawStatus = stringValue(raw.status);
+  const status = mapSepStatusToBridgeStatus(rawStatus);
+  const sourceTxHash =
+    stringValue(raw.stellar_transaction_id) ||
+    stringValue(raw.stellarTransactionId) ||
+    stringValue(raw.from_tx_hash);
+  const targetTxHash =
+    stringValue(raw.external_transaction_id) ||
+    stringValue(raw.externalTransactionId) ||
+    stringValue(raw.to_tx_hash);
+
+  return {
+    id,
+    sourceChain: inferSourceChain(kind, endpoint),
+    targetChain: inferTargetChain(kind, endpoint),
+    amount:
+      stringValue(raw.amount_in) ||
+      stringValue(raw.amount_out) ||
+      stringValue(raw.amount) ||
+      'Unknown',
+    asset:
+      stringValue(raw.asset_code) ||
+      stringValue(raw.assetCode) ||
+      endpoint.assetCode ||
+      'Asset',
+    sender: stringValue(raw.from) || stringValue(raw.sender) || 'Unknown',
+    recipient: stringValue(raw.to) || stringValue(raw.recipient) || 'Unknown',
+    status,
+    timestamp: dateValue(raw.started_at) || dateValue(raw.created_at) || new Date(),
+    sourceTxHash,
+    targetTxHash,
+    anchorId: stringValue(raw.id),
+    errorMessage:
+      status === 'failed' || status === 'refunded' ? stringValue(raw.message) : undefined,
+    refundTxHash: firstRefundHash(raw),
+    estimatedCompletion: dateValue(raw.user_action_required_by),
+    serviceName: endpoint.label,
+    protocol: endpoint.protocol,
+    rawStatus,
+  };
+}
+
+export class HttpBridgeStatusService implements BridgeStatusService {
+  async listTransactions(
+    endpoints: BridgeEndpointConfig[],
+    signal?: AbortSignal
+  ): Promise<BridgeTransaction[]> {
+    const transactions = await Promise.all(
+      endpoints.map((endpoint) => this.fetchEndpointTransactions(endpoint, signal))
+    );
+
+    return transactions.flat().sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  }
+
+  async getTransactionStatus(
+    endpoint: BridgeEndpointConfig,
+    transactionId: string,
+    signal?: AbortSignal
+  ): Promise<BridgeTransaction> {
+    validateEndpoint(endpoint);
+    validateTransactionId(transactionId);
+
+    const url = buildEndpointUrl(endpoint.baseUrl, '/transaction');
+    url.searchParams.set('id', transactionId);
+    if (endpoint.assetCode) url.searchParams.set('asset_code', endpoint.assetCode);
+
+    const payload = await fetchJson(url, endpoint, signal);
+    const raw = extractSingleTransaction(payload);
+    return mapRawBridgeTransaction(raw, endpoint);
+  }
+
+  private async fetchEndpointTransactions(
+    endpoint: BridgeEndpointConfig,
+    signal?: AbortSignal
+  ): Promise<BridgeTransaction[]> {
+    validateEndpoint(endpoint);
+
+    const url = buildEndpointUrl(endpoint.baseUrl, '/transactions');
+    if (endpoint.assetCode) url.searchParams.set('asset_code', endpoint.assetCode);
+
+    const payload = await fetchJson(url, endpoint, signal);
+    return extractTransactions(payload).map((transaction) =>
+      mapRawBridgeTransaction(transaction, endpoint)
+    );
+  }
+}
+
+export const bridgeStatusService = new HttpBridgeStatusService();
+
+function validateEndpoint(endpoint: BridgeEndpointConfig) {
+  if (!SUPPORTED_PROTOCOLS.has(endpoint.protocol)) {
+    throw new BridgeServiceError(`Unsupported bridge protocol: ${endpoint.protocol}`, 'invalid_config');
+  }
+
+  try {
+    new URL(endpoint.baseUrl);
+  } catch {
+    throw new BridgeServiceError(`Invalid bridge endpoint URL: ${endpoint.baseUrl}`, 'invalid_config');
+  }
+
+  if (endpoint.network && endpoint.network.toLowerCase() === 'unsupported') {
+    throw new BridgeServiceError('Configured bridge network is unsupported.', 'unsupported_network');
+  }
+}
+
+function buildEndpointUrl(baseUrl: string, path: string) {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(path.replace(/^\/+/, ''), base);
+}
+
+async function fetchJson(
+  url: URL,
+  endpoint: BridgeEndpointConfig,
+  signal?: AbortSignal
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method: 'GET',
+    signal,
+    headers: endpoint.authToken
+      ? {
+          Authorization: `Bearer ${endpoint.authToken}`,
+        }
+      : undefined,
+  });
+
+  if (!response.ok) {
+    throw new BridgeServiceError(
+      `${endpoint.label} returned ${response.status} while fetching bridge status.`,
+      'service_unavailable'
+    );
+  }
+
+  return response.json();
+}
+
+function extractTransactions(payload: unknown): RawBridgeTransaction[] {
+  if (Array.isArray(payload)) return payload as RawBridgeTransaction[];
+  if (!payload || typeof payload !== 'object') {
+    throw new BridgeServiceError('Bridge endpoint returned an invalid response.', 'invalid_response');
+  }
+
+  const record = payload as Record<string, unknown>;
+  const candidates = [record.transactions, record.records, record.data];
+  const transactions = candidates.find(Array.isArray);
+  if (!transactions) return [];
+  return transactions as RawBridgeTransaction[];
+}
+
+function extractSingleTransaction(payload: unknown): RawBridgeTransaction {
+  if (!payload || typeof payload !== 'object') {
+    throw new BridgeServiceError('Bridge endpoint returned an invalid transaction.', 'invalid_response');
+  }
+
+  const record = payload as Record<string, unknown>;
+  const transaction = record.transaction || record.record || payload;
+  if (!transaction || typeof transaction !== 'object' || Array.isArray(transaction)) {
+    throw new BridgeServiceError('Bridge endpoint returned an invalid transaction.', 'invalid_response');
+  }
+
+  return transaction as RawBridgeTransaction;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+}
+
+function dateValue(value: unknown): Date | undefined {
+  const text = stringValue(value);
+  if (!text) return undefined;
+  const date = new Date(text);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function firstRefundHash(raw: RawBridgeTransaction): string | undefined {
+  const refunds = raw.refunds;
+  if (!refunds || typeof refunds !== 'object') return undefined;
+  const payments = (refunds as Record<string, unknown>).payments;
+  if (!Array.isArray(payments)) return undefined;
+  const first = payments[0];
+  if (!first || typeof first !== 'object') return undefined;
+  return stringValue((first as Record<string, unknown>).id);
+}
+
+function inferSourceChain(kind: string, endpoint: BridgeEndpointConfig): string {
+  if (kind.includes('withdraw')) return 'Stellar';
+  return endpoint.network || endpoint.label;
+}
+
+function inferTargetChain(kind: string, endpoint: BridgeEndpointConfig): string {
+  if (kind.includes('withdraw')) return endpoint.network || endpoint.label;
+  return 'Stellar';
+}

--- a/frontend/src/lib/bridge/devFixtures.ts
+++ b/frontend/src/lib/bridge/devFixtures.ts
@@ -1,0 +1,38 @@
+import type { BridgeTransaction } from './types';
+
+export function getDevelopmentBridgeTransactions(): BridgeTransaction[] {
+  return [
+    {
+      id: 'local-sep24-completed',
+      sourceChain: 'Circle test anchor',
+      targetChain: 'Stellar',
+      amount: '100.00',
+      asset: 'USDC',
+      sender: 'External account',
+      recipient: 'GBX...123',
+      status: 'completed',
+      timestamp: new Date(Date.now() - 3600000),
+      sourceTxHash: 'stellar_tx_hash_001',
+      targetTxHash: '0xabcdef123456789',
+      serviceName: 'Local fixture',
+      protocol: 'sep24',
+      rawStatus: 'completed',
+    },
+    {
+      id: 'local-sep6-pending',
+      sourceChain: 'Stellar',
+      targetChain: 'Test bridge',
+      amount: '0.5',
+      asset: 'ETH',
+      sender: 'GDX...456',
+      recipient: '0x1234...5678',
+      status: 'on_chain',
+      timestamp: new Date(Date.now() - 1800000),
+      sourceTxHash: '0x123456789abcdef',
+      estimatedCompletion: new Date(Date.now() + 900000),
+      serviceName: 'Local fixture',
+      protocol: 'sep6',
+      rawStatus: 'pending_external',
+    },
+  ];
+}

--- a/frontend/src/lib/bridge/types.ts
+++ b/frontend/src/lib/bridge/types.ts
@@ -1,0 +1,53 @@
+export type BridgeStatus =
+  | 'initiated'
+  | 'pending_anchor'
+  | 'on_chain'
+  | 'completed'
+  | 'failed'
+  | 'refunded';
+
+export type BridgeProtocol = 'sep6' | 'sep24' | 'compatible';
+
+export interface BridgeEndpointConfig {
+  id: string;
+  label: string;
+  protocol: BridgeProtocol;
+  baseUrl: string;
+  assetCode?: string;
+  network?: string;
+  authToken?: string;
+  pollIntervalMs?: number;
+}
+
+export interface BridgeTransaction {
+  id: string;
+  sourceChain: string;
+  targetChain: string;
+  amount: string;
+  asset: string;
+  sender: string;
+  recipient: string;
+  status: BridgeStatus;
+  timestamp: Date;
+  sourceTxHash?: string;
+  targetTxHash?: string;
+  anchorId?: string;
+  errorMessage?: string;
+  refundTxHash?: string;
+  estimatedCompletion?: Date;
+  serviceName?: string;
+  protocol?: BridgeProtocol;
+  rawStatus?: string;
+}
+
+export interface BridgeStatusService {
+  listTransactions(
+    endpoints: BridgeEndpointConfig[],
+    signal?: AbortSignal
+  ): Promise<BridgeTransaction[]>;
+  getTransactionStatus(
+    endpoint: BridgeEndpointConfig,
+    transactionId: string,
+    signal?: AbortSignal
+  ): Promise<BridgeTransaction>;
+}

--- a/frontend/src/lib/bridge/useBridgeTracker.ts
+++ b/frontend/src/lib/bridge/useBridgeTracker.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  bridgeStatusService,
+  getDefaultPollIntervalMs,
+  parseBridgeEndpointConfig,
+} from './bridgeService';
+import { getDevelopmentBridgeTransactions } from './devFixtures';
+import type { BridgeEndpointConfig, BridgeStatusService, BridgeTransaction } from './types';
+
+interface UseBridgeTrackerOptions {
+  endpoints?: BridgeEndpointConfig[];
+  service?: BridgeStatusService;
+  autoRefresh: boolean;
+}
+
+interface UseBridgeTrackerResult {
+  transactions: BridgeTransaction[];
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  configured: boolean;
+  usingLocalFixtures: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useBridgeTracker({
+  endpoints,
+  service = bridgeStatusService,
+  autoRefresh,
+}: UseBridgeTrackerOptions): UseBridgeTrackerResult {
+  const configuredEndpoints = useMemo(
+    () => endpoints ?? parseBridgeEndpointConfig(),
+    [endpoints]
+  );
+  const [transactions, setTransactions] = useState<BridgeTransaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const activeRequest = useRef<AbortController | null>(null);
+  const mounted = useRef(false);
+
+  const configured = configuredEndpoints.length > 0;
+  const usingLocalFixtures = !configured && process.env.NODE_ENV !== 'production';
+
+  const refresh = useCallback(async () => {
+    if (activeRequest.current) return;
+
+    if (!configured) {
+      setTransactions(usingLocalFixtures ? getDevelopmentBridgeTransactions() : []);
+      setError(
+        usingLocalFixtures
+          ? null
+          : 'No bridge endpoints are configured. Set NEXT_PUBLIC_BRIDGE_ENDPOINTS to enable live tracking.'
+      );
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    activeRequest.current = controller;
+    setRefreshing(true);
+    setError(null);
+
+    try {
+      const liveTransactions = await service.listTransactions(configuredEndpoints, controller.signal);
+      if (!mounted.current || controller.signal.aborted) return;
+      setTransactions(liveTransactions);
+    } catch (caught) {
+      if (!mounted.current || controller.signal.aborted) return;
+      setError(caught instanceof Error ? caught.message : 'Bridge service is unavailable.');
+    } finally {
+      if (activeRequest.current === controller) {
+        activeRequest.current = null;
+      }
+      if (mounted.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, [configured, configuredEndpoints, service, usingLocalFixtures]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+
+    return () => {
+      mounted.current = false;
+      activeRequest.current?.abort();
+      activeRequest.current = null;
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!autoRefresh || !configured) return;
+
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, getDefaultPollIntervalMs(configuredEndpoints));
+
+    return () => window.clearInterval(interval);
+  }, [autoRefresh, configured, configuredEndpoints, refresh]);
+
+  return {
+    transactions,
+    loading,
+    refreshing,
+    error,
+    configured,
+    usingLocalFixtures,
+    refresh,
+  };
+}


### PR DESCRIPTION
Closes #876
## Summary
- Adds a typed bridge status service for SEP-6, SEP-24, and compatible bridge endpoints.
- Replaces simulated bridge tracker transitions with live `/transactions` and `/transaction` status fetching.
- Adds polling with abort/cancellation guards, clear loading/empty/error states, and local-only development fixtures.
- Maps SEP statuses into tracker states: pending, completed, failed, and refunded.

## Configuration
Set `NEXT_PUBLIC_BRIDGE_ENDPOINTS` to either a JSON array of endpoint configs or semicolon-delimited entries:
`protocol|baseUrl|assetCode|label`

## Tests
- `npx vitest run src/lib/bridge/__tests__/bridgeService.test.ts src/lib/bridge/__tests__/useBridgeTracker.test.tsx` passed.
- `npx tsc --noEmit --pretty false` still fails on existing unrelated repo-wide TypeScript issues in theme tests, admin content, video fullscreen typings, Monaco/LSP, whiteboard, and other areas.