### PR TITLE
docs(generator): document AI idea-generation safety guardrails (#908)

### DIFF
--- a/backend/src/generator/README.md
+++ b/backend/src/generator/README.md
@@ -1,0 +1,20 @@
+# AI hackathon idea generator — safety guardrails (#908)
+
+`POST /api/generator/generate` calls an OpenAI-backed model to produce
+structured hackathon project ideas. To keep generated content safe,
+on-schema, and resistant to prompt injection, the endpoint enforces:
+
+- **Output contract** (`ideaSchema.ts`): every idea returned to the
+  frontend is validated against `ProjectIdeaSchema` (Zod). Model output
+  that doesn't conform is rejected rather than passed through.
+- **Prompt-injection resistance** (`generator.service.ts`): the system
+  prompt explicitly instructs the model to ignore any instructions
+  embedded in user-supplied text, and user input is passed as clearly
+  delimited content rather than concatenated into the instruction set.
+- **Safe fallback**: when generation fails or returns invalid output,
+  the API responds with an actionable error rather than surfacing raw
+  model output or a silent empty result.
+- **Evaluation suite** (`backend/tests/generatorIdeaSafety.eval.test.ts`):
+  a deterministic test suite exercising harmful, malformed, and
+  off-topic model responses against mocked model output — no live,
+  paid API calls are made in CI.


### PR DESCRIPTION
## Context

The actual guardrails implementation for #908 (Zod output-contract validation, prompt-injection-resistant system instructions, safe fallback on invalid/failed generation, and a mocked deterministic evaluation suite in `backend/tests/generatorIdeaSafety.eval.test.ts`) was already implemented and merged into `main` via #1029.

That PR's closing keyword was added via an edit after it had already merged, so GitHub did not retroactively close #908. This small follow-up PR adds a README documenting the guardrails (backend/src/generator/README.md) and properly closes #908.

## What's in this PR

- `backend/src/generator/README.md` — documents the output contract, prompt-injection resistance, safe-fallback behavior, and evaluation suite added in #1029.

## Test plan

- [x] Documentation-only change; no code/behavior touched.
- [x] Confirmed the referenced guardrail code (`ideaSchema.ts`, `generator.service.ts`, `generatorIdeaSafety.eval.test.ts`) is present on `main`.

Closes #908