### PR TITLE
validation accross student identity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -129,7 +129,7 @@
   "breadcrumbs.enabled": true,
   "workbench.editor.enablePreview": false,
   "workbench.editor.showTabs": "multiple",
-  "workbench.colorTheme": "Dark Modern",
+  "workbench.colorTheme": "Default Dark Modern",
   "workbench.iconTheme": "vs-seti",
   "terminal.integrated.shell.osx": "/bin/zsh",
   "terminal.integrated.fontSize": 14,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,15 +1,129 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import { StrKey } from '@stellar/stellar-sdk';
 import prisma from '../db/index.js';
 import { LoginRequest, RegisterRequest, User } from './types.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-in-production';
 const JWT_EXPIRES_IN = '7d';
 const SALT_ROUNDS = 10;
-const DID_REGEX = /^did:soroban:[A-Za-z0-9._:%-]+(?:#[A-Za-z0-9._:%-]+)?$/;
+
+const SUPPORTED_SOROBAN_NETWORKS = new Set(['testnet', 'mainnet', 'futurenet']);
+const SUPPORTED_DID_METHODS = new Set(['soroban', 'stellar']);
+
+export class DidValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DidValidationError';
+  }
+}
+
+export interface ParsedDid {
+  method: 'soroban' | 'stellar';
+  network: 'testnet' | 'mainnet' | 'futurenet' | null;
+  subject: string;
+  fragment: string | null;
+  normalizedDid: string;
+}
+
+const normalizeNetwork = (network: string): 'testnet' | 'mainnet' | 'futurenet' | null => {
+  const normalized = network.trim().toLowerCase();
+  if (normalized === 'public') {
+    return 'mainnet';
+  }
+
+  if (SUPPORTED_SOROBAN_NETWORKS.has(normalized)) {
+    return normalized as 'testnet' | 'mainnet' | 'futurenet';
+  }
+
+  return null;
+};
+
+const isValidDidSubject = (subject: string): boolean => /^[A-Za-z0-9._:%-]+$/.test(subject);
+
+const extractFragment = (value: string): { base: string; fragment: string | null } => {
+  const [base, ...fragmentParts] = value.split('#');
+  if (fragmentParts.length === 0) {
+    return { base, fragment: null };
+  }
+
+  const fragment = fragmentParts.join('#').trim();
+  if (!fragment || !isValidDidSubject(fragment)) {
+    throw new DidValidationError('Invalid DID format. Fragment contains unsupported characters');
+  }
+
+  return { base, fragment };
+};
+
+export const parseSupportedDid = (did: string): ParsedDid => {
+  const trimmedDid = did.trim();
+  if (!trimmedDid || trimmedDid.length > 256) {
+    throw new DidValidationError('Invalid DID format. DID must be between 1 and 256 characters');
+  }
+
+  const { base, fragment } = extractFragment(trimmedDid);
+  const segments = base.split(':');
+
+  if (segments[0]?.toLowerCase() !== 'did' || segments.length < 3) {
+    throw new DidValidationError('Invalid DID format. Expected did:<method>:<subject>');
+  }
+
+  const method = segments[1]!.toLowerCase();
+  if (!SUPPORTED_DID_METHODS.has(method)) {
+    throw new DidValidationError(`Unsupported DID method. Supported methods: ${Array.from(SUPPORTED_DID_METHODS).join(', ')}`);
+  }
+
+  if (method === 'stellar') {
+    if (segments.length !== 3) {
+      throw new DidValidationError('Invalid DID format. Expected did:stellar:<stellarPublicKey>');
+    }
+
+    const subject = segments[2]!.trim().toUpperCase();
+    if (!StrKey.isValidEd25519PublicKey(subject)) {
+      throw new DidValidationError('Invalid DID subject. Expected a valid Stellar public key');
+    }
+
+    return {
+      method: 'stellar',
+      network: null,
+      subject,
+      fragment,
+      normalizedDid: `did:stellar:${subject}${fragment ? `#${fragment}` : ''}`,
+    };
+  }
+
+  if (segments.length !== 4) {
+    throw new DidValidationError('Invalid DID format. Expected did:soroban:<network>:<identifier>');
+  }
+
+  const network = normalizeNetwork(segments[2]!);
+  if (!network) {
+    throw new DidValidationError(
+      `Unsupported DID network. Supported Soroban networks: ${Array.from(SUPPORTED_SOROBAN_NETWORKS).join(', ')}`
+    );
+  }
+
+  const subject = segments[3]!.trim();
+  if (!subject || !isValidDidSubject(subject)) {
+    throw new DidValidationError('Invalid DID subject. Identifier contains unsupported characters');
+  }
+
+  return {
+    method: 'soroban',
+    network,
+    subject,
+    fragment,
+    normalizedDid: `did:soroban:${network}:${subject}${fragment ? `#${fragment}` : ''}`,
+  };
+};
 
 export const isValidSorobanDid = (did: string): boolean => {
-  return did.length <= 256 && DID_REGEX.test(did);
+  try {
+    const parsed = parseSupportedDid(did);
+    return parsed.method === 'soroban';
+  } catch {
+    return false;
+  }
 };
 
 export const normalizeSorobanDid = (did: string | null | undefined): string | null | undefined => {
@@ -26,11 +140,77 @@ export const normalizeSorobanDid = (did: string | null | undefined): string | nu
     return null;
   }
 
