### PR TITLE
fix: resolve TS2345 in vulnerabilityScanner.service.ts

### DIFF
--- a/backend/src/services/vulnerabilityScanner.service.ts
+++ b/backend/src/services/vulnerabilityScanner.service.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Security Vulnerability Scanner — Blockchain Learning Simulator backend.
  */
@@ -75,7 +74,8 @@ const SCAN_RULES: ScanRule[] = [
 ];
 
 function severityWeight(severity: Severity): number {
-  return { low: 5, medium: 15, high: 30, critical: 50 }[severity];
+  const weights: Record<Severity, number> = { low: 5, medium: 15, high: 30, critical: 50 };
+  return weights[severity];
 }
 
 export function scanContractSource(sourceCode: string): ScanResult {


### PR DESCRIPTION
- Remove @ts-nocheck suppressor
- Fix TS2345: change severityWeight to use a typed Record<Severity, number> lookup instead of an inline object literal index, so TypeScript knows the return is always number and never undefined

Closes #966 