### PR TITLE
feat: validate frontend runtime configuration before Web3 features initialize

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,10 +1,32 @@
 # ==========================================
 # Web3 Student Lab - Frontend Environment
 # ==========================================
+#
+# All variables here are NEXT_PUBLIC_* and are inlined into the client
+# bundle at build time — never put server-only secrets in this file.
+# Validated by src/lib/env.ts; see that file for what's required vs
+# optional and how missing/malformed values are handled.
 
-# Backend API URL
+# Backend API URL (required in production; defaults to localhost in dev)
 # This is used for all API calls including GitHub OAuth authentication
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 
-# WebSocket URL (for real-time features)
+# WebSocket URL for real-time features (required in production; defaults to localhost in dev)
 NEXT_PUBLIC_WS_URL=ws://localhost:8080
+
+# Soroban RPC endpoint used by Web3/certificate features (optional — defaults to public testnet RPC)
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Horizon endpoint used for Stellar asset lookups (optional — defaults to public testnet Horizon)
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Deployed certificate contract id (optional — certificate verification/issuance
+# features are disabled gracefully when unset; must match ^C[A-Z2-7]{55}$ if set)
+NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID=
+
+# Optional STUN/TURN servers for WebRTC collaboration features, as a JSON array of URLs
+NEXT_PUBLIC_WEBRTC_ICE_SERVERS=
+
+# Optional build metadata surfaced in the UI (e.g. footer/version badge)
+NEXT_PUBLIC_APP_VERSION=
+NEXT_PUBLIC_BUILD_NUMBER=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,6 +55,7 @@
         "y-monaco": "^0.1.6",
         "y-websocket": "^3.0.0",
         "yjs": "^13.6.30",
+        "zod": "^4.4.3",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -174,7 +175,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -184,7 +185,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -219,7 +220,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -2381,7 +2382,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -5795,7 +5796,6 @@
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5805,7 +5805,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6150,7 +6149,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -6489,7 +6488,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -7487,7 +7485,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8821,7 +8818,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -8840,7 +8837,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -10756,6 +10753,15 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "y-monaco": "^0.1.6",
     "y-websocket": "^3.0.0",
     "yjs": "^13.6.30",
+    "zod": "^4.4.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/frontend/src/lib/__tests__/env.test.ts
+++ b/frontend/src/lib/__tests__/env.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetPublicEnvCacheForTests,
+  DEFAULT_HORIZON_URL,
+  DEFAULT_SOROBAN_RPC_URL,
+  getPublicEnv,
+  validatePublicEnv,
+} from '../env';
+
+const VALID_CONTRACT_ID = `C${'A'.repeat(55)}`;
+
+function makeEnv(overrides: Partial<NodeJS.ProcessEnv> = {}): NodeJS.ProcessEnv {
+  return {
+    NEXT_PUBLIC_API_URL: 'https://api.example.com',
+    NEXT_PUBLIC_WS_URL: 'wss://ws.example.com',
+    ...overrides,
+  } as NodeJS.ProcessEnv;
+}
+
+describe('validatePublicEnv', () => {
+  it('accepts a fully valid configuration with no errors', () => {
+    const { env, errors } = validatePublicEnv(
+      makeEnv({
+        NEXT_PUBLIC_SOROBAN_RPC_URL: 'https://rpc.example.com',
+        NEXT_PUBLIC_HORIZON_URL: 'https://horizon.example.com',
+        NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID: VALID_CONTRACT_ID,
+      }),
+    );
+
+    expect(errors).toEqual([]);
+    expect(env.apiUrl).toBe('https://api.example.com');
+    expect(env.wsUrl).toBe('wss://ws.example.com');
+    expect(env.sorobanRpcUrl).toBe('https://rpc.example.com');
+    expect(env.horizonUrl).toBe('https://horizon.example.com');
+    expect(env.certificateContractId).toBe(VALID_CONTRACT_ID);
+  });
+
+  it('degrades optional Soroban/contract configuration gracefully when absent', () => {
+    const { env, errors } = validatePublicEnv(makeEnv());
+
+    expect(errors).toEqual([]);
+    expect(env.sorobanRpcUrl).toBe(DEFAULT_SOROBAN_RPC_URL);
+    expect(env.horizonUrl).toBe(DEFAULT_HORIZON_URL);
+    expect(env.certificateContractId).toBeNull();
+  });
+
+  it('treats an explicitly empty contract id the same as absent, not malformed', () => {
+    const { env, errors } = validatePublicEnv(
+      makeEnv({ NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID: '' }),
+    );
+
+    expect(errors).toEqual([]);
+    expect(env.certificateContractId).toBeNull();
+  });
+
+  it('reports a malformed contract id by name, without echoing the value', () => {
+    const { errors } = validatePublicEnv(
+      makeEnv({ NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID: 'not-a-contract-id' }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID');
+    expect(errors[0]).not.toContain('not-a-contract-id');
+  });
+
+  it('reports a malformed API URL by name', () => {
+    const { errors } = validatePublicEnv(makeEnv({ NEXT_PUBLIC_API_URL: 'not-a-url' }));
+
+    expect(errors.some((e) => e.startsWith('NEXT_PUBLIC_API_URL'))).toBe(true);
+  });
+
+  it('flags required public config missing in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const { env, errors } = validatePublicEnv({} as NodeJS.ProcessEnv);
+
+    expect(errors).toContain('NEXT_PUBLIC_API_URL: required in production but not set');
+    expect(errors).toContain('NEXT_PUBLIC_WS_URL: required in production but not set');
+    expect(env.apiUrl).toBe('');
+    expect(env.wsUrl).toBe('');
+  });
+
+  it('falls back to local dev defaults for API/WS URL outside production without erroring', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const { env, errors } = validatePublicEnv({} as NodeJS.ProcessEnv);
+
+    expect(errors).toEqual([]);
+    expect(env.apiUrl).toBe('http://localhost:8080/api/v1');
+    expect(env.wsUrl).toBe('ws://localhost:8080');
+  });
+});
+
+describe('getPublicEnv', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    __resetPublicEnvCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetPublicEnvCacheForTests();
+    process.env = { ...originalEnv };
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('throws in development with every problem listed by key, not value', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    process.env.NEXT_PUBLIC_API_URL = 'not-a-url';
+    process.env.NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID = 'bad-id';
+
+    expect(() => getPublicEnv()).toThrowError(/NEXT_PUBLIC_API_URL/);
+    __resetPublicEnvCacheForTests();
+    expect(() => getPublicEnv()).toThrowError(/NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID/);
+  });
+
+  it('never throws in production, and logs diagnostics instead', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    process.env.NEXT_PUBLIC_API_URL = '';
+    process.env.NEXT_PUBLIC_WS_URL = '';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const env = getPublicEnv();
+
+    expect(env.apiUrl).toBe('');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('NEXT_PUBLIC_API_URL');
+  });
+
+  it('memoizes the result so validation only runs once per process', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    getPublicEnv();
+    process.env.NEXT_PUBLIC_API_URL = 'https://changed.example.com';
+    const second = getPublicEnv();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(second.apiUrl).toBe('');
+  });
+});

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -1,6 +1,6 @@
-const RAW_API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
+import { getPublicEnv } from './env';
 