-  if (!isValidSorobanDid(trimmedDid)) {
-    throw new Error('Invalid DID format. Expected did:soroban:<network>:<identifier>');
+  const parsed = parseSupportedDid(trimmedDid);
+  if (parsed.method !== 'soroban') {
+    throw new DidValidationError('Invalid DID format. Expected did:soroban:<network>:<identifier>');
   }
 
-  return trimmedDid;
+  return parsed.normalizedDid;
+};
+
+export const normalizeSupportedDid = (did: string | null | undefined): string | null | undefined => {
+  if (did === undefined) {
+    return undefined;
+  }
+
+  if (did === null) {
+    return null;
+  }
+
+  const trimmedDid = did.trim();
+  if (!trimmedDid) {
+    return null;
+  }
+
+  return parseSupportedDid(trimmedDid).normalizedDid;
+};
+
+export const validateStudentDidCompatibility = (params: {
+  did: string | null | undefined;
+  walletAddress?: string | null;
+  expectedNetwork?: string | null;
+}): string | null | undefined => {
+  const { did, walletAddress, expectedNetwork } = params;
+  const normalizedDid = normalizeSupportedDid(did);
+
+  if (normalizedDid === undefined || normalizedDid === null) {
+    return normalizedDid;
+  }
+
+  const parsed = parseSupportedDid(normalizedDid);
+  const normalizedWalletAddress = walletAddress?.trim().toUpperCase() || null;
+
+  if (expectedNetwork) {
+    const normalizedExpectedNetwork = normalizeNetwork(expectedNetwork);
+    if (!normalizedExpectedNetwork) {
+      throw new DidValidationError(`Unsupported enrollment network: ${expectedNetwork}`);
+    }
+
+    if (parsed.network !== normalizedExpectedNetwork) {
+      throw new DidValidationError(
+        `DID network mismatch. Expected ${normalizedExpectedNetwork} but received ${parsed.network ?? 'none'}`
+      );
+    }
+  }
+
+  if (normalizedWalletAddress) {
+    if (!StrKey.isValidEd25519PublicKey(normalizedWalletAddress)) {
+      throw new DidValidationError('Invalid wallet address. Expected a valid Stellar public key');
+    }
+
+    if (parsed.method === 'stellar' && parsed.subject !== normalizedWalletAddress) {
+      throw new DidValidationError('DID subject mismatch. Stellar DID subject must match the linked wallet address');
+    }
+
+    if (parsed.method === 'soroban' && StrKey.isValidEd25519PublicKey(parsed.subject.toUpperCase())) {
+      const normalizedSubject = parsed.subject.toUpperCase();
+      if (normalizedSubject !== normalizedWalletAddress) {
+        throw new DidValidationError('DID subject mismatch. Soroban DID subject must match the linked wallet address');
+      }
+    }
+  }
+
+  return normalizedDid;
 };
 
 /**

--- a/backend/src/routes/enrollments.ts
+++ b/backend/src/routes/enrollments.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
+import { DidValidationError, validateStudentDidCompatibility } from '../auth/auth.service.js';
 import prisma from '../db/index.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 
@@ -129,6 +131,28 @@ router.post('/', async (req, res) => {
 
     if (!student || !course) {
       return res.status(404).json({ error: 'Student or course not found' });
+    }
+
+    try {
+      validateStudentDidCompatibility({
+        did: student.did,
+        walletAddress: student.walletAddress,
+        expectedNetwork: process.env.STELLAR_NETWORK || 'testnet',
+      });
+    } catch (error) {
+      if (error instanceof DidValidationError) {
+        logger.warn('Rejected enrollment because linked DID is incompatible with student identity', {
+          route: '/api/v1/enrollments',
+          studentId,
+          courseId,
+          did: student.did,
+          walletAddress: student.walletAddress,
+          reason: error.message,
+        });
+        return res.status(400).json({ error: error.message });
+      }
+
+      throw error;
     }
 
     const newEnrollment = {

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -1,12 +1,13 @@
 // @ts-nocheck
 import { Router } from 'express';
-import { normalizeSorobanDid } from '../auth/auth.service.js';
+import { DidValidationError, validateStudentDidCompatibility } from '../auth/auth.service.js';
 import { invalidateUserCache } from '../cache/CacheInvalidation.js';
 import { cacheMiddleware } from '../cache/CacheMiddleware.js';
 import { CACHE_KEYS } from '../cache/CacheService.js';
 import { cacheTTL } from '../config/redis.config.js';
 import prisma from '../db/index.js';
 import { auditAction } from '../middleware/audit.js';
+import logger from '../utils/logger.js';
 import { broadcastEvent } from '../websocket/gateway.js';
 import { linkDidToCertificates } from './certificates.js';
 
@@ -73,7 +74,10 @@ router.post('/', auditAction('CREATE_STUDENT', 'Student'), async (req, res) => {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
-    const normalizedDid = normalizeSorobanDid(did);
+    const normalizedDid = validateStudentDidCompatibility({
+      did,
+      expectedNetwork: process.env.STELLAR_NETWORK || 'testnet',
+    });
 
     const student = await prisma.student.create({
       data: {
@@ -94,12 +98,17 @@ router.post('/', auditAction('CREATE_STUDENT', 'Student'), async (req, res) => {
 
     res.status(201).json(student);
   } catch (error) {
-    console.error("CREATE STUDENT ERROR:", error);
-    if (error instanceof Error && error.message.startsWith('Invalid DID format')) {
+    if (error instanceof DidValidationError) {
+      logger.warn('Rejected student creation due to DID validation failure', {
+        route: '/api/v1/students',
+        email: req.body?.email,
+        reason: error.message,
+      });
       res.status(400).json({ error: error.message });
       return;
     }
 
+    console.error("CREATE STUDENT ERROR:", error);
     res.status(500).json({ error: 'Failed to create student' });
   }
 });
@@ -109,7 +118,16 @@ router.put('/:id', auditAction('UPDATE_STUDENT', 'Student'), auditAction('UPDATE
   try {
     const { id } = req.params;
     const { email, firstName, lastName, did } = req.body;
-    const normalizedDid = normalizeSorobanDid(did);
+    const existingStudent = await prisma.student.findUnique({
+      where: { id },
+      select: { walletAddress: true },
+    });
+
+    const normalizedDid = validateStudentDidCompatibility({
+      did,
+      walletAddress: existingStudent?.walletAddress ?? null,
+      expectedNetwork: process.env.STELLAR_NETWORK || 'testnet',
+    });
 
     const updateData: Record<string, unknown> = {
       email,
@@ -137,7 +155,12 @@ router.put('/:id', auditAction('UPDATE_STUDENT', 'Student'), auditAction('UPDATE
     await invalidateUserCache(id);
     res.json(student);
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Invalid DID format')) {
+    if (error instanceof DidValidationError) {
+      logger.warn('Rejected student update due to DID validation failure', {
+        route: '/api/v1/students/:id',
+        studentId: req.params.id,
+        reason: error.message,
+      });
       res.status(400).json({ error: error.message });
       return;
     }

--- a/backend/src/user/routes.ts
+++ b/backend/src/user/routes.ts
@@ -1,10 +1,11 @@
 import { Prisma } from '@prisma/client';
 import { Request, Response, Router } from 'express';
 import { authenticate } from '../auth/auth.middleware.js';
-import { normalizeSorobanDid } from '../auth/auth.service.js';
+import { DidValidationError, validateStudentDidCompatibility } from '../auth/auth.service.js';
 import prisma from '../db/index.js';
 import { markUserWriteToPrimary } from '../db/requestContext.js';
 import { linkDidToCertificates } from '../routes/certificates.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 
@@ -64,7 +65,16 @@ router.put('/profile', authenticate, async (req: Request, res: Response) => {
       did?: string | null;
     };
 
-    const normalizedDid = normalizeSorobanDid(did);
+    const existingStudent = await prisma.student.findUnique({
+      where: { id: req.user.id },
+      select: { walletAddress: true },
+    });
+
+    const normalizedDid = validateStudentDidCompatibility({
+      did,
+      walletAddress: existingStudent?.walletAddress ?? null,
+      expectedNetwork: process.env.STELLAR_NETWORK || 'testnet',
+    });
     const updateData: {
       email?: string;
       firstName?: string;
@@ -116,7 +126,12 @@ router.put('/profile', authenticate, async (req: Request, res: Response) => {
       updatedAt: student.updatedAt.toISOString(),
     });
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Invalid DID format')) {
+    if (error instanceof DidValidationError) {
+      logger.warn('Rejected DID update on user profile', {
+        route: '/api/v1/user/profile',
+        userId: req.user?.id,
+        reason: error.message,
+      });
       res.status(400).json({ error: error.message });
       return;
     }

--- a/backend/tests/did-validation.test.ts
+++ b/backend/tests/did-validation.test.ts
@@ -1,0 +1,156 @@
+import request from 'supertest';
+import prisma from '../src/db/index.js';
+import {
+  DidValidationError,
+  parseSupportedDid,
+  validateStudentDidCompatibility,
+} from '../src/auth/auth.service.js';
+import { app } from '../src/index.js';
+
+const VALID_WALLET_A = 'GBST4SW5DKCK3SN5EQQYQA4SDSF4NYVZ647YV6NA5PHWJ2N2UJNAPNAI';
+const VALID_WALLET_B = 'GBSXA7IC23YOWSJHJNMVO4K66LZAMVLOUVM2ATCSJJRZ74UCE7IPJLAO';
+
+describe('DID validation', () => {
+  describe('parseSupportedDid', () => {
+    it('normalizes supported soroban DIDs', () => {
+      expect(parseSupportedDid('  did:soroban:TESTNET:student-123#profile  ')).toEqual(
+        expect.objectContaining({
+          method: 'soroban',
+          network: 'testnet',
+          subject: 'student-123',
+          fragment: 'profile',
+          normalizedDid: 'did:soroban:testnet:student-123#profile',
+        })
+      );
+    });
+
+    it('rejects unsupported soroban networks', () => {
+      expect(() => parseSupportedDid('did:soroban:devnet:student-123')).toThrow(
+        new DidValidationError('Unsupported DID network. Supported Soroban networks: testnet, mainnet, futurenet')
+      );
+    });
+  });
+
+  describe('validateStudentDidCompatibility', () => {
+    it('rejects a soroban DID whose network does not match the active network', () => {
+      expect(() =>
+        validateStudentDidCompatibility({
+          did: 'did:soroban:mainnet:student-123',
+          expectedNetwork: 'testnet',
+        })
+      ).toThrow(new DidValidationError('DID network mismatch. Expected testnet but received mainnet'));
+    });
+
+    it('rejects a stellar-subject mismatch when the wallet is linked', () => {
+      expect(() =>
+        validateStudentDidCompatibility({
+          did: `did:stellar:${VALID_WALLET_A}`,
+          walletAddress: VALID_WALLET_B,
+        })
+      ).toThrow(new DidValidationError('DID subject mismatch. Stellar DID subject must match the linked wallet address'));
+    });
+  });
+
+  describe('route enforcement', () => {
+    beforeEach(async () => {
+      await prisma.certificate.deleteMany();
+      await prisma.enrollment.deleteMany();
+      await prisma.course.deleteMany();
+      await prisma.student.deleteMany();
+    });
+
+    afterAll(async () => {
+      await prisma.$disconnect();
+    });
+
+    it('stores a normalized DID on authenticated profile updates', async () => {
+      const registerResponse = await request(app).post('/api/v1/auth/register').send({
+        email: 'normalized-did@example.com',
+        password: 'password123',
+        firstName: 'Normalized',
+        lastName: 'Did',
+      });
+
+      const token = registerResponse.body.token as string;
+
+      const updateResponse = await request(app)
+        .put('/api/v1/user/profile')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ did: '  did:soroban:TESTNET:student-123#profile  ' })
+        .expect(200);
+
+      expect(updateResponse.body.did).toBe('did:soroban:testnet:student-123#profile');
+    });
+
+    it('stores a normalized stellar DID on authenticated profile updates', async () => {
+      const registerResponse = await request(app).post('/api/v1/auth/register').send({
+        email: 'stellar-did@example.com',
+        password: 'password123',
+        firstName: 'Stellar',
+        lastName: 'Did',
+        walletAddress: VALID_WALLET_A,
+      });
+
+      const token = registerResponse.body.token as string;
+
+      const updateResponse = await request(app)
+        .put('/api/v1/user/profile')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ did: ` did:stellar:${VALID_WALLET_A.toLowerCase()} ` })
+        .expect(200);
+
+      expect(updateResponse.body.did).toBe(`did:stellar:${VALID_WALLET_A}`);
+    });
+
+    it('rejects unsupported DID networks on authenticated profile updates', async () => {
+      const registerResponse = await request(app).post('/api/v1/auth/register').send({
+        email: 'unsupported-network@example.com',
+        password: 'password123',
+        firstName: 'Unsupported',
+        lastName: 'Network',
+      });
+
+      const token = registerResponse.body.token as string;
+
+      const response = await request(app)
+        .put('/api/v1/user/profile')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ did: 'did:soroban:devnet:student-123' })
+        .expect(400);
+
+      expect(response.body.error).toContain('Unsupported DID network');
+    });
+
+    it('rejects enrollment when the linked DID does not match the student wallet', async () => {
+      const student = await prisma.student.create({
+        data: {
+          email: 'mismatch-enrollment@example.com',
+          password: 'password123',
+          firstName: 'Mismatch',
+          lastName: 'Enrollment',
+          walletAddress: VALID_WALLET_B,
+          did: `did:stellar:${VALID_WALLET_A}`,
+        },
+      });
+
+      const course = await prisma.course.create({
+        data: {
+          title: 'Identity Systems 101',
+          description: 'Validation test course',
+          instructor: 'Test Instructor',
+          credits: 3,
+        },
+      });
+
+      const response = await request(app)
+        .post('/api/v1/enrollments')
+        .send({
+          studentId: student.id,
+          courseId: course.id,
+        })
+        .expect(400);
+
+      expect(response.body.error).toContain('DID subject mismatch');
+    });
+  });
+});

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -69,6 +69,19 @@ npm run test:coverage
 Coverage reports will be available in the `coverage/` directory. Open
 `coverage/lcov-report/index.html` in your browser to view the HTML report.
 
+## DID Validation Notes
+
+- Supported student identity formats are `did:soroban:<network>:<identifier>` and
+  `did:stellar:<stellarPublicKey>`.
+- Supported Soroban DID networks are `testnet`, `mainnet`, and `futurenet`. The active API
+  boundary expects Soroban DIDs to match `STELLAR_NETWORK` and normalizes aliases such as
+  `public` to `mainnet`.
+- Linked student DIDs are normalized before persistence, and enrollment creation now rejects
+  students whose linked DID is malformed, on the wrong network, or incompatible with the linked
+  Stellar wallet address.
+- No database migration is required for this change. Existing malformed rows should be corrected
+  before re-running enrollment flows that depend on identity validation.
+
 ### Test Structure
 
 Tests are located in the `tests/` directory:


### PR DESCRIPTION
## Summary

Strengthen DID validation across student identity and enrollment flows.

This change adds explicit DID parsing, normalization, network validation, and wallet-subject compatibility checks so malformed, unsupported-network, or mismatched identities cannot be attached to student records or used during enrollment.

Closes #915

## What Changed

- Added shared DID validation for:
  - `did:soroban:<network>:<identifier>`
  - `did:stellar:<stellarPublicKey>`
- Normalized supported DIDs before persistence
- Rejected unsupported Soroban networks
- Rejected DID/network mismatches against `STELLAR_NETWORK`
- Rejected DID subject mismatches when a linked Stellar wallet exists
- Added structured warning logs for rejected profile, student, and enrollment writes
- Enforced validation on:
  - `PUT /api/v1/user/profile`
  - `POST /api/v1/students`
  - `PUT /api/v1/students/:id`
  - `POST /api/v1/enrollments`
- Added unit/integration-style route coverage for valid and invalid DID paths

## Operational Notes

- No database migration is required
- Existing malformed student DIDs should be corrected before retrying enrollment flows
- Supported Soroban DID networks are `testnet`, `mainnet`, and `futurenet`
- `public` is normalized to `mainnet`

## Testing

Intended commands:
- `cd backend && npm test -- did-validation.test.ts`
- `cd backend && npm run build`

Note: these could not be executed in the current workspace because backend dependencies are not installed locally (`jest` and `@stellar/stellar-sdk` were unavailable).