### PR TITLE
feat(reliability): separate liveness and readiness checks for deployment-safe health monitoring #892

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,9 +50,9 @@ ENV PORT=8080
 
 EXPOSE 8080
 
-# Health check
+# Health check: readiness probe (API up AND database + Redis available)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:8080/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+  CMD node -e "require('http').get('http://localhost:8080/health/ready', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 # Switch to non-root user
 USER nodejs

--- a/backend/src/db/readinessMonitor.ts
+++ b/backend/src/db/readinessMonitor.ts
@@ -1,0 +1,106 @@
+import redisClient from '../cache/RedisClient.js';
+import logger from '../utils/logger.js';
+import prisma from './index.js';
+
+export interface DependencyProbeResult {
+  status: 'ready' | 'unavailable';
+  latencyMs: number;
+  /** Safe, sanitized message. Never includes credentials, connection strings, or stack traces. */
+  error?: string;
+}
+
+export interface ReadinessResult {
+  status: 'ready' | 'not_ready';
+  checks: {
+    database: DependencyProbeResult;
+    redis: DependencyProbeResult;
+  };
+  checkedAt: string;
+}
+
+const DEFAULT_READINESS_TIMEOUT_MS = 3000;
+
+function getReadinessTimeoutMs(): number {
+  const configured = Number(process.env.HEALTH_READINESS_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_READINESS_TIMEOUT_MS;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`probe timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+async function checkDatabase(timeoutMs: number): Promise<DependencyProbeResult> {
+  const start = Date.now();
+  try {
+    await withTimeout((prisma as any).$queryRaw`SELECT 1`, timeoutMs);
+    return { status: 'ready', latencyMs: Date.now() - start };
+  } catch (error) {
+    logger.error('Readiness probe: database check failed', error);
+    return {
+      status: 'unavailable',
+      latencyMs: Date.now() - start,
+      error: 'database unavailable',
+    };
+  }
+}
+
+async function checkRedis(timeoutMs: number): Promise<DependencyProbeResult> {
+  const start = Date.now();
+  const client = redisClient.getClient();
+  if (!client) {
+    logger.warn('Readiness probe: redis client is not connected');
+    return {
+      status: 'unavailable',
+      latencyMs: Date.now() - start,
+      error: 'redis unavailable',
+    };
+  }
+
+  try {
+    await withTimeout(client.ping(), timeoutMs);
+    return { status: 'ready', latencyMs: Date.now() - start };
+  } catch (error) {
+    logger.error('Readiness probe: redis check failed', error);
+    return {
+      status: 'unavailable',
+      latencyMs: Date.now() - start,
+      error: 'redis unavailable',
+    };
+  }
+}
+
+/**
+ * Verifies that the database and Redis are reachable within a bounded timeout.
+ *
+ * Responses are intentionally sanitized: dependency failures surface a safe
+ * message only, while full errors are logged server-side.
+ */
+export async function checkReadiness(): Promise<ReadinessResult> {
+  const timeoutMs = getReadinessTimeoutMs();
+  const [database, redis] = await Promise.all([
+    checkDatabase(timeoutMs),
+    checkRedis(timeoutMs),
+  ]);
+
+  const ready = database.status === 'ready' && redis.status === 'ready';
+
+  return {
+    status: ready ? 'ready' : 'not_ready',
+    checks: { database, redis },
+    checkedAt: new Date().toISOString(),
+  };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import { rateLimiter } from './middleware/rateLimiter.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import { requireWorkspaceMiddleware } from './middleware/WorkspaceContext.js';
 import freelanceRoute from './routes/freelance.js';
+import { livenessHandler, readinessHandler } from './routes/health.routes.js';
 import routes from './routes/index.js';
 import { startWebhookWorker, stopWebhookWorker } from './services/webhooks/index.js';
 import logger from './utils/logger.js';
@@ -147,6 +148,13 @@ app.get('/health', (_req: Request, res: Response) => {
     cacheWarmer: cacheWarmer.getStatus(),
   });
 });
+
+// Liveness probe — no dependency calls, returns 200 while the process is alive.
+app.get('/health/live', livenessHandler);
+
+// Readiness probe — verifies database and Redis capabilities with timeouts.
+// Returns 503 when essential dependencies are unavailable.
+app.get('/health/ready', readinessHandler);
 
 // Cache metrics endpoint
 app.use('/api/v1/cache', cacheMetrics);

--- a/backend/src/routes/health.routes.ts
+++ b/backend/src/routes/health.routes.ts
@@ -1,6 +1,8 @@
-import { Router } from 'express';
+import { Router, type RequestHandler } from 'express';
+import { checkReadiness } from '../db/readinessMonitor.js';
 import { cbManager } from '../lib/circuit-breaker/CircuitBreakerManager.js';
 import { checkDbHealth } from '../db/healthMonitor.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 
@@ -31,6 +33,99 @@ router.get('/circuit-breakers', (req, res) => {
     data: stats,
   });
 });
+
+/**
+ * @openapi
+ * /api/v1/health/live:
+ *   get:
+ *     summary: Liveness probe
+ *     description: Lightweight endpoint with no dependency calls. Succeeds while the process is alive.
+ *     tags: [Health]
+ *     responses:
+ *       200:
+ *         description: Process is alive
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: ok
+ *                 uptime:
+ *                   type: number
+ *                 version:
+ *                   type: string
+ *                 timestamp:
+ *                   type: string
+ */
+export const livenessHandler: RequestHandler = (_req, res) => {
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    version: '1.0.0',
+    timestamp: new Date().toISOString(),
+  });
+};
+
+router.get('/live', livenessHandler);
+
+/**
+ * @openapi
+ * /api/v1/health/ready:
+ *   get:
+ *     summary: Readiness probe
+ *     description: Checks database and Redis capabilities with timeouts. Returns 503 when essential dependencies are unavailable.
+ *     tags: [Health]
+ *     responses:
+ *       200:
+ *         description: All dependencies ready
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: ready
+ *                 checks:
+ *                   type: object
+ *                 checkedAt:
+ *                   type: string
+ *       503:
+ *         description: One or more dependencies unavailable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: not_ready
+ *                 checks:
+ *                   type: object
+ *                 checkedAt:
+ *                   type: string
+ */
+export const readinessHandler: RequestHandler = async (_req, res) => {
+  try {
+    const readiness = await checkReadiness();
+    const httpStatus = readiness.status === 'ready' ? 200 : 503;
+    res.status(httpStatus).json(readiness);
+  } catch (error) {
+    logger.error('Readiness probe failed unexpectedly', error);
+    res.status(503).json({
+      status: 'not_ready',
+      checks: {
+        database: { status: 'unavailable', latencyMs: 0, error: 'database unavailable' },
+        redis: { status: 'unavailable', latencyMs: 0, error: 'redis unavailable' },
+      },
+      checkedAt: new Date().toISOString(),
+    });
+  }
+};
+
+router.get('/ready', readinessHandler);
 
 /**
  * @route GET /api/v1/health/db

--- a/backend/src/services/storage/queue.ts
+++ b/backend/src/services/storage/queue.ts
@@ -29,9 +29,6 @@ const createQueue = <T>(name: string, defaultJobOptions?: JobsOptions) => {
     } as unknown as Queue<T>;
   }
 
-  const redisUrl = new URL(process.env.REDIS_URL || (() => {
-    throw new Error('REDIS_URL environment variable is required');
-  })());
   const redisUrl = new URL(process.env.REDIS_URL || 'redis://localhost:6379');
 
   return new Queue<T>(name, {

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,7 +1,36 @@
 import request from 'supertest';
 import { app } from '../src/index';
+import { checkReadiness } from '../src/db/readinessMonitor';
+
+jest.mock('../src/db/readinessMonitor.js', () => ({
+  checkReadiness: jest.fn(),
+}));
+
+const mockedCheckReadiness = checkReadiness as jest.Mock;
+
+const readyResult = {
+  status: 'ready',
+  checks: {
+    database: { status: 'ready', latencyMs: 3 },
+    redis: { status: 'ready', latencyMs: 2 },
+  },
+  checkedAt: '2026-07-31T12:00:00.000Z',
+};
+
+const notReadyResult = {
+  status: 'not_ready',
+  checks: {
+    database: { status: 'ready', latencyMs: 3 },
+    redis: { status: 'unavailable', latencyMs: 3000, error: 'redis unavailable' },
+  },
+  checkedAt: '2026-07-31T12:00:00.000Z',
+};
 
 describe('Health Endpoint Integration Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /health', () => {
     it('should return 200 and health status', async () => {
       const response = await request(app).get('/health');
@@ -31,6 +60,63 @@ describe('Health Endpoint Integration Tests', () => {
       const response = await request(app).get('/health');
 
       expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+  });
+
+  describe('GET /health/live', () => {
+    it('should return 200 with ok status', async () => {
+      const response = await request(app).get('/health/live');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('ok');
+      expect(response.body).toHaveProperty('uptime');
+      expect(typeof response.body.uptime).toBe('number');
+      expect(response.body).toHaveProperty('version');
+      expect(response.body.version).toBe('1.0.0');
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+
+    it('should succeed without making any dependency calls', async () => {
+      const response = await request(app).get('/health/live');
+
+      expect(response.status).toBe(200);
+      expect(mockedCheckReadiness).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /health/ready', () => {
+    it('should return 200 when all dependencies are ready', async () => {
+      mockedCheckReadiness.mockResolvedValueOnce(readyResult);
+
+      const response = await request(app).get('/health/ready');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('ready');
+      expect(response.body.checks.database.status).toBe('ready');
+      expect(response.body.checks.redis.status).toBe('ready');
+    });
+
+    it('should return 503 when a required dependency is unavailable', async () => {
+      mockedCheckReadiness.mockResolvedValueOnce(notReadyResult);
+
+      const response = await request(app).get('/health/ready');
+
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('not_ready');
+      expect(response.body.checks.database.status).toBe('ready');
+      expect(response.body.checks.redis.status).toBe('unavailable');
+      expect(response.body.checks.redis.error).toBe('redis unavailable');
+    });
+
+    it('should return 503 without leaking details when the check fails unexpectedly', async () => {
+      mockedCheckReadiness.mockRejectedValueOnce(new Error('postgres://user:secret@db:5432 exploded'));
+
+      const response = await request(app).get('/health/ready');
+
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('not_ready');
+      expect(JSON.stringify(response.body)).not.toContain('postgres://');
+      expect(response.body.checks.database.error).toBe('database unavailable');
     });
   });
 

--- a/backend/tests/readinessMonitor.test.ts
+++ b/backend/tests/readinessMonitor.test.ts
@@ -1,0 +1,109 @@
+import redisClient from '../src/cache/RedisClient.js';
+import prisma from '../src/db/index.js';
+import { checkReadiness } from '../src/db/readinessMonitor.js';
+
+jest.mock('../src/db/index.js', () => ({
+  __esModule: true,
+  default: {
+    $queryRaw: jest.fn(),
+  },
+}));
+
+jest.mock('../src/cache/RedisClient.js', () => ({
+  __esModule: true,
+  default: {
+    getClient: jest.fn(),
+  },
+}));
+
+jest.mock('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  auditLogger: { info: jest.fn() },
+}));
+
+const mockedPrisma = prisma as unknown as { $queryRaw: jest.Mock };
+const mockedGetClient = redisClient.getClient as jest.Mock;
+
+describe('Readiness Monitor', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete process.env.HEALTH_READINESS_TIMEOUT_MS;
+  });
+
+  it('returns ready when database and redis are healthy', async () => {
+    mockedPrisma.$queryRaw.mockResolvedValueOnce([]);
+    mockedGetClient.mockReturnValue({ ping: jest.fn().mockResolvedValue('PONG') });
+
+    const result = await checkReadiness();
+
+    expect(result.status).toBe('ready');
+    expect(result.checks.database.status).toBe('ready');
+    expect(result.checks.redis.status).toBe('ready');
+  });
+
+  it('returns not_ready when database is unavailable', async () => {
+    mockedPrisma.$queryRaw.mockRejectedValueOnce(new Error('connection refused'));
+    mockedGetClient.mockReturnValue({ ping: jest.fn().mockResolvedValue('PONG') });
+
+    const result = await checkReadiness();
+
+    expect(result.status).toBe('not_ready');
+    expect(result.checks.database.status).toBe('unavailable');
+    expect(result.checks.database.error).toBe('database unavailable');
+    expect(result.checks.redis.status).toBe('ready');
+  });
+
+  it('returns not_ready when redis is unavailable', async () => {
+    mockedPrisma.$queryRaw.mockResolvedValueOnce([]);
+    mockedGetClient.mockReturnValue({
+      ping: jest.fn().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:6379')),
+    });
+
+    const result = await checkReadiness();
+
+    expect(result.status).toBe('not_ready');
+    expect(result.checks.database.status).toBe('ready');
+    expect(result.checks.redis.status).toBe('unavailable');
+    expect(result.checks.redis.error).toBe('redis unavailable');
+  });
+
+  it('returns not_ready when redis client is not connected', async () => {
+    mockedPrisma.$queryRaw.mockResolvedValueOnce([]);
+    mockedGetClient.mockReturnValue(null);
+
+    const result = await checkReadiness();
+
+    expect(result.status).toBe('not_ready');
+    expect(result.checks.redis.status).toBe('unavailable');
+  });
+
+  it('times out slow dependency checks', async () => {
+    process.env.HEALTH_READINESS_TIMEOUT_MS = '10';
+    mockedPrisma.$queryRaw.mockReturnValueOnce(new Promise(() => {}));
+    mockedGetClient.mockReturnValue({ ping: jest.fn().mockResolvedValue('PONG') });
+
+    const result = await checkReadiness();
+
+    expect(result.status).toBe('not_ready');
+    expect(result.checks.database.status).toBe('unavailable');
+    expect(result.checks.database.error).toBe('database unavailable');
+    expect(result.checks.database.latencyMs).toBeGreaterThanOrEqual(10);
+  });
+
+  it('sanitizes errors and never leaks credentials or connection details', async () => {
+    mockedPrisma.$queryRaw.mockRejectedValueOnce(
+      new Error('postgres://user:secret@db:5432/web3-student-lab FAILED')
+    );
+    mockedGetClient.mockReturnValue({
+      ping: jest.fn().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:6379')),
+    });
+
+    const result = await checkReadiness();
+
+    expect(result.checks.database.error).toBe('database unavailable');
+    expect(result.checks.database.error).not.toContain('postgres://');
+    expect(result.checks.redis.error).toBe('redis unavailable');
+    expect(result.checks.redis.error).not.toContain('127.0.0.1');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,9 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+      # Readiness probe: container is healthy only when the API is running
+      # AND database + Redis are available.
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health/ready', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/deployment/HEALTH_PROBES.md
+++ b/docs/deployment/HEALTH_PROBES.md
@@ -1,0 +1,187 @@
+# Health Probes (Liveness & Readiness)
+
+This document describes the health monitoring endpoints and how to configure
+probes for Docker and common hosting providers so orchestrators can
+distinguish a running process from one that is ready to serve traffic.
+
+## Overview
+
+A single combined health endpoint cannot tell an orchestrator *why* a service
+is unhealthy. The backend therefore exposes three separate endpoints:
+
+| Endpoint | Purpose | Status codes | Dependency calls |
+| --- | --- | --- | --- |
+| `GET /health` | Legacy overview endpoint (kept for backward compatibility) | `200` always | none (cached state only) |
+| `GET /health/live` | **Liveness** — process is alive and not deadlocked | `200` | none |
+| `GET /health/ready` | **Readiness** — process can serve dependent services | `200` / `503` | database (`SELECT 1`), Redis (`PING`) |
+
+The same endpoints are also available under the versioned API namespace at
+`/api/v1/health/live` and `/api/v1/health/ready`.
+
+## Liveness probe
+
+`GET /health/live`
+
+Fast, dependency-free probe. Returns `200 OK` while the Node.js process is
+alive, regardless of the state of downstream services.
+
+```json
+{
+  "status": "ok",
+  "uptime": 123.456,
+  "version": "1.0.0",
+  "timestamp": "2026-07-31T12:00:00.000Z"
+}
+```
+
+## Readiness probe
+
+`GET /health/ready`
+
+Checks database and Redis capabilities with a bounded timeout
+(`HEALTH_READINESS_TIMEOUT_MS`, default `3000` ms). Returns `200 OK` only when
+every required dependency is available, otherwise `503 Service Unavailable`.
+
+**Ready — `200`:**
+
+```json
+{
+  "status": "ready",
+  "checks": {
+    "database": { "status": "ready", "latencyMs": 12 },
+    "redis": { "status": "ready", "latencyMs": 3 }
+  },
+  "checkedAt": "2026-07-31T12:00:00.000Z"
+}
+```
+
+**Not ready — `503`:**
+
+```json
+{
+  "status": "not_ready",
+  "checks": {
+    "database": { "status": "ready", "latencyMs": 12 },
+    "redis": { "status": "unavailable", "latencyMs": 3000, "error": "redis unavailable" }
+  },
+  "checkedAt": "2026-07-31T12:00:00.000Z"
+}
+```
+
+### Security
+
+Probe responses are sanitized. They never include credentials, connection
+strings, or internal stack traces — dependency failures return a safe message
+such as `"database unavailable"` / `"redis unavailable"`, while full error
+details are written to the server logs.
+
+## Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `HEALTH_READINESS_TIMEOUT_MS` | `3000` | Maximum time (ms) each readiness dependency check may take before it is reported as unavailable. |
+
+## Docker Compose
+
+The backend service in `docker-compose.yml` uses the readiness probe so a
+container is only considered healthy once the API is running **and** database
+and Redis are reachable:
+
+```yaml
+backend:
+  # ...
+  healthcheck:
+    test: ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health/ready', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 40s
+```
+
+## Dockerfile
+
+`backend/Dockerfile` declares the same readiness probe:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health/ready', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+```
+
+## Kubernetes
+
+```yaml
+containers:
+  - name: backend
+    image: web3-student-lab-backend:latest
+    ports:
+      - containerPort: 8080
+    livenessProbe:
+      httpGet:
+        path: /health/live
+        port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health/ready
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    env:
+      - name: HEALTH_READINESS_TIMEOUT_MS
+        value: "3000"
+```
+
+## Other hosting providers
+
+### Render
+
+```yaml
+healthCheckPath: /health/live
+```
+
+Or use the readiness path `/health/ready` for services whose dependency
+health should gate traffic.
+
+### Fly.io
+
+```toml
+[services.checks]
+grace_period = "30s"
+interval = "10s"
+timeout = "3s"
+[services.checks.http]
+path = "/health/live"
+method = "GET"
+```
+
+### Heroku
+
+```bash
+# Health check via a resource:
+heroku ps:wait
+curl -f https://YOUR-APP.herokuapp.com/health/ready
+```
+
+### Railway
+
+Use the `HEALTHCHECK_ENDPOINT`/monitor configuration of the service to point
+at `/health/ready`.
+
+## Testing
+
+Health probes have automated tests:
+
+- `backend/tests/health.test.ts` — integration tests for `/health`, `/health/live`, and `/health/ready`.
+- `backend/tests/readinessMonitor.test.ts` — unit tests for `checkReadiness()` covering success, dependency failures, and timeouts.
+
+Run them with:
+
+```bash
+cd backend
+npm test -- health.test.ts readinessMonitor.test.ts
+```


### PR DESCRIPTION
## Overview

This PR separates liveness and readiness checks for deployment-safe health monitoring, so orchestrators can distinguish a running process from one that is ready to serve dependent services. It adds a dependency-free liveness endpoint and a readiness endpoint that verifies PostgreSQL and Redis capabilities with bounded timeouts — returning a non-2xx status when essential dependencies are unavailable while keeping responses free of credentials, connection strings, and stack traces.

## Related Issue

Closes #892

## Changes

### Health Monitoring

* **[ADD]** `backend/src/db/readinessMonitor.ts`
  * Runs database `SELECT 1` and Redis `PING` in parallel with bounded timeouts (`HEALTH_READINESS_TIMEOUT_MS`, default 3000ms).
  * Sanitized per-dependency results (`ready` / `unavailable`); full error details are logged server-side only.

* **[MODIFY]** `backend/src/routes/health.routes.ts`
  * Adds `GET /live` and `GET /ready` (also available under `/api/v1/health`) with OpenAPI docs.
  * `GET /health/live` — liveness probe with zero dependency calls, returns `200` while the process is alive.
  * `GET /health/ready` — readiness probe, returns `503` when database or Redis is unavailable.

* **[MODIFY]** `backend/src/index.ts`
  * Registers root-level `GET /health/live` and `GET /health/ready` probes.

* **[MODIFY]** Docker healthchecks — `docker-compose.yml` and `backend/Dockerfile`
  * Healthchecks now target `/health/ready` so containers are only marked healthy once dependencies are reachable.

* **[ADD]** `docs/deployment/HEALTH_PROBES.md`
  * Probe configuration for Docker Compose, Dockerfile, Kubernetes, Render, Fly.io, Heroku, and Railway.

* **[MODIFY]** `backend/src/services/storage/queue.ts`
  * Removes a duplicate `const redisUrl` declaration that was a syntax error on `main` and broke the health test suite.

### Tests

* **[MODIFY]** `backend/tests/health.test.ts`
  * Integration tests for `/health`, `/health/live` (success, no dependency calls), and `/health/ready` (ready, dependency failure, no credential leakage).

* **[ADD]** `backend/tests/readinessMonitor.test.ts`
  * Unit tests covering ready state, database failure, Redis failure, disconnected client, timeout, and error sanitization.

## Verification Results

```
npx jest --runInBand --forceExit tests/health.test.ts tests/readinessMonitor.test.ts
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

✅ Liveness returns 200 without any dependency calls
✅ Readiness returns 503 when database/Redis unavailable
✅ Responses avoid credentials, connection strings, and stack traces
✅ Full backend suite runs the previously-broken health test suite

| Acceptance Criteria | Status |
| --- | --- |
| Liveness remains fast and succeeds while the process is alive | ✅ dependency-free, returns 200 |
| Readiness fails when required dependencies are unavailable or unhealthy | ✅ returns 503 with per-dependency status |
| Responses avoid credentials, connection strings, and internal stack traces | ✅ sanitized messages only |
| Health routes have automated success and dependency-failure tests | ✅ 16 tests covering success, failure, timeout |
| Deployment documentation includes probe examples | ✅ `docs/deployment/HEALTH_PROBES.md` |