-export const API_BASE_URL = RAW_API_BASE_URL.replace(/\/+$/, '');
+export const API_BASE_URL = getPublicEnv().apiUrl;
 export const API_ORIGIN = API_BASE_URL.replace(/\/api\/v\d+$/, '');
 
 export function getWorkspaceId() {

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+
+/**
+ * Typed, validated public runtime configuration.
+ *
+ * Only `NEXT_PUBLIC_*` variables belong here — Next.js inlines them into the
+ * client bundle at build time, so nothing read through this module can ever
+ * be a server-only secret. Server-only config must not be added to this
+ * schema or exposed through `getPublicEnv()`.
+ *
+ * `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_WS_URL` are treated as required in
+ * production (a deployed app pointed at localhost is a misconfiguration, not
+ * a usable default) but fall back to local dev values outside production so
+ * `next dev` keeps working with an empty `.env.local`.
+ *
+ * Soroban RPC/Horizon URLs and the certificate contract ID back optional
+ * Web3 features: they have safe public-network defaults (RPC/Horizon) or
+ * degrade to "feature disabled" (contract ID) rather than failing the whole
+ * app when absent.
+ */
+
+const emptyToUndefined = (value: unknown) => (value === '' ? undefined : value);
+
+const DEV_API_URL = 'http://localhost:8080/api/v1';
+const DEV_WS_URL = 'ws://localhost:8080';
+export const DEFAULT_SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+export const DEFAULT_HORIZON_URL = 'https://horizon-testnet.stellar.org';
+
+// Soroban contract StrKey: 'C' followed by 55 base32 characters (RFC 4648, no padding).
+const CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
+
+const rawEnvSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.preprocess(emptyToUndefined, z.string().url().optional()),
+  NEXT_PUBLIC_WS_URL: z.preprocess(emptyToUndefined, z.string().url().optional()),
+  NEXT_PUBLIC_SOROBAN_RPC_URL: z.preprocess(emptyToUndefined, z.string().url().optional()),
+  NEXT_PUBLIC_HORIZON_URL: z.preprocess(emptyToUndefined, z.string().url().optional()),
+  NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID: z.preprocess(
+    emptyToUndefined,
+    z.string().regex(CONTRACT_ID_PATTERN, 'must be a valid Soroban contract id (e.g. C...)').optional(),
+  ),
+  NEXT_PUBLIC_WEBRTC_ICE_SERVERS: z.preprocess(emptyToUndefined, z.string().optional()),
+  NEXT_PUBLIC_APP_VERSION: z.preprocess(emptyToUndefined, z.string().optional()),
+  NEXT_PUBLIC_BUILD_NUMBER: z.preprocess(emptyToUndefined, z.string().optional()),
+});
+
+export interface PublicEnv {
+  apiUrl: string;
+  wsUrl: string;
+  sorobanRpcUrl: string;
+  horizonUrl: string;
+  /** null when no (valid) contract id is configured — dependent features should degrade, not throw. */
+  certificateContractId: string | null;
+  webrtcIceServers: string | undefined;
+  appVersion: string;
+  buildNumber: string;
+}
+
+export interface EnvValidationResult {
+  env: PublicEnv;
+  /** Human-readable, value-free descriptions of anything invalid or missing-in-production. */
+  errors: string[];
+}
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+/**
+ * Validates `process.env`'s public configuration and returns a safe, typed
+ * config object plus a list of problems (if any). Never throws itself —
+ * callers decide whether to escalate (see {@link assertValidPublicEnv}).
+ */
+export function validatePublicEnv(source: NodeJS.ProcessEnv = process.env): EnvValidationResult {
+  const parsed = rawEnvSchema.safeParse(source);
+  const errors: string[] = [];
+
+  // Malformed values (present but fail schema, e.g. not a URL) are always
+  // reported, dev or prod — a typo shouldn't only ever surface as a runtime
+  // fetch failure downstream.
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const key = issue.path.join('.');
+      errors.push(`${key}: ${issue.message}`);
+    }
+  }
+
+  const data = parsed.success ? parsed.data : rawEnvSchema.partial().parse({});
+
+  const production = isProduction();
+
+  if (!data.NEXT_PUBLIC_API_URL) {
+    if (production) errors.push('NEXT_PUBLIC_API_URL: required in production but not set');
+  }
+  if (!data.NEXT_PUBLIC_WS_URL) {
+    if (production) errors.push('NEXT_PUBLIC_WS_URL: required in production but not set');
+  }
+
+  const env: PublicEnv = {
+    apiUrl: (data.NEXT_PUBLIC_API_URL ?? (production ? '' : DEV_API_URL)).replace(/\/+$/, ''),
+    wsUrl: data.NEXT_PUBLIC_WS_URL ?? (production ? '' : DEV_WS_URL),
+    sorobanRpcUrl: data.NEXT_PUBLIC_SOROBAN_RPC_URL ?? DEFAULT_SOROBAN_RPC_URL,
+    horizonUrl: data.NEXT_PUBLIC_HORIZON_URL ?? DEFAULT_HORIZON_URL,
+    certificateContractId: data.NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID ?? null,
+    webrtcIceServers: data.NEXT_PUBLIC_WEBRTC_ICE_SERVERS,
+    appVersion: data.NEXT_PUBLIC_APP_VERSION ?? 'dev',
+    buildNumber: data.NEXT_PUBLIC_BUILD_NUMBER ?? 'unknown',
+  };
+
+  return { env, errors };
+}
+
+let cached: PublicEnv | null = null;
+
+/**
+ * Returns the validated public config, computed once and memoized.
+ *
+ * - In development: throws with every problem listed (key names only, never
+ *   values) so a misconfiguration is loud and immediate instead of a vague
+ *   wallet/RPC failure three clicks later.
+ * - In production: never throws (a config problem shouldn't blank-page every
+ *   visitor); logs the same key-only diagnostics once via `console.error`
+ *   and returns best-effort defaults so optional features degrade instead
+ *   of crashing the app shell.
+ */
+export function getPublicEnv(): PublicEnv {
+  if (cached) return cached;
+
+  const { env, errors } = validatePublicEnv();
+
+  if (errors.length > 0) {
+    const message = `Invalid frontend runtime configuration:\n- ${errors.join('\n- ')}`;
+    if (isProduction()) {
+      console.error(message);
+    } else {
+      throw new Error(message);
+    }
+  }
+
+  cached = env;
+  return env;
+}
+
+/** Test-only: clears the memoized config so validation re-runs against a fresh env. */
+export function __resetPublicEnvCacheForTests(): void {
+  cached = null;
+}

--- a/frontend/src/lib/notarization.ts
+++ b/frontend/src/lib/notarization.ts
@@ -1,8 +1,8 @@
 import { rpc, scValToNative, xdr, Contract, Address } from '@stellar/stellar-sdk';
+import { getPublicEnv } from './env';
 
-const SOROBAN_RPC_URL =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
-const CONTRACT_ID = process.env.NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID || '';
+const SOROBAN_RPC_URL = getPublicEnv().sorobanRpcUrl;
+const CONTRACT_ID = getPublicEnv().certificateContractId ?? '';
 
 export interface TimestampedProof {
   timestamp: bigint;

--- a/frontend/src/lib/soroban-tools.ts
+++ b/frontend/src/lib/soroban-tools.ts
@@ -3,12 +3,11 @@
  * ScVal decoder, RPC helpers, fee stats
  */
 import { rpc, scValToNative, xdr } from '@stellar/stellar-sdk';
+import { getPublicEnv } from './env';
 
-export const SOROBAN_RPC_URL =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+export const SOROBAN_RPC_URL = getPublicEnv().sorobanRpcUrl;
 
-export const HORIZON_URL =
-  process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+export const HORIZON_URL = getPublicEnv().horizonUrl;
 
 // ─── ScVal Decoder ────────────────────────────────────────────────────────────
 

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -1,12 +1,13 @@
+import { getPublicEnv } from './env';
+
 // Dynamic imports for Stellar SDK to reduce initial bundle size
 // and allow for better code splitting
 const getStellarSDK = async () => {
   return await import('@stellar/stellar-sdk');
 };
 
-const SOROBAN_RPC_URL =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-test.stellar.org:443';
-const CERTIFICATE_CONTRACT_ID = process.env.NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID || '';
+const SOROBAN_RPC_URL = getPublicEnv().sorobanRpcUrl;
+const CERTIFICATE_CONTRACT_ID = getPublicEnv().certificateContractId ?? '';
 
 export interface CertificateData {
   symbol: string;

--- a/frontend/src/lib/stellar-assets.ts
+++ b/frontend/src/lib/stellar-assets.ts
@@ -12,8 +12,9 @@ import {
   AuthRequiredFlag,
   AuthClawbackEnabledFlag,
 } from '@stellar/stellar-sdk';
+import { getPublicEnv } from './env';
 
-const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const HORIZON_URL = getPublicEnv().horizonUrl;
 const server = new Server(HORIZON_URL);
 
 export interface StellarAssetInfo {


### PR DESCRIPTION
## Summary

Closes #896.

Public env vars (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_WS_URL`, `NEXT_PUBLIC_SOROBAN_RPC_URL`, `NEXT_PUBLIC_CERTIFICATE_CONTRACT_ID`, `NEXT_PUBLIC_HORIZON_URL`, ...) were read directly via `process.env.X || default` scattered across `src/lib/soroban.ts`, `soroban-tools.ts`, `notarization.ts`, `stellar-assets.ts` and `api-config.ts`, with no shared validation. Two concrete symptoms of that: `soroban.ts` and `soroban-tools.ts` each hardcoded a *different* default Soroban RPC URL, and `stellar-assets.ts` constructs a Horizon `Server` at module load time with an unvalidated URL. `.env.example` also only documented 2 of the 8 public vars actually read by the app.

- Added `src/lib/env.ts`: a zod schema for all public config, exposed through `getPublicEnv()`. `NEXT_PUBLIC_API_URL`/`WS_URL` are required in production (with a dev-only localhost fallback so `next dev` still works out of the box); Soroban RPC/Horizon URLs keep safe public-network defaults; the certificate contract id is validated by format but stays optional, since certificate features already degrade gracefully (`console.warn` + return null) when it's absent.
- In development, an invalid or missing-in-prod config throws with every problem named by key (never by value); in production it logs once via `console.error` and returns safe defaults instead of crashing the app shell.
- Wired the four Web3 init modules and `api-config.ts` through it, keeping their existing exported names so no call sites elsewhere had to change.
- Brought `.env.example` up to date with every var the schema covers.

## Test plan
- [x] Added `src/lib/__tests__/env.test.ts` (none existed before) — 10/10 passed, covering valid config, missing-in-dev vs missing-in-prod, malformed URL/contract id, and memoization
- [x] `npx tsc --noEmit` — no new type errors
- [x] Full `vitest run` — no regressions in files that import the touched modules (none have dedicated tests, and none reference these env vars directly)

**Note on `pnpm-lock.yaml`:** intentionally untouched here. Regenerating it on this branch re-resolved the still-unpinned `"latest"` `@ledgerhq/*` dependencies to newer versions unrelated to this change (that pin is #895's fix, on a separate branch) — bundling that drift into this PR would violate the same "no unrelated changes" principle #895 is about. `package-lock.json` (what CI's `npm ci` actually installs from) is updated correctly with the new `zod` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)