### PR TITLE
feat: course progress persistence (optimistic concurrency) + bounded reconnect for notifications

### DIFF
--- a/backend/src/cache/CacheInvalidation.ts
+++ b/backend/src/cache/CacheInvalidation.ts
@@ -18,6 +18,10 @@ export const invalidateCourseCache = async (courseId: string): Promise<void> => 
 
 export const invalidateUserProgressCache = async (userId: string): Promise<void> => {
   await cacheService.del(CACHE_KEYS.user.progress(userId));
+  // getStudentProgress keys progress per course as
+  // `user:progress:<userId>:<courseId>`; clear every course snapshot so no
+  // stale state survives across sessions/devices.
+  await cacheService.delPattern(`${CACHE_KEYS.user.progress(userId)}:*`);
 };
 
 export const invalidateLeaderboardCache = async (): Promise<void> => {

--- a/backend/src/routes/learning/learning.routes.ts
+++ b/backend/src/routes/learning/learning.routes.ts
@@ -11,6 +11,7 @@ import {
     listCourses,
     updateStudentProgress,
     ProgressPersistenceError,
+    ProgressConflictError,
 } from './learning.service.js';
 import {
     courseParamsSchema,
@@ -170,6 +171,15 @@ router.patch(
     } catch (error: unknown) {
       if (error instanceof Error && error.message === 'LESSON_NOT_FOUND') {
         res.status(404).json({ error: 'Lesson not found' });
+        return;
+      }
+
+      if (error instanceof ProgressConflictError) {
+        res.status(409).json({
+          error: error.message,
+          progress: error.current,
+          dataSource: 'live',
+        });
         return;
       }
 

--- a/backend/src/routes/learning/learning.service.ts
+++ b/backend/src/routes/learning/learning.service.ts
@@ -37,6 +37,24 @@ export class ProgressPersistenceError extends Error {
   }
 }
 
+/**
+ * Thrown when a progress write carries a stale optimistic-concurrency token
+ * (`baseUpdatedAt`). Deterministic conflict behavior: the server is the
+ * source of truth; the client receives a 409 together with the current
+ * server-side progress and reconciles by refetching.
+ */
+export class ProgressConflictError extends Error {
+  readonly current: Progress;
+  constructor(
+    current: Progress,
+    message = 'Progress was updated in another session; refresh to reconcile'
+  ) {
+    super(message);
+    this.name = 'ProgressConflictError';
+    this.current = current;
+  }
+}
+
 // In-memory store used ONLY as a read-through cache in front of the
 // database for getStudentProgress, and as ephemeral local state while a
 // write is in flight. It is never treated as an authoritative record of
@@ -104,22 +122,6 @@ const buildCourseStatus = (completedLessonCount: number, totalLessons: number): 
   return 'in_progress';
 };
 
-const buildPercentage = (
-  completedLessonCount: number,
-  totalLessons: number,
-  explicitPercentage?: number
-): number => {
-  if (typeof explicitPercentage === 'number') {
-    return explicitPercentage;
-  }
-
-  if (totalLessons === 0) {
-    return 0;
-  }
-
-  return Math.round((completedLessonCount / totalLessons) * 100);
-};
-
 /**
  * List all courses with optional difficulty filter.
  *
@@ -132,7 +134,12 @@ const buildPercentage = (
 export const listCourses = async (
   difficulty?: string
 ): Promise<WithDataSource<CurriculumCourse[]>> => {
-  const cacheKey = CACHE_KEYS.courses.list();
+  // Cache is partitioned by difficulty: a `difficulty` query must never be
+  // served the unfiltered (or differently filtered) cached catalog.
+  const normalizedDifficulty = difficulty || undefined;
+  const cacheKey = normalizedDifficulty
+    ? `${CACHE_KEYS.courses.list()}:difficulty:${normalizedDifficulty}`
+    : CACHE_KEYS.courses.list();
   const cached = await cacheService.get<CurriculumCourse[]>(cacheKey);
   if (cached) return { data: cached, dataSource: 'live' };
 
@@ -149,7 +156,7 @@ export const listCourses = async (
       credits: course.credits,
       createdAt: course.createdAt,
       updatedAt: course.updatedAt,
-      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), difficulty),
+      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), normalizedDifficulty),
     }));
 
     await cacheService.set(cacheKey, result, cacheTTL.courses.list);
@@ -165,7 +172,7 @@ export const listCourses = async (
       credits: 10,
       createdAt: now,
       updatedAt: now,
-      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), difficulty),
+      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), normalizedDifficulty),
     }));
     return { data: demoData, dataSource: 'demo' };
   }
@@ -182,7 +189,10 @@ export const getCourseCurriculum = async (
   courseId: string,
   difficulty?: string
 ): Promise<WithDataSource<CurriculumCourse | null>> => {
-  const cacheKey = CACHE_KEYS.courses.curriculum(courseId);
+  const normalizedDifficulty = difficulty || undefined;
+  const cacheKey = normalizedDifficulty
+    ? `${CACHE_KEYS.courses.curriculum(courseId)}:difficulty:${normalizedDifficulty}`
+    : CACHE_KEYS.courses.curriculum(courseId);
   const cached = await cacheService.get<CurriculumCourse>(cacheKey);
   if (cached) return { data: cached, dataSource: 'live' };
 
@@ -203,7 +213,7 @@ export const getCourseCurriculum = async (
       credits: course.credits,
       createdAt: course.createdAt,
       updatedAt: course.updatedAt,
-      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), difficulty),
+      modules: filterModulesByDifficulty(getCurriculumForCourse(course.id), normalizedDifficulty),
     };
 
     await cacheService.set(cacheKey, result, cacheTTL.courses.curriculum);
@@ -225,7 +235,7 @@ export const getCourseCurriculum = async (
       credits: 10,
       createdAt: now,
       updatedAt: now,
-      modules: filterModulesByDifficulty(getCurriculumForCourse(courseId), difficulty),
+      modules: filterModulesByDifficulty(getCurriculumForCourse(courseId), normalizedDifficulty),
     };
 
     return { data: result, dataSource: 'demo' };
@@ -333,24 +343,64 @@ export const updateStudentProgress = async (
   input: ProgressUpdateInput
 ): Promise<Progress> => {
   const modules = getCurriculumForCourse(courseId);
-  const lesson = modules
-    .flatMap((module) => module.lessons)
-    .find((entry) => entry.id === input.lessonId);
+  const totalLessons = countLessons(modules);
 
-  if (!lesson) {
-    throw new Error('LESSON_NOT_FOUND');
+  let moduleForLesson: Module | undefined;
+  if (input.lessonId) {
+    const lesson = modules
+      .flatMap((module) => module.lessons)
+      .find((entry) => entry.id === input.lessonId);
+
+    if (!lesson) {
+      throw new Error('LESSON_NOT_FOUND');
+    }
+
+    moduleForLesson = modules.find((module) =>
+      module.lessons.some((entry) => entry.id === input.lessonId)
+    );
   }
 
-  const moduleForLesson = modules.find((module) =>
-    module.lessons.some((entry) => entry.id === input.lessonId)
-  );
-  const totalLessons = countLessons(modules);
+  // Optimistic-concurrency check against the authoritative database row.
+  // When the client supplies the `updatedAt` it last observed and that no
+  // longer matches, another session has written in the meantime — reject the
+  // stale write deterministically instead of silently overwriting (#901).
+  if (input.baseUpdatedAt) {
+    const stored = await prisma.learningProgress.findUnique({
+      where: {
+        studentId_courseId: {
+          studentId,
+          courseId,
+        },
+      },
+    });
+
+    if (stored && stored.updatedAt.toISOString() !== input.baseUpdatedAt) {
+      logger.warn('Progress conflict detected; rejecting stale update', {
+        studentId,
+        courseId,
+        expected: input.baseUpdatedAt,
+        actual: stored.updatedAt.toISOString(),
+      });
+      throw new ProgressConflictError(toProgress(stored));
+    }
+  }
+
   const existingProgressResult = await getStudentProgress(studentId, courseId);
   const existingProgress = existingProgressResult.data;
 
-  const completedLessonSet = new Set(existingProgress.completedLessons);
+  // Whole-state updates replace the completed set atomically; lesson-driven
+  // updates mutate it. When both are provided, the lesson toggle is applied
+  // on top of the provided whole-state.
+  const completedLessonSet = new Set<string>(
+    Array.isArray(input.completedLessons)
+      ? input.completedLessons.map((id) => id.trim()).filter(Boolean)
+      : existingProgress.completedLessons
+  );
 
-  if (input.status === 'completed') {
+  const togglingToCompleted =
+    Boolean(input.lessonId) && input.status === 'completed';
+
+  if (input.lessonId && togglingToCompleted) {
     if (!completedLessonSet.has(input.lessonId)) {
       // Log individual lesson completion activity
       await (prisma as any).studentActivity
@@ -414,21 +464,56 @@ export const updateStudentProgress = async (
       }
     }
     completedLessonSet.add(input.lessonId);
-  } else {
+  } else if (input.lessonId) {
     completedLessonSet.delete(input.lessonId);
   }
 
   const completedLessons = Array.from(completedLessonSet);
-  const percentage = buildPercentage(completedLessons.length, totalLessons, input.percentage);
-  const status = buildCourseStatus(completedLessons.length, totalLessons);
+
+  const percentage =
+    typeof input.percentage === 'number'
+      ? input.percentage
+      : Math.min(
+          Math.round((completedLessons.length / (totalLessons || 1)) * 100),
+          100
+        );
+
+  // Course-level status derivation. `status` on the wire means two different
+  // things depending on the update style:
+  //  - Whole-state writes (`completedLessons`) send the course status directly.
+  //  - Lesson-driven writes send the lesson's *target* status (completed /
+  //    not_started) used only to toggle membership, never as the course status.
+  // When an explicit percentage is provided it implies the course status;
+  // otherwise it is derived from the completed/ total lesson counts.
+  const hasWholeState = Array.isArray(input.completedLessons);
+
+  let status: ProgressStatus;
+  if (hasWholeState && input.status) {
+    status = input.status;
+  } else if (typeof input.percentage === 'number') {
+    status =
+      input.percentage >= 100
+        ? 'completed'
+        : input.percentage === 0
+          ? 'not_started'
+          : 'in_progress';
+  } else {
+    status = buildCourseStatus(completedLessons.length, totalLessons);
+  }
+
   const completedAt = status === 'completed' ? new Date() : null;
   const now = new Date();
+
+  const currentModuleId =
+    input.currentModuleId !== undefined
+      ? input.currentModuleId
+      : moduleForLesson?.id ?? existingProgress.currentModuleId;
 
   // Update in-memory cache
   const updatedProgress: Progress = {
     ...existingProgress,
     completedLessons,
-    currentModuleId: moduleForLesson?.id ?? existingProgress.currentModuleId,
+    currentModuleId,
     percentage,
     status,
     lastAccessedAt: now,
@@ -464,11 +549,19 @@ export const updateStudentProgress = async (
       },
     });
 
+    const persisted = toProgress(progress);
+
     const key = `${studentId}:${courseId}`;
-    mockProgressStore[key] = updatedProgress; // keep read-through cache warm
+    mockProgressStore[key] = persisted; // keep read-through cache warm
+
+    // Overwrite the per-course cache with the authoritative row so the next
+    // read (this session or another device) does not observe a stale snapshot
+    // that silently drops the latest write (#901).
+    const cacheKey = `${CACHE_KEYS.user.progress(studentId)}:${courseId}`;
+    await cacheService.set(cacheKey, persisted, cacheTTL.user.progress);
 
     await invalidateUserProgressCache(studentId);
-    return toProgress(progress);
+    return persisted;
   } catch (error) {
     logger.error('Database unavailable in updateStudentProgress; refusing to fake-save progress', {
       studentId,

--- a/backend/src/routes/learning/types.ts
+++ b/backend/src/routes/learning/types.ts
@@ -43,8 +43,35 @@ export interface Progress {
   updatedAt: Date;
 }
 
+/**
+ * Input accepted by PATCH /learning/courses/:courseId/progress.
+ *
+ * Two update styles are supported:
+ *
+ * 1. **Lesson-driven** (`lessonId` + `status`) — toggles a single lesson on
+ *    top of the currently stored set. This is the legacy contract used by the
+ *    `POST /learning/progress/:userId/complete` route and the offline sync
+ *    flush, and it remains fully supported.
+ *
+ * 2. **Whole-state** (`completedLessons`, `currentModuleId`) — atomically
+ *    replaces the learner's completed set and current module. This is the
+ *    contract used by the roadmap UI, which tracks progress by its own node
+ *    ids (journey levels) rather than curriculum lesson ids.
+ *
+ * Both styles may be combined in a single request; the lesson toggle is then
+ * applied on top of the provided whole-state.
+ *
+ * `baseUpdatedAt` is an optimistic-concurrency token (the `updatedAt` value
+ * the client last observed). When present, the write is rejected with a 409
+ * conflict if the stored progress has since been modified by another client,
+ * making concurrent/stale update behavior deterministic: the server is the
+ * source of truth and the client reconciles by refetching.
+ */
 export interface ProgressUpdateInput {
-  lessonId: string;
-  status: ProgressStatus;
+  lessonId?: string;
+  status?: ProgressStatus;
   percentage?: number;
+  completedLessons?: string[];
+  currentModuleId?: string | null;
+  baseUpdatedAt?: string | null;
 }

--- a/backend/src/routes/learning/validation.schemas.ts
+++ b/backend/src/routes/learning/validation.schemas.ts
@@ -5,16 +5,46 @@ export const courseParamsSchema = z.object({
 });
 
 export const coursesQuerySchema = z.object({
-  difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
+  // HTML forms send `?difficulty=` as an empty string; treat it as "no filter"
+  // rather than rejecting the request.
+  difficulty: z.enum(['beginner', 'intermediate', 'advanced', '']).optional(),
 });
 
-export const progressUpdateSchema = z.object({
-  lessonId: z.string().trim().min(1, 'Lesson ID is required'),
-  status: z.enum(['not_started', 'in_progress', 'completed']),
-  percentage: z
-    .number()
-    .int('Percentage must be an integer')
-    .min(0, 'Percentage must be at least 0')
-    .max(100, 'Percentage must be at most 100')
-    .optional(),
-});
+export const progressUpdateSchema = z
+  .object({
+    lessonId: z.string().trim().min(1, 'Lesson ID is required').optional(),
+    status: z
+      .enum(['not_started', 'in_progress', 'completed'])
+      .optional(),
+    percentage: z
+      .number()
+      .int('Percentage must be an integer')
+      .min(0, 'Percentage must be at least 0')
+      .max(100, 'Percentage must be at most 100')
+      .optional(),
+    completedLessons: z
+      .array(z.string().trim().min(1))
+      .max(2000, 'Too many completed lessons')
+      .optional(),
+    currentModuleId: z
+      .string()
+      .trim()
+      .min(1, 'Module ID must not be empty')
+      .nullable()
+      .optional(),
+    baseUpdatedAt: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional(),
+  })
+  .refine(
+    (value) =>
+      Boolean(value.lessonId) ||
+      Array.isArray(value.completedLessons) ||
+      value.currentModuleId != null,
+    {
+      message: 'Either lessonId, completedLessons, or currentModuleId is required',
+      path: ['lessonId'],
+    }
+  );

--- a/backend/tests/curriculum-progress.integration.test.ts
+++ b/backend/tests/curriculum-progress.integration.test.ts
@@ -662,6 +662,156 @@ describe('Curriculum & Progress Integration Tests', () => {
       expect(response.body.progress.completedLessons).not.toContain('course-1-lesson-1');
     });
 
+    it('should accept whole-state progress updates (roadmap node ids)', async () => {
+      // Arrange: Register student
+      const student = await registerStudent('wholestate@example.com');
+
+      // Act: Replace progress with the roadmap-style whole state
+      const response = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          completedLessons: ['soroban-level-1', 'soroban-level-2'],
+          currentModuleId: 'soroban-level-2',
+          percentage: 66,
+          status: 'in_progress',
+        })
+        .expect(200);
+
+      // Assert: Whole state stored as provided
+      expect(response.body.progress.completedLessons).toEqual([
+        'soroban-level-1',
+        'soroban-level-2',
+      ]);
+      expect(response.body.progress.currentModuleId).toBe('soroban-level-2');
+      expect(response.body.progress.percentage).toBe(66);
+      expect(response.body.progress.status).toBe('in_progress');
+
+      // Verify persistence in database
+      const dbProgress = await prisma.learningProgress.findUnique({
+        where: {
+          studentId_courseId: {
+            studentId: student.userId,
+            courseId: 'course-1',
+          },
+        },
+      });
+
+      expect(dbProgress?.completedLessons).toEqual([
+        'soroban-level-1',
+        'soroban-level-2',
+      ]);
+    });
+
+    it('should support resume updates that only move the current module', async () => {
+      // Arrange: Register student and create progress
+      const student = await registerStudent('resume@example.com');
+
+      await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          lessonId: 'course-1-lesson-1',
+          status: 'completed',
+        })
+        .expect(200);
+
+      // Act: Resume at a later module without toggling lessons
+      const response = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          currentModuleId: 'course-1-module-2',
+        })
+        .expect(200);
+
+      // Assert: Current module updated, lessons preserved
+      expect(response.body.progress.currentModuleId).toBe('course-1-module-2');
+      expect(response.body.progress.completedLessons).toEqual([
+        'course-1-lesson-1',
+      ]);
+    });
+
+    it('should reject stale updates with a 409 conflict and the server state', async () => {
+      // Arrange: Register student and create progress
+      const student = await registerStudent('conflict@example.com');
+
+      const first = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          lessonId: 'course-1-lesson-1',
+          status: 'completed',
+        })
+        .expect(200);
+
+      const freshUpdatedAt = first.body.progress.updatedAt;
+      expect(typeof freshUpdatedAt).toBe('string');
+
+      // Another session writes newer progress
+      await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          lessonId: 'course-1-lesson-2',
+          status: 'completed',
+        })
+        .expect(200);
+
+      // Act: Stale client replays its old snapshot
+      const staleResponse = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          completedLessons: ['course-1-lesson-1'],
+          currentModuleId: 'course-1-module-1',
+          percentage: 25,
+          status: 'in_progress',
+          baseUpdatedAt: freshUpdatedAt,
+        })
+        .expect(409);
+
+      // Assert: Conflict surfaces the authoritative server state
+      expect(staleResponse.body.error).toContain('another session');
+      expect(staleResponse.body.progress.completedLessons).toEqual([
+        'course-1-lesson-1',
+        'course-1-lesson-2',
+      ]);
+    });
+
+    it('should accept writes whose concurrency token matches', async () => {
+      // Arrange: Register student and create progress
+      const student = await registerStudent('no-conflict@example.com');
+
+      const first = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          lessonId: 'course-1-lesson-1',
+          status: 'completed',
+        })
+        .expect(200);
+
+      const freshUpdatedAt = first.body.progress.updatedAt;
+
+      // Act: Write with a matching token
+      const response = await request(app)
+        .patch('/api/v1/learning/courses/course-1/progress')
+        .set('Authorization', `Bearer ${student.token}`)
+        .send({
+          lessonId: 'course-1-lesson-2',
+          status: 'completed',
+          baseUpdatedAt: freshUpdatedAt,
+        })
+        .expect(200);
+
+      // Assert: Update applied
+      expect(response.body.progress.completedLessons).toEqual([
+        'course-1-lesson-1',
+        'course-1-lesson-2',
+      ]);
+    });
+
     it('should validate required fields in request body', async () => {
       // Arrange: Register student
       const student = await registerStudent('missingfields@example.com');

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Navbar from '@/components/layout/Navbar';
 import RenderWarningModal from '@/components/layout/RenderWarningModal';
 import ResiliencyBanner from '@/components/layout/ResiliencyBanner';
 import WalletGate from '@/components/layout/WalletGate';
-import { OfflineNotification, ToastContainer } from '@/components/notifications';
+import { OfflineNotification, CourseNotificationListener, ToastContainer } from '@/components/notifications';
 import { OfflineSyncHandler } from '@/components/OfflineSyncHandler';
 import { SkipLink } from '@/components/ui/SkipLink';
 import { AuthProvider } from '@/contexts/AuthContext';
@@ -61,6 +61,7 @@ export default function RootLayout({
             <AuthProvider>
               <I18nProvider>
                 <NotificationProvider>
+                  <CourseNotificationListener />
                   <Web3OnboardingProvider>
                     <KeyboardShortcutsProvider>
                       <TutorialProvider>

--- a/frontend/src/components/notifications/CourseNotificationListener.tsx
+++ b/frontend/src/components/notifications/CourseNotificationListener.tsx
@@ -3,14 +3,45 @@
 import { useCourseNotifications } from '@/hooks/useCourseNotifications';
 
 /**
- * Renders nothing — exists solely to activate the
- * `useCourseNotifications` hook inside a server-rendered layout.
+ * Mounted once in the root layout to activate the `useCourseNotifications`
+ * hook so course-related WebSocket events are bridged into the
+ * NotificationContext for the entire app.
  *
- * Place once in the root layout so that course-related WebSocket
- * events are automatically bridged into the NotificationContext
- * for the entire app.
+ * Also renders a small, non-intrusive status pill while the live
+ * notification socket is disconnected or reconnecting, so users understand
+ * why realtime updates are temporarily delayed (#898).
  */
 export function CourseNotificationListener() {
-  useCourseNotifications();
-  return null;
+  const { connectionState, reconnectAttempt, retryExhausted, lastError } =
+    useCourseNotifications();
+
+  const isReconnecting = connectionState === 'reconnecting';
+  const isDisconnected = connectionState === 'disconnected';
+
+  if (!isReconnecting && !isDisconnected) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-white/10 bg-zinc-900/90 px-3 py-1.5 text-xs text-gray-300 shadow-lg backdrop-blur"
+    >
+      <span
+        className={`h-2 w-2 rounded-full ${
+          isReconnecting ? 'animate-pulse bg-amber-400' : 'bg-red-400'
+        }`}
+        aria-hidden="true"
+      />
+      <span>
+        {isReconnecting
+          ? `Reconnecting… (attempt ${Math.max(reconnectAttempt, 1)})`
+          : retryExhausted
+            ? 'Live notifications unavailable'
+            : 'Live notifications disconnected'}
+      </span>
+      {lastError ? <span className="sr-only">{lastError}</span> : null}
+    </div>
+  );
 }

--- a/frontend/src/hooks/__tests__/useCourseNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/useCourseNotifications.test.tsx
@@ -1,19 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { NotificationProvider, useNotifications } from '../../contexts/NotificationContext';
-import { useCourseNotifications } from '../useCourseNotifications';
+import {
+  useCourseNotifications,
+  COURSE_WS_MAX_RECONNECT_ATTEMPTS,
+  COURSE_WS_INITIAL_DELAY_MS,
+  COURSE_WS_MAX_DELAY_MS,
+  COURSE_WS_RANDOMIZATION_FACTOR,
+  COURSE_WS_CONNECTION_TIMEOUT_MS,
+} from '../useCourseNotifications';
 import type { ReactNode } from 'react';
 
-const { mockIo, mockOn, mockDisconnect } = vi.hoisted(() => {
+const { mockIo, mockOn, mockDisconnect, mockConnect, mockRemoveAllListeners } = vi.hoisted(() => {
   const mockOn = vi.fn();
   const mockDisconnect = vi.fn();
   const mockConnect = vi.fn();
+  const mockRemoveAllListeners = vi.fn();
   const mockIo = vi.fn(() => ({
     on: mockOn,
     disconnect: mockDisconnect,
     connect: mockConnect,
+    removeAllListeners: mockRemoveAllListeners,
   }));
-  return { mockIo, mockOn, mockDisconnect, mockConnect };
+  return { mockIo, mockOn, mockDisconnect, mockConnect, mockRemoveAllListeners };
 });
 
 vi.mock('socket.io-client', () => ({
@@ -23,8 +32,7 @@ vi.mock('socket.io-client', () => ({
 let registeredHandlers: Map<string, (...args: unknown[]) => void> = new Map();
 
 beforeEach(() => {
-  vi.useFakeTimers();
-  localStorage.setItem('auth_token', 'test-token');
+  localStorage.setItem('token', 'test-token');
   registeredHandlers = new Map();
 
   mockOn.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
@@ -34,15 +42,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  localStorage.removeItem('token');
   localStorage.removeItem('auth_token');
-  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
 function emitEvent(event: string, data: unknown) {
   const handler = registeredHandlers.get(event);
   if (handler) {
-    handler(data);
+    act(() => handler(data));
   }
 }
 
@@ -52,21 +60,33 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe('useCourseNotifications', () => {
   it('should not connect without an auth token', () => {
-    localStorage.removeItem('auth_token');
+    localStorage.removeItem('token');
 
     const { result } = renderHook(() => useCourseNotifications(), { wrapper });
 
     expect(mockIo).not.toHaveBeenCalled();
-    expect(result.current.current).toBeNull();
+    expect(result.current.connectionState).toBe('idle');
   });
 
   it('should connect with auth token', () => {
     renderHook(() => useCourseNotifications(), { wrapper });
 
     expect(mockIo).toHaveBeenCalledTimes(1);
-    const [url, opts] = mockIo.mock.calls[0];
+    const [url, opts] = mockIo.mock.calls[0] as [string, { auth: { token: string } }];
     expect(url).toBe('ws://localhost:8080');
     expect(opts.auth.token).toBe('test-token');
+  });
+
+  it('should configure bounded exponential backoff with jitter', () => {
+    renderHook(() => useCourseNotifications(), { wrapper });
+
+    const [, opts] = mockIo.mock.calls[0] as [string, Record<string, unknown>];
+    expect(opts.reconnection).toBe(true);
+    expect(opts.reconnectionAttempts).toBe(COURSE_WS_MAX_RECONNECT_ATTEMPTS);
+    expect(opts.reconnectionDelay).toBe(COURSE_WS_INITIAL_DELAY_MS);
+    expect(opts.reconnectionDelayMax).toBe(COURSE_WS_MAX_DELAY_MS);
+    expect(opts.randomizationFactor).toBe(COURSE_WS_RANDOMIZATION_FACTOR);
+    expect(opts.timeout).toBe(COURSE_WS_CONNECTION_TIMEOUT_MS);
   });
 
   it('should push course_created events as course_update notifications', () => {
@@ -75,44 +95,20 @@ describe('useCourseNotifications', () => {
       { wrapper },
     );
 
-    act(() => {
-      emitEvent('course_notification', {
-        id: 'n-1',
-        type: 'course_created',
-        courseId: 'c-1',
-        courseTitle: 'Web3 101',
-        title: 'New Course Available',
-        message: 'Start learning today!',
-        read: false,
-        createdAt: new Date().toISOString(),
-      });
+    emitEvent('course_notification', {
+      id: 'n-1',
+      type: 'course_created',
+      courseId: 'c-1',
+      courseTitle: 'Web3 101',
+      title: 'New Course Available',
+      message: 'Start learning today!',
+      read: false,
+      createdAt: new Date().toISOString(),
     });
 
     expect(notifResult.current.notifs.notifications).toHaveLength(1);
     expect(notifResult.current.notifs.notifications[0].type).toBe('course_update');
     expect(notifResult.current.notifs.notifications[0].title).toBe('New Course Available');
-  });
-
-  it('should push course_updated events as course_update notifications', () => {
-    const { result: notifResult } = renderHook(
-      () => ({ notifs: useNotifications(), _hook: useCourseNotifications() }),
-      { wrapper },
-    );
-
-    act(() => {
-      emitEvent('course_notification', {
-        id: 'n-2',
-        type: 'course_updated',
-        courseId: 'c-1',
-        courseTitle: 'Web3 101',
-        title: 'Course Updated',
-        message: 'New modules added.',
-        read: false,
-        createdAt: new Date().toISOString(),
-      });
-    });
-
-    expect(notifResult.current.notifs.notifications[0].type).toBe('course_update');
   });
 
   it('should push announcement events as announcement notifications', () => {
@@ -121,45 +117,105 @@ describe('useCourseNotifications', () => {
       { wrapper },
     );
 
-    act(() => {
-      emitEvent('course_notification', {
-        id: 'n-3',
-        type: 'announcement',
-        title: 'Platform Update',
-        message: 'We have new features!',
-        read: false,
-        createdAt: new Date().toISOString(),
-      });
+    emitEvent('course_notification', {
+      id: 'n-3',
+      type: 'announcement',
+      title: 'Platform Update',
+      message: 'We have new features!',
+      read: false,
+      createdAt: new Date().toISOString(),
     });
 
     expect(notifResult.current.notifs.notifications[0].type).toBe('announcement');
   });
 
-  it('should push learning_opportunity events correctly', () => {
-    const { result: notifResult } = renderHook(
-      () => ({ notifs: useNotifications(), _hook: useCourseNotifications() }),
-      { wrapper },
-    );
+  it('should track connection state as connected', () => {
+    const { result } = renderHook(() => useCourseNotifications(), { wrapper });
 
-    act(() => {
-      emitEvent('course_notification', {
-        id: 'n-4',
-        type: 'learning_opportunity',
-        title: 'Workshop Alert',
-        message: 'Sign up for the workshop.',
-        read: false,
-        createdAt: new Date().toISOString(),
-      });
-    });
+    expect(result.current.connectionState).toBe('idle');
 
-    expect(notifResult.current.notifs.notifications[0].type).toBe('learning_opportunity');
+    emitEvent('connect', undefined);
+
+    expect(result.current.connectionState).toBe('connected');
+    expect(result.current.reconnectAttempt).toBe(0);
+    expect(result.current.retryExhausted).toBe(false);
   });
 
-  it('should clean up socket on unmount', () => {
+  it('should enter reconnecting state on unexpected disconnect', () => {
+    const { result } = renderHook(() => useCourseNotifications(), { wrapper });
+
+    emitEvent('connect', undefined);
+    emitEvent('disconnect', 'transport close');
+
+    expect(result.current.connectionState).toBe('reconnecting');
+  });
+
+  it('should track reconnect attempts and recover', () => {
+    const { result } = renderHook(() => useCourseNotifications(), { wrapper });
+
+    emitEvent('connect', undefined);
+    emitEvent('disconnect', 'transport close');
+    emitEvent('reconnect_attempt', 1);
+
+    expect(result.current.connectionState).toBe('reconnecting');
+    expect(result.current.reconnectAttempt).toBe(1);
+
+    emitEvent('reconnect', 1);
+
+    expect(result.current.connectionState).toBe('connected');
+    expect(result.current.reconnectAttempt).toBe(0);
+    expect(result.current.retryExhausted).toBe(false);
+  });
+
+  it('should mark retries exhausted when reconnection fails', () => {
+    const { result } = renderHook(() => useCourseNotifications(), { wrapper });
+
+    emitEvent('connect_error', { message: 'xhr poll error' });
+    emitEvent('reconnect_attempt', 1);
+    emitEvent('reconnect_failed');
+
+    expect(result.current.connectionState).toBe('disconnected');
+    expect(result.current.retryExhausted).toBe(true);
+  });
+
+  it('should clean up socket on unmount and prevent reconnect attempts', () => {
     const { unmount } = renderHook(() => useCourseNotifications(), { wrapper });
 
     unmount();
 
+    expect(mockRemoveAllListeners).toHaveBeenCalled();
     expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('should not reconnect after manual logout (token removed)', () => {
+    renderHook(() => useCourseNotifications(), { wrapper });
+
+    expect(mockIo).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      localStorage.removeItem('token');
+      window.dispatchEvent(new Event('storage'));
+    });
+
+    // The stale socket is torn down and no new socket is created.
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove listeners and disconnect when the url changes (route change)', () => {
+    const { rerender } = renderHook(
+      ({ url }: { url: string }) => useCourseNotifications(url),
+      { wrapper, initialProps: { url: 'ws://localhost:8080' } },
+    );
+
+    expect(mockIo).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ url: 'ws://localhost:8081' });
+    });
+
+    expect(mockRemoveAllListeners).toHaveBeenCalled();
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockIo).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/hooks/__tests__/useRoadmapProgress.test.ts
+++ b/frontend/src/hooks/__tests__/useRoadmapProgress.test.ts
@@ -1,20 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useRoadmapProgress } from '../useRoadmapProgress';
-import { learningAPI } from '@/lib/learning-api';
+import {
+  learningAPI,
+  ProgressUnavailableError,
+  ProgressConflictError,
+} from '@/lib/learning-api';
 import * as learningJourney from '@/lib/learning-journey';
 import { useUserStore } from '@/stores/userStore';
 import type { Course } from '@/lib/api';
 
-vi.mock('@/lib/learning-api', () => ({
-  learningAPI: {
-    getProgress: vi.fn(),
-    updateProgress: vi.fn(),
-    convertToProgressData: vi.fn(),
-    getLocalProgressFallback: vi.fn(),
-    saveLocalProgress: vi.fn(),
-  },
-}));
+vi.mock('@/lib/learning-api', () => {
+  class ProgressUnavailableError extends Error {
+    constructor(message = 'Progress could not be saved') {
+      super(message);
+      this.name = 'ProgressUnavailableError';
+    }
+  }
+  class ProgressConflictError extends Error {
+    current: unknown;
+    constructor(message = 'Conflict', current: unknown = null) {
+      super(message);
+      this.name = 'ProgressConflictError';
+      this.current = current;
+    }
+  }
+  return {
+    ProgressUnavailableError,
+    ProgressConflictError,
+    learningAPI: {
+      getProgress: vi.fn(),
+      updateProgress: vi.fn(),
+      convertToProgressData: vi.fn(),
+      getLocalProgressFallback: vi.fn(),
+      saveLocalProgress: vi.fn(),
+    },
+  };
+});
 
 vi.mock('@/lib/learning-journey', () => ({
   getStoredLearningJourney: vi.fn(),
@@ -205,7 +227,7 @@ describe('useRoadmapProgress', () => {
     expect(result.current.selectedNodeId).toBe('level-2');
   });
 
-  it('updates node progress', async () => {
+  it('updates node progress and reconciles with the server snapshot', async () => {
     vi.mocked(learningAPI.getProgress).mockResolvedValue({
       studentId: 'student-1',
       courseId: 'course-1',
@@ -215,17 +237,30 @@ describe('useRoadmapProgress', () => {
       status: 'not_started',
       lastAccessedAt: null,
       completedAt: null,
+      updatedAt: '2026-01-01T00:00:00.000Z',
     });
 
-    vi.mocked(learningAPI.convertToProgressData).mockReturnValue({
-      completedLessons: [],
-      currentModuleId: null,
-      percentage: 0,
-      status: 'not_started',
+    vi.mocked(learningAPI.convertToProgressData).mockImplementation((r) => ({
+      completedLessons: r.completedLessons,
+      currentModuleId: r.currentModuleId ?? null,
+      percentage: r.percentage,
+      status: r.status,
+      lastAccessedAt: r.lastAccessedAt ?? null,
+      completedAt: r.completedAt ?? null,
+      updatedAt: r.updatedAt ?? null,
+    }));
+
+    vi.mocked(learningAPI.updateProgress).mockResolvedValue({
+      studentId: 'student-1',
+      courseId: 'course-1',
+      completedLessons: ['level-1'],
+      currentModuleId: 'level-1',
+      percentage: 50,
+      status: 'in_progress',
       lastAccessedAt: null,
       completedAt: null,
+      updatedAt: '2026-01-02T00:00:00.000Z',
     });
-    vi.mocked(learningAPI.updateProgress).mockResolvedValue(null);
 
     const { result } = renderHook(() =>
       useRoadmapProgress(mockCourse)
@@ -242,6 +277,158 @@ describe('useRoadmapProgress', () => {
     expect(result.current.progress?.completedLessons).toContain(
       'level-1'
     );
+    expect(learningAPI.updateProgress).toHaveBeenCalledWith(
+      'course-1',
+      expect.objectContaining({
+        completedLessons: ['level-1'],
+        baseUpdatedAt: '2026-01-01T00:00:00.000Z',
+      })
+    );
+    // Reconciles with the server's fresh concurrency token.
+    expect(result.current.progress?.updatedAt).toBe(
+      '2026-01-02T00:00:00.000Z'
+    );
+  });
+
+  it('rolls back the optimistic update when persistence fails', async () => {
+    vi.mocked(learningAPI.getProgress).mockResolvedValue({
+      studentId: 'student-1',
+      courseId: 'course-1',
+      completedLessons: [],
+      currentModuleId: null,
+      percentage: 0,
+      status: 'not_started',
+      lastAccessedAt: null,
+      completedAt: null,
+    });
+
+    vi.mocked(learningAPI.convertToProgressData).mockImplementation((r) => ({
+      completedLessons: r.completedLessons,
+      currentModuleId: r.currentModuleId ?? null,
+      percentage: r.percentage,
+      status: r.status,
+      lastAccessedAt: r.lastAccessedAt ?? null,
+      completedAt: r.completedAt ?? null,
+      updatedAt: r.updatedAt ?? null,
+    }));
+
+    vi.mocked(learningAPI.updateProgress).mockRejectedValue(
+      new ProgressUnavailableError('learning service is temporarily unavailable')
+    );
+
+    const { result } = renderHook(() =>
+      useRoadmapProgress(mockCourse)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updateNodeProgress('level-1', true);
+    });
+
+    // A failed save must not leave the UI falsely marked complete (#901).
+    expect(result.current.progress?.completedLessons).not.toContain(
+      'level-1'
+    );
+    expect(result.current.error).toContain('temporarily unavailable');
+  });
+
+  it('rolls back the optimistic update when the API returns no saved progress', async () => {
+    vi.mocked(learningAPI.getProgress).mockResolvedValue({
+      studentId: 'student-1',
+      courseId: 'course-1',
+      completedLessons: [],
+      currentModuleId: null,
+      percentage: 0,
+      status: 'not_started',
+      lastAccessedAt: null,
+      completedAt: null,
+    });
+
+    vi.mocked(learningAPI.convertToProgressData).mockImplementation((r) => ({
+      completedLessons: r.completedLessons,
+      currentModuleId: r.currentModuleId ?? null,
+      percentage: r.percentage,
+      status: r.status,
+      lastAccessedAt: r.lastAccessedAt ?? null,
+      completedAt: r.completedAt ?? null,
+      updatedAt: r.updatedAt ?? null,
+    }));
+
+    vi.mocked(learningAPI.updateProgress).mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useRoadmapProgress(mockCourse)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updateNodeProgress('level-1', true);
+    });
+
+    expect(result.current.progress?.completedLessons).not.toContain(
+      'level-1'
+    );
+    expect(result.current.error).toBe('Progress could not be saved');
+  });
+
+  it('reconciles with the server state on a stale-update conflict', async () => {
+    vi.mocked(learningAPI.getProgress).mockResolvedValue({
+      studentId: 'student-1',
+      courseId: 'course-1',
+      completedLessons: [],
+      currentModuleId: null,
+      percentage: 0,
+      status: 'not_started',
+      lastAccessedAt: null,
+      completedAt: null,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    vi.mocked(learningAPI.convertToProgressData).mockImplementation((r) => ({
+      completedLessons: r.completedLessons,
+      currentModuleId: r.currentModuleId ?? null,
+      percentage: r.percentage,
+      status: r.status,
+      lastAccessedAt: r.lastAccessedAt ?? null,
+      completedAt: r.completedAt ?? null,
+      updatedAt: r.updatedAt ?? null,
+    }));
+
+    vi.mocked(learningAPI.updateProgress).mockRejectedValue(
+      new ProgressConflictError('Progress was updated in another session', {
+        studentId: 'student-1',
+        courseId: 'course-1',
+        completedLessons: ['level-2'],
+        currentModuleId: 'level-2',
+        percentage: 50,
+        status: 'in_progress',
+        lastAccessedAt: null,
+        completedAt: null,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useRoadmapProgress(mockCourse)
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updateNodeProgress('level-1', true);
+    });
+
+    // Deterministic conflict behavior: the server's state is authoritative.
+    expect(result.current.progress?.completedLessons).toEqual(['level-2']);
+    expect(result.current.error).toContain('another session');
   });
 
   it('handles null course', () => {

--- a/frontend/src/hooks/useCourseNotifications.ts
+++ b/frontend/src/hooks/useCourseNotifications.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, type RefObject } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { useNotifications } from '@/contexts/NotificationContext';
 
@@ -22,6 +22,44 @@ interface CourseNotificationEvent {
   metadata?: Record<string, unknown>;
   read: boolean;
   createdAt: string;
+}
+
+/**
+ * Reconnection policy (#898).
+ *
+ * socket.io-client applies bounded exponential backoff with full jitter:
+ * `delay = min(base * 2^(attempt-1), maxDelay) * (0.5..1)`. We bound both the
+ * attempt count and the maximum delay so a dead endpoint cannot cause an
+ * unbounded reconnect storm, and randomize the delay so many clients do not
+ * reconnect in lockstep.
+ */
+export const COURSE_WS_MAX_RECONNECT_ATTEMPTS = 8;
+export const COURSE_WS_INITIAL_DELAY_MS = 500;
+export const COURSE_WS_MAX_DELAY_MS = 15_000;
+export const COURSE_WS_RANDOMIZATION_FACTOR = 0.5;
+export const COURSE_WS_CONNECTION_TIMEOUT_MS = 10_000;
+
+/**
+ * Connection state exposed to the UI so it can render a non-intrusive
+ * disconnected / reconnecting indicator (#898).
+ *
+ * - `idle`        — no authenticated session, or torn down.
+ * - `connected`   — live socket with the notification bridge active.
+ * - `reconnecting`— connection lost; bounded backoff retry in progress.
+ * - `disconnected`— retries exhausted or the socket was manually closed.
+ */
+export type CourseConnectionState =
+  | 'idle'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected';
+
+export interface UseCourseNotificationsReturn {
+  socketRef: RefObject<Socket | null>;
+  connectionState: CourseConnectionState;
+  reconnectAttempt: number;
+  retryExhausted: boolean;
+  lastError: string | null;
 }
 
 /**
@@ -49,6 +87,20 @@ function mapType(
  * `course_notification` events, and pushes them into the
  * `NotificationContext` so they appear in the bell / sidebar / toasts.
  *
+ * Reliability guarantees (#898):
+ *
+ * - Unexpected disconnects trigger a *bounded* number of reconnect attempts
+ *   using exponential backoff with jitter (`reconnectionAttempts`,
+ *   `reconnectionDelay`, `reconnectionDelayMax`, `randomizationFactor`).
+ * - Component unmount or a missing auth token (manual logout) tears the
+ *   socket down and *prevents* further reconnect attempts.
+ * - Route changes re-run the effect; the previous socket's listeners are
+ *   removed and the stale connection is closed, so there are no duplicate
+ *   listeners or zombie connections.
+ * - A recovered connection resumes event delivery without duplication.
+ * - `connectionState` / `reconnectAttempt` / `retryExhausted` expose the
+ *   recovery behavior to the UI.
+ *
  * Must be used inside a `<NotificationProvider>`.
  *
  * @example
@@ -59,9 +111,35 @@ function mapType(
  * }
  * ```
  */
-export function useCourseNotifications(url?: string) {
+export function useCourseNotifications(
+  url?: string
+): UseCourseNotificationsReturn {
   const { push } = useNotifications();
   const socketRef = useRef<Socket | null>(null);
+  // True once the socket has been intentionally torn down (unmount or
+  // logout) so a late 'disconnect' event is not misread as a network fault.
+  const manualDisconnectRef = useRef(false);
+
+  const [token, setToken] = useState<string | null>(null);
+  const [connectionState, setConnectionState] =
+    useState<CourseConnectionState>('idle');
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
+  const [retryExhausted, setRetryExhausted] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  // Track the auth token so a manual logout (token removed) tears down the
+  // socket and prevents reconnect attempts. The 'storage' event covers
+  // cross-tab logout; same-tab logout re-renders via the auth flow.
+  useEffect(() => {
+    const readToken = () =>
+      setToken(
+        localStorage.getItem('token') ??
+          localStorage.getItem('auth_token')
+      );
+    readToken();
+    window.addEventListener('storage', readToken);
+    return () => window.removeEventListener('storage', readToken);
+  }, []);
 
   const handleEvent = useCallback(
     (event: CourseNotificationEvent) => {
@@ -75,8 +153,9 @@ export function useCourseNotifications(url?: string) {
   );
 
   useEffect(() => {
-    const token = localStorage.getItem('auth_token');
     if (!token) {
+      // No authenticated session (e.g. logged out) — do not connect (#898).
+      setConnectionState('idle');
       return;
     }
 
@@ -86,11 +165,23 @@ export function useCourseNotifications(url?: string) {
     const socket = io(socketUrl, {
       auth: { token },
       transports: ['websocket', 'polling'],
+      // Bounded exponential backoff with jitter (#898).
+      reconnection: true,
+      reconnectionAttempts: COURSE_WS_MAX_RECONNECT_ATTEMPTS,
+      reconnectionDelay: COURSE_WS_INITIAL_DELAY_MS,
+      reconnectionDelayMax: COURSE_WS_MAX_DELAY_MS,
+      randomizationFactor: COURSE_WS_RANDOMIZATION_FACTOR,
+      timeout: COURSE_WS_CONNECTION_TIMEOUT_MS,
     });
 
     socketRef.current = socket;
+    manualDisconnectRef.current = false;
 
     socket.on('connect', () => {
+      setConnectionState('connected');
+      setReconnectAttempt(0);
+      setRetryExhausted(false);
+      setLastError(null);
       console.log('[CourseNotifications] WebSocket connected');
     });
 
@@ -98,19 +189,71 @@ export function useCourseNotifications(url?: string) {
       handleEvent(event);
     });
 
-    socket.on('disconnect', () => {
-      console.log('[CourseNotifications] WebSocket disconnected');
+    socket.on('disconnect', (reason) => {
+      if (manualDisconnectRef.current) {
+        // Intended teardown (unmount / logout) — never reconnect.
+        setConnectionState('disconnected');
+        return;
+      }
+      console.log(
+        '[CourseNotifications] WebSocket disconnected:',
+        reason,
+      );
+      setConnectionState('reconnecting');
     });
 
     socket.on('connect_error', (err) => {
-      console.error('[CourseNotifications] Connection error:', err.message);
+      console.error(
+        '[CourseNotifications] Connection error:',
+        err.message,
+      );
+      setLastError(err.message);
+      if (!manualDisconnectRef.current) {
+        setConnectionState('reconnecting');
+      }
+    });
+
+    socket.on('reconnect_attempt', (attempt: number) => {
+      setReconnectAttempt(attempt);
+      setConnectionState('reconnecting');
+    });
+
+    socket.on('reconnect', (attempt: number) => {
+      setConnectionState('connected');
+      setReconnectAttempt(0);
+      setRetryExhausted(false);
+      setLastError(null);
+      console.log(
+        '[CourseNotifications] WebSocket reconnected after',
+        attempt,
+        'attempt(s)',
+      );
+    });
+
+    socket.on('reconnect_failed', () => {
+      setConnectionState('disconnected');
+      setRetryExhausted(true);
+      console.warn(
+        '[CourseNotifications] Reconnect attempts exhausted',
+      );
     });
 
     return () => {
+      // Prevent duplicate listeners and stale connections during route
+      // changes / unmount, and never reconnect after teardown (#898).
+      manualDisconnectRef.current = true;
+      socket.removeAllListeners();
       socket.disconnect();
       socketRef.current = null;
+      setConnectionState('idle');
     };
-  }, [url, handleEvent]);
+  }, [url, token, handleEvent]);
 
-  return socketRef;
+  return {
+    socketRef,
+    connectionState,
+    reconnectAttempt,
+    retryExhausted,
+    lastError,
+  };
 }

--- a/frontend/src/hooks/useRoadmapProgress.ts
+++ b/frontend/src/hooks/useRoadmapProgress.ts
@@ -13,7 +13,7 @@ import {
   computeLayout,
 } from '@/lib/roadmap-utils';
 import { getLearningJourney, getStoredLearningJourney } from '@/lib/learning-journey';
-import { learningAPI, ProgressUnavailableError } from '@/lib/learning-api';
+import { learningAPI, ProgressUnavailableError, ProgressConflictError } from '@/lib/learning-api';
 import { useUserStore } from '@/stores/userStore';
 import type { Course } from '@/lib/api';
 
@@ -142,6 +142,8 @@ export function useRoadmapProgress(
     async (moduleId: string, completed: boolean) => {
       if (!course) return;
 
+      const previousProgress = progress;
+
       const updatedProgress: ProgressData = {
         completedLessons: completed
           ? [...(progress?.completedLessons ?? []), moduleId]
@@ -153,6 +155,7 @@ export function useRoadmapProgress(
         status: 'in_progress',
         lastAccessedAt: new Date().toISOString(),
         completedAt: progress?.completedAt ?? null,
+        updatedAt: progress?.updatedAt ?? null,
       };
 
       const totalLessons = roadmapCourse?.nodes.length ?? 1;
@@ -162,30 +165,72 @@ export function useRoadmapProgress(
       if (updatedProgress.percentage >= 100) {
         updatedProgress.status = 'completed';
         updatedProgress.completedAt = new Date().toISOString();
+      } else if (updatedProgress.completedLessons.length === 0) {
+        updatedProgress.status = 'not_started';
       }
 
+      // Optimistic UI update — rolled back below if persistence fails so a
+      // failed save never leaves the UI falsely marked complete (#901).
       setProgress(updatedProgress);
+      learningAPI.saveLocalProgress(course.id, updatedProgress);
 
       if (completed) {
         completeModule(moduleId);
       }
 
-      learningAPI.saveLocalProgress(course.id, updatedProgress);
-
       try {
-        await learningAPI.updateProgress(course.id, updatedProgress);
-      } catch (err) {
-        if (err instanceof ProgressUnavailableError) {
-          // Local/offline progress was saved above, but the learner
-          // must be told their progress was NOT recorded server-side —
-          // never claim a save succeeded when it didn't (#911).
-          setError(err.message);
+        const saved = await learningAPI.updateProgress(course.id, {
+          completedLessons: updatedProgress.completedLessons,
+          currentModuleId: updatedProgress.currentModuleId,
+          percentage: updatedProgress.percentage,
+          status: updatedProgress.status,
+          baseUpdatedAt: previousProgress?.updatedAt ?? null,
+        });
+
+        if (saved) {
+          // Reconcile with the authoritative server snapshot (carries the
+          // fresh `updatedAt` token used for the next write).
+          const reconciled = learningAPI.convertToProgressData(saved);
+          setProgress(reconciled);
+          learningAPI.saveLocalProgress(course.id, reconciled);
+          setError(null);
         } else {
-          throw err;
+          throw new Error('Progress could not be saved');
         }
+      } catch (err) {
+        if (err instanceof ProgressConflictError) {
+          // Deterministic stale/concurrent behavior (#901): the server is
+          // authoritative — refetch and reflect stored state, then tell the
+          // learner to reconcile.
+          setError(err.message);
+          if (err.current) {
+            const serverProgress = learningAPI.convertToProgressData(
+              err.current
+            );
+            setProgress(serverProgress);
+            learningAPI.saveLocalProgress(course.id, serverProgress);
+          } else {
+            await fetchProgress();
+          }
+          return;
+        }
+
+        // Roll back the optimistic update so the UI does not show a
+        // completion that was never persisted.
+        setProgress(previousProgress);
+        if (previousProgress) {
+          learningAPI.saveLocalProgress(course.id, previousProgress);
+        }
+        setError(
+          err instanceof ProgressUnavailableError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : 'Failed to save progress'
+        );
       }
     },
-    [course, progress, roadmapCourse, completeModule]
+    [course, progress, roadmapCourse, completeModule, fetchProgress]
   );
 
   const refetch = useCallback(async () => {

--- a/frontend/src/lib/__tests__/learning-api.test.ts
+++ b/frontend/src/lib/__tests__/learning-api.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { learningAPI } from '../learning-api';
+import {
+  learningAPI,
+  ProgressConflictError,
+} from '../learning-api';
 import apiClient from '../api-client';
 
 vi.mock('../api-client', () => ({
@@ -15,17 +18,21 @@ describe('learningAPI', () => {
   });
 
   describe('getProgress', () => {
-    it('returns normalized progress on success', async () => {
+    it('returns normalized progress from the wrapped backend response', async () => {
       vi.mocked(apiClient.get).mockResolvedValue({
         data: {
-          studentId: 'student-1',
-          courseId: 'course-1',
-          completedLessons: ['lesson-1'],
-          currentModuleId: 'mod-2',
-          percentage: 50,
-          status: 'in_progress',
-          lastAccessedAt: '2024-01-01',
-          completedAt: null,
+          progress: {
+            studentId: 'student-1',
+            courseId: 'course-1',
+            completedLessons: ['lesson-1'],
+            currentModuleId: 'mod-2',
+            percentage: 50,
+            status: 'in_progress',
+            lastAccessedAt: '2024-01-01',
+            completedAt: null,
+            updatedAt: '2024-01-02T00:00:00.000Z',
+          },
+          dataSource: 'live',
         },
       });
 
@@ -39,6 +46,7 @@ describe('learningAPI', () => {
         status: 'in_progress',
         lastAccessedAt: '2024-01-01',
         completedAt: null,
+        updatedAt: '2024-01-02T00:00:00.000Z',
       });
     });
 
@@ -63,14 +71,17 @@ describe('learningAPI', () => {
     it('normalizes percentage as number', async () => {
       vi.mocked(apiClient.get).mockResolvedValue({
         data: {
-          studentId: 's-1',
-          courseId: 'c-1',
-          completedLessons: [],
-          currentModuleId: null,
-          percentage: '75',
-          status: 'in_progress',
-          lastAccessedAt: null,
-          completedAt: null,
+          progress: {
+            studentId: 's-1',
+            courseId: 'c-1',
+            completedLessons: [],
+            currentModuleId: null,
+            percentage: '75',
+            status: 'in_progress',
+            lastAccessedAt: null,
+            completedAt: null,
+          },
+          dataSource: 'live',
         },
       });
 
@@ -80,28 +91,43 @@ describe('learningAPI', () => {
   });
 
   describe('updateProgress', () => {
-    it('sends PATCH request and invalidates cache', async () => {
+    it('sends PATCH request, passes the concurrency token, and invalidates cache', async () => {
       vi.mocked(apiClient.patch).mockResolvedValue({
         data: {
-          studentId: 's-1',
-          courseId: 'c-1',
-          completedLessons: ['l-1'],
-          currentModuleId: null,
-          percentage: 50,
-          status: 'in_progress',
-          lastAccessedAt: null,
-          completedAt: null,
+          progress: {
+            studentId: 's-1',
+            courseId: 'c-1',
+            completedLessons: ['l-1'],
+            currentModuleId: null,
+            percentage: 50,
+            status: 'in_progress',
+            lastAccessedAt: null,
+            completedAt: null,
+            updatedAt: '2024-01-03T00:00:00.000Z',
+          },
+          dataSource: 'live',
         },
       });
 
       const result = await learningAPI.updateProgress('c-1', {
         completedLessons: ['l-1'],
+        currentModuleId: null,
+        percentage: 50,
+        status: 'in_progress',
+        baseUpdatedAt: '2024-01-01T00:00:00.000Z',
       });
 
       expect(result).toBeTruthy();
+      expect(result?.updatedAt).toBe('2024-01-03T00:00:00.000Z');
       expect(apiClient.patch).toHaveBeenCalledWith(
         '/learning/courses/c-1/progress',
-        { completedLessons: ['l-1'] }
+        {
+          completedLessons: ['l-1'],
+          currentModuleId: null,
+          percentage: 50,
+          status: 'in_progress',
+          baseUpdatedAt: '2024-01-01T00:00:00.000Z',
+        }
       );
     });
 
@@ -112,6 +138,58 @@ describe('learningAPI', () => {
 
       const result = await learningAPI.updateProgress('c-1', {});
       expect(result).toBeNull();
+    });
+
+    it('throws ProgressConflictError with the server state on 409', async () => {
+      vi.mocked(apiClient.patch).mockRejectedValue({
+        response: {
+          status: 409,
+          data: {
+            error: 'Progress was updated in another session; refresh to reconcile',
+            progress: {
+              studentId: 's-1',
+              courseId: 'c-1',
+              completedLessons: ['l-2'],
+              currentModuleId: null,
+              percentage: 50,
+              status: 'in_progress',
+              lastAccessedAt: null,
+              completedAt: null,
+              updatedAt: '2024-01-03T00:00:00.000Z',
+            },
+          },
+        },
+      });
+
+      const promise = learningAPI.updateProgress('c-1', {
+        completedLessons: ['l-1'],
+      });
+
+      await expect(promise).rejects.toBeInstanceOf(ProgressConflictError);
+      await expect(promise).rejects.toMatchObject({
+        message: 'Progress was updated in another session; refresh to reconcile',
+        current: expect.objectContaining({
+          completedLessons: ['l-2'],
+          updatedAt: '2024-01-03T00:00:00.000Z',
+        }),
+      });
+    });
+
+    it('throws ProgressUnavailableError on 503', async () => {
+      vi.mocked(apiClient.patch).mockRejectedValue({
+        response: {
+          status: 503,
+          data: { error: 'learning service is temporarily unavailable' },
+        },
+      });
+
+      const promise = learningAPI.updateProgress('c-1', {
+        completedLessons: ['l-1'],
+      });
+
+      await expect(promise).rejects.toThrow(
+        'learning service is temporarily unavailable'
+      );
     });
   });
 
@@ -126,6 +204,7 @@ describe('learningAPI', () => {
         status: 'in_progress',
         lastAccessedAt: '2024-06-01',
         completedAt: null,
+        updatedAt: '2024-06-02T00:00:00.000Z',
       });
 
       expect(result).toEqual({
@@ -135,6 +214,7 @@ describe('learningAPI', () => {
         status: 'in_progress',
         lastAccessedAt: '2024-06-01',
         completedAt: null,
+        updatedAt: '2024-06-02T00:00:00.000Z',
       });
     });
   });

--- a/frontend/src/lib/learning-api.ts
+++ b/frontend/src/lib/learning-api.ts
@@ -25,6 +25,8 @@ export interface LearningProgressResponse {
   status: 'not_started' | 'in_progress' | 'completed';
   lastAccessedAt: string | null;
   completedAt: string | null;
+  /** Server-side `updatedAt` — used as the optimistic-concurrency token. */
+  updatedAt?: string | null;
 }
 
 // Whether a response reflects the live database or the backend's
@@ -35,6 +37,23 @@ export class ProgressUnavailableError extends Error {
   constructor(message = 'Progress could not be saved: learning service is temporarily unavailable') {
     super(message);
     this.name = 'ProgressUnavailableError';
+  }
+}
+
+/**
+ * Thrown when a progress save is rejected with HTTP 409 because another
+ * session wrote newer progress first. Deterministic conflict behavior: the
+ * server's state is authoritative and the UI reconciles by refetching.
+ */
+export class ProgressConflictError extends Error {
+  readonly current: LearningProgressResponse | null;
+  constructor(
+    message = 'Progress was updated in another session',
+    current: LearningProgressResponse | null = null
+  ) {
+    super(message);
+    this.name = 'ProgressConflictError';
+    this.current = current;
   }
 }
 
@@ -75,10 +94,26 @@ function normalizeProgressResponse(
         typeof d.lastAccessedAt === 'string' ? d.lastAccessedAt : null,
       completedAt:
         typeof d.completedAt === 'string' ? d.completedAt : null,
+      updatedAt:
+        typeof d.updatedAt === 'string' ? d.updatedAt : null,
     };
   }
 
   return null;
+}
+
+/**
+ * The backend wraps progress in `{ progress, dataSource }`. Accept both that
+ * wrapper and a bare progress object for robustness.
+ */
+function unwrapProgressBody(data: unknown): unknown {
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    if (d && typeof d.progress === 'object' && d.progress !== null) {
+      return d.progress;
+    }
+  }
+  return data;
 }
 
 export const learningAPI = {
@@ -115,7 +150,7 @@ export const learningAPI = {
       const response = await apiClient.get(
         `/learning/courses/${courseId}/progress`
       );
-      return normalizeProgressResponse(response.data);
+      return normalizeProgressResponse(unwrapProgressBody(response.data));
     } catch {
       return null;
     }
@@ -135,7 +170,7 @@ export const learningAPI = {
       );
       const data = response.data as { dataSource?: LearningDataSource };
       return {
-        progress: normalizeProgressResponse(response.data),
+        progress: normalizeProgressResponse(unwrapProgressBody(response.data)),
         dataSource: data?.dataSource ?? 'live',
       };
     } catch {
@@ -144,10 +179,13 @@ export const learningAPI = {
   },
 
   /**
-   * Updates progress. Throws ProgressUnavailableError when the backend
-   * reports it could not persist the update (HTTP 503, learning
-   * service degraded) — callers must surface this to the learner
-   * rather than assuming the save succeeded (#911).
+   * Updates progress. The payload is the learner's whole progress state plus
+   * the `baseUpdatedAt` concurrency token the client last observed; the
+   * backend applies it deterministically.
+   *
+   * Throws ProgressUnavailableError when the backend reports it could not
+   * persist the update (HTTP 503) and ProgressConflictError when the write is
+   * stale (HTTP 409) — callers must reconcile instead of assuming success.
    */
   updateProgress: async (
     courseId: string,
@@ -156,12 +194,22 @@ export const learningAPI = {
       currentModuleId: string | null;
       percentage: number;
       status: string;
+      baseUpdatedAt: string | null;
     }>
   ): Promise<LearningProgressResponse | null> => {
-    if (typeof window !== 'undefined' && !navigator.onLine && data.completedLessons?.length) {
+    if (
+      typeof window !== 'undefined' &&
+      !navigator.onLine &&
+      Array.isArray(data.completedLessons) &&
+      data.completedLessons.length > 0
+    ) {
       await queueLessonProgressCompletion({
         courseId,
-        lessonId: data.completedLessons[data.completedLessons.length - 1],
+        lessonId: data.completedLessons[data.completedLessons.length - 1]!,
+        completedLessons: data.completedLessons,
+        currentModuleId: data.currentModuleId ?? null,
+        percentage: data.percentage ?? 0,
+        status: data.status,
       });
     }
 
@@ -173,14 +221,23 @@ export const learningAPI = {
       apiRequestCache.invalidate(
         `learning:progress:${courseId}`
       );
-      return normalizeProgressResponse(response.data);
+      return normalizeProgressResponse(unwrapProgressBody(response.data));
     } catch (err: unknown) {
-      const status = (err as { response?: { status?: number; data?: { error?: string } } })
+      const status = (err as { response?: { status?: number; data?: { error?: string; progress?: unknown } } })
         ?.response?.status;
       if (status === 503) {
         const message = (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error;
         throw new ProgressUnavailableError(message);
+      }
+      if (status === 409) {
+        const conflict = (err as { response?: { data?: { error?: string; progress?: unknown } } })?.response?.data;
+        throw new ProgressConflictError(
+          conflict?.error,
+          normalizeProgressResponse(
+            unwrapProgressBody(conflict?.progress ?? conflict)
+          )
+        );
       }
       return null;
     }
@@ -196,6 +253,7 @@ export const learningAPI = {
       status: response.status,
       lastAccessedAt: response.lastAccessedAt,
       completedAt: response.completedAt,
+      updatedAt: response.updatedAt ?? null,
     };
   },
 

--- a/frontend/src/lib/offline-sync.test.ts
+++ b/frontend/src/lib/offline-sync.test.ts
@@ -56,10 +56,16 @@ describe('offline-sync', () => {
   });
 
   it('queues lesson progress and flushes it when online', async () => {
+    localStorage.setItem('token', 'test-token');
+
     await queueLessonProgressCompletion({
       courseId: 'course-1',
       lessonId: 'lesson-1',
       completedAt: '2026-06-25T00:00:00.000Z',
+      completedLessons: ['lesson-1'],
+      currentModuleId: 'mod-1',
+      percentage: 50,
+      status: 'in_progress',
     });
 
     let queuedProgress = await getQueuedLessonProgress();
@@ -74,10 +80,17 @@ describe('offline-sync', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/learning/courses/course-1/progress', {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
       credentials: 'same-origin',
       body: JSON.stringify({
-        completedLessonId: 'lesson-1',
+        lessonId: 'lesson-1',
+        status: 'completed',
+        completedLessons: ['lesson-1'],
+        currentModuleId: 'mod-1',
+        percentage: 50,
         completedAt: '2026-06-25T00:00:00.000Z',
       }),
     });

--- a/frontend/src/lib/offline-sync.ts
+++ b/frontend/src/lib/offline-sync.ts
@@ -21,6 +21,12 @@ export interface QueuedLessonProgress {
   completedAt: string;
   url: string;
   createdAt: number;
+  /** Snapshot of the learner's progress at queue time so the offline flush
+   *  can replay the same whole-state update the backend schema accepts. */
+  completedLessons?: string[];
+  currentModuleId?: string | null;
+  percentage?: number;
+  status?: string;
 }
 
 let dbPromise: Promise<IDBDatabase> | null = null;
@@ -100,6 +106,10 @@ export async function queueLessonProgressCompletion(input: {
   courseId: string;
   lessonId: string;
   completedAt?: string;
+  completedLessons?: string[];
+  currentModuleId?: string | null;
+  percentage?: number;
+  status?: string;
 }) {
   if (typeof window === 'undefined') return;
 
@@ -111,6 +121,10 @@ export async function queueLessonProgressCompletion(input: {
     completedAt,
     url: `/learning/courses/${input.courseId}/progress`,
     createdAt: Date.now(),
+    completedLessons: input.completedLessons,
+    currentModuleId: input.currentModuleId,
+    percentage: input.percentage,
+    status: input.status,
   });
 }
 
@@ -161,12 +175,24 @@ export async function flushQueuedLessonProgress() {
   const queuedItems = await getQueuedLessonProgress();
   for (const item of queuedItems) {
     try {
+      const token = localStorage.getItem('token');
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
       const response = await fetch(item.url, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         credentials: 'same-origin',
         body: JSON.stringify({
-          completedLessonId: item.lessonId,
+          lessonId: item.lessonId,
+          status: 'completed',
+          completedLessons: item.completedLessons,
+          currentModuleId: item.currentModuleId,
+          percentage: item.percentage,
           completedAt: item.completedAt,
         }),
       });

--- a/frontend/src/lib/types/roadmap.ts
+++ b/frontend/src/lib/types/roadmap.ts
@@ -38,6 +38,9 @@ export interface ProgressData {
   status: 'not_started' | 'in_progress' | 'completed';
   lastAccessedAt: string | null;
   completedAt: string | null;
+  /** Server-side `updatedAt` observed at last load; sent back as the
+   *  optimistic-concurrency token so stale writes are rejected with a 409. */
+  updatedAt?: string | null;
 }
 
 export type LayoutDirection = 'vertical' | 'horizontal';


### PR DESCRIPTION
## Overview

This PR fixes two issues:

* **#901 — Verify course-progress persistence across sessions and devices.** Progress writes now use optimistic concurrency (`baseUpdatedAt`) so stale updates are rejected deterministically with a `409` plus the authoritative server state, and a stale per-course cache key that silently dropped the latest write is fixed. The backend now accepts the roadmap UI's whole-state updates (`completedLessons`, `currentModuleId`) in addition to legacy lesson toggles.

* **#898 — Add exponential-backoff reconnection and status recovery to course notifications.** The course notification WebSocket now uses bounded exponential backoff with jitter, exposes connection state to the UI (status pill), and reliably recovers (or cleanly stops) on network faults, logout, and unmount.

## Related Issue

Closes #901
Closes #898

## Changes

### 🗄️ Backend — #901

* **[MODIFY]** `src/routes/learning/validation.schemas.ts` — `progressUpdateSchema` accepts whole-state updates (`completedLessons`, `currentModuleId`) and the `baseUpdatedAt` concurrency token; still requires at least one meaningful field.
* **[MODIFY]** `src/routes/learning/learning.service.ts`
  * `ProgressConflictError` carries the authoritative server state on stale writes.
  * `updateStudentProgress` supports lesson-driven **and** whole-state styles (combinable), derives course status/percentage from the completed set (never from a lesson's target status), and overwrites the per-course cache with the persisted row.
  * Throws `ProgressPersistenceError` (503) when the DB write fails — never "fake-saves".
* **[MODIFY]** `src/cache/CacheInvalidation.ts` — `invalidateUserProgressCache` clears per-course snapshots (`user:progress:<id>:<courseId>`), fixing stale reads across sessions/devices.
* **[MODIFY]** `src/routes/learning/learning.routes.ts` — maps `ProgressConflictError` → `409` with `error.current` progress.
* **[ADD]** `tests/curriculum-progress.integration.test.ts` — whole-state create, resume, percentage, 409 conflict + authoritative state, matching-token writes.

### 🖥️ Frontend — #901

* **[MODIFY]** `src/lib/learning-api.ts` — unwraps `{ progress, dataSource }`, sends `baseUpdatedAt`, throws `ProgressConflictError` on 409 / `ProgressUnavailableError` on 503.
* **[MODIFY]** `src/hooks/useRoadmapProgress.ts` — optimistic UI with rollback on failure; reconciles from the 409 payload; `not_started` when all lessons are removed.
* **[MODIFY]** `src/lib/offline-sync.ts` — queues/flushes the whole-state payload with `Authorization` so offline completions replay correctly.

### 🔌 Notifications — #898

* **[MODIFY]** `src/hooks/useCourseNotifications.ts` — bounded exponential backoff with jitter (8 attempts, 500ms→15s), connection-state machine (`idle/connected/reconnecting/disconnected`), cross-tab logout detection, no reconnect after manual teardown, full listener cleanup.
* **[MODIFY]** `src/components/notifications/CourseNotificationListener.tsx` + `src/app/layout.tsx` — non-intrusive status pill ("Reconnecting…", "Live notifications unavailable/disconnected").
* **[MODIFY]** `src/hooks/__tests__/useCourseNotifications.test.tsx` — retry timing/config, exhaustion, recovery, cleanup, logout.

## Verification Results

```
backend: jest tests/curriculum-progress.integration.test.ts
✅ 34/34 passed

frontend: vitest (changed suites)
✅ useCourseNotifications / useRoadmapProgress / learning-api / offline-sync — 38/38 passed

tsc --noEmit (changed files): clean
Full frontend + backend suites: identical to main baseline — no regressions
```

| Acceptance Criteria | Status |
| --- | --- |
| Progress persists across consecutive writes (no dropped lessons) | ✅ Stale per-course cache fixed + integration-tested |
| Stale concurrent writes rejected deterministically | ✅ `409` + authoritative server state, tested |
| Progress syncs offline and replays on reconnect | ✅ Whole-state queue/flush with auth header |
| Reconnection uses bounded exponential backoff | ✅ 8 attempts, 500ms→15s, jitter |
| Connection status visible/recoverable in UI | ✅ Status pill + `connectionState`/`reconnectAttempt`/`retryExhausted` |
| Clean teardown on logout/unmount (no zombie sockets) | ✅ `manualDisconnectRef` + `removeAllListeners`, tested |