### PR TITLE
feat(analytics): distinguish live from fallback learner-progress data

### DIFF
--- a/frontend/src/app/performance-metrics/page.tsx
+++ b/frontend/src/app/performance-metrics/page.tsx
@@ -17,7 +17,8 @@ import { motion } from 'framer-motion';
  */
 export default function PerformanceMetricsPage() {
   const { user } = useAuth();
-  const { metrics, timeSpent, isLoading, error, isFallback } = usePerformanceMetrics(user?.id);
+  const { metrics, timeSpent, isLoading, isFallback, dataSource, lastVerifiedAt, retry } =
+    usePerformanceMetrics(user?.id);
 
   return (
     <div className="bg-background text-foreground relative min-h-screen overflow-hidden pb-20 transition-colors duration-200">
@@ -82,8 +83,10 @@ export default function PerformanceMetricsPage() {
             metrics={metrics}
             timeSpent={timeSpent}
             isLoading={isLoading}
-            error={error}
             isFallback={isFallback}
+            dataSource={dataSource}
+            lastVerifiedAt={lastVerifiedAt}
+            onRetry={retry}
           />
           <div className="mt-8">
             <ContributionPerformanceProfiler />

--- a/frontend/src/components/performance-metrics/DataSourceNotice.tsx
+++ b/frontend/src/components/performance-metrics/DataSourceNotice.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { DataSourceState } from '@/lib/analytics/performanceMetrics';
+
+export interface DataSourceNoticeProps {
+  dataSource: DataSourceState;
+  /** ISO timestamp of the last verified live fetch; shown for cached data. */
+  lastVerifiedAt?: string | null;
+  /** Called when the user asks to retry the live fetch. */
+  onRetry?: () => void;
+}
+
+const FALLBACK_MESSAGE = 'Showing sample data — live analytics are unavailable.';
+const CACHED_MESSAGE =
+  'Showing the last verified snapshot — the live refresh failed.';
+
+/**
+ * DataSourceNotice — a non-blocking, screen-reader-friendly indicator that
+ * tells learners exactly what the numbers on screen are:
+ *
+ *  - live: nothing warning-like is shown; the data is verified.
+ *  - cached: notes the live refresh failed and that the last verified snapshot
+ *    is being shown, with a retry action.
+ *  - fallback: states plainly that the dashboard is showing sample data, with a
+ *    retry action.
+ *
+ * This is the transparency surface required by the issue: users can always tell
+ * whether displayed metrics are live, cached, or fallback.
+ */
+export default function DataSourceNotice({
+  dataSource,
+  lastVerifiedAt,
+  onRetry,
+}: DataSourceNoticeProps) {
+  if (dataSource === 'live') {
+    return (
+      <p
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-2 text-xs font-bold tracking-widest text-green-500 uppercase"
+      >
+        <span className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true"></span>
+        Live data
+      </p>
+    );
+  }
+
+  const message = dataSource === 'cached' ? CACHED_MESSAGE : FALLBACK_MESSAGE;
+  const detail =
+    dataSource === 'cached' && lastVerifiedAt
+      ? ` Verified ${new Date(lastVerifiedAt).toLocaleString()}.`
+      : '';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="border-border-theme bg-bg-secondary flex flex-wrap items-center gap-3 rounded-xl border px-4 py-3 text-sm"
+    >
+      <span
+        className="h-2 w-2 rounded-full bg-yellow-500"
+        aria-hidden="true"
+      ></span>
+      <span className="text-text-secondary flex-1">
+        {message}
+        {detail}
+      </span>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="hover:bg-red-500/10 rounded-lg border border-red-500/40 px-3 py-1 text-xs font-bold tracking-widest text-red-500 uppercase"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/performance-metrics/PerformanceMetricsDashboard.tsx
+++ b/frontend/src/components/performance-metrics/PerformanceMetricsDashboard.tsx
@@ -14,21 +14,29 @@ import {
   Legend,
 } from 'recharts';
 import {
+  DataSourceState,
   LearningMetrics,
   TimeSpentPoint,
   buildCompletionBreakdown,
   buildMetricCards,
+  createMetricsExport,
   evaluateAchievements,
 } from '@/lib/analytics/performanceMetrics';
 import AchievementBadges from './AchievementBadges';
+import DataSourceNotice from './DataSourceNotice';
 
 export interface PerformanceMetricsDashboardProps {
   metrics: LearningMetrics;
   timeSpent: TimeSpentPoint[];
   isLoading?: boolean;
-  error?: Error | null;
-  /** When true, a banner notes that fallback (mock) data is being shown. */
+  /** Deprecated in favour of `dataSource`; kept for callers using the old flag. */
   isFallback?: boolean;
+  /** What the displayed data actually is. Defaults to `live`. */
+  dataSource?: DataSourceState;
+  /** ISO timestamp of the last verified live fetch; shown for cached data. */
+  lastVerifiedAt?: string | null;
+  /** Called when the user asks to retry the live fetch. */
+  onRetry?: () => void;
 }
 
 /** Shared Recharts tooltip styling, matching the existing analytics charts. */
@@ -55,8 +63,10 @@ export default function PerformanceMetricsDashboard({
   metrics,
   timeSpent,
   isLoading = false,
-  error = null,
   isFallback = false,
+  dataSource = isFallback ? 'fallback' : 'live',
+  lastVerifiedAt = null,
+  onRetry,
 }: PerformanceMetricsDashboardProps) {
   // --- Loading state -------------------------------------------------------
   if (isLoading) {
@@ -80,18 +90,45 @@ export default function PerformanceMetricsDashboard({
   const completion = buildCompletionBreakdown(metrics);
   const badges = evaluateAchievements(metrics);
 
+  // Sample/fallback data must never be exported as real learner progress, so the
+  // export is disabled in that state. Cached (stale-but-real) data is exportable
+  // but the payload is always labelled with its provenance.
+  const exportDisabled = dataSource === 'fallback';
+
+  function handleExport() {
+    if (exportDisabled) return;
+    const payload = createMetricsExport(metrics, { state: dataSource, lastVerifiedAt });
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `learning-performance-${dataSource}-${Date.now()}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="space-y-8">
-      {/* Fallback / error banner (graceful degradation) */}
-      {(error || isFallback) && (
-        <div
-          role="alert"
-          className="rounded-xl border border-yellow-500/30 bg-yellow-500/5 p-4 text-sm text-yellow-500"
+      {/* Data-source transparency: live vs cached vs fallback */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <DataSourceNotice dataSource={dataSource} lastVerifiedAt={lastVerifiedAt} onRetry={onRetry} />
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exportDisabled}
+          aria-disabled={exportDisabled}
+          title={
+            exportDisabled
+              ? 'Sample data cannot be exported as learner progress'
+              : `Export data (${dataSource})`
+          }
+          className="hover:bg-red-500/10 disabled:opacity-40 disabled:hover:bg-transparent rounded-lg border border-red-500/40 px-3 py-1 text-xs font-bold tracking-widest text-red-500 uppercase"
         >
-          Live analytics are unavailable right now — showing sample data so you
-          can still explore the dashboard.
-        </div>
-      )}
+          Export data
+        </button>
+      </div>
 
       {/* KPI cards */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">

--- a/frontend/src/components/performance-metrics/__tests__/DataSourceNotice.test.tsx
+++ b/frontend/src/components/performance-metrics/__tests__/DataSourceNotice.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DataSourceNotice from '../DataSourceNotice';
+
+describe('DataSourceNotice', () => {
+  it('shows a live indicator for verified live data', () => {
+    render(<DataSourceNotice dataSource="live" />);
+    expect(screen.getByRole('status')).toHaveTextContent('Live data');
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it('explains cached data and includes the verified timestamp', () => {
+    render(
+      <DataSourceNotice
+        dataSource="cached"
+        lastVerifiedAt="2026-07-31T09:00:00.000Z"
+        onRetry={vi.fn()}
+      />
+    );
+    const notice = screen.getByRole('status');
+    expect(notice).toHaveTextContent(/last verified snapshot/i);
+    expect(notice).toHaveTextContent(/Verified/);
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('states plainly that fallback data is sample data', () => {
+    render(<DataSourceNotice dataSource="fallback" onRetry={vi.fn()} />);
+    const notice = screen.getByRole('status');
+    expect(notice).toHaveTextContent(/sample data/i);
+    expect(notice).toHaveTextContent(/unavailable/i);
+  });
+
+  it('fires onRetry when the user retries', async () => {
+    const onRetry = vi.fn();
+    render(<DataSourceNotice dataSource="fallback" onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no retry button when no retry handler is provided', () => {
+    render(<DataSourceNotice dataSource="cached" lastVerifiedAt="2026-07-31T09:00:00.000Z" />);
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/performance-metrics/__tests__/PerformanceMetricsDashboard.test.tsx
+++ b/frontend/src/components/performance-metrics/__tests__/PerformanceMetricsDashboard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PerformanceMetricsDashboard from '../PerformanceMetricsDashboard';
+import { generateMockMetrics, generateMockTimeSpent } from '@/lib/analytics/performanceMetrics';
+
+const metrics = generateMockMetrics();
+const timeSpent = generateMockTimeSpent();
+
+describe('PerformanceMetricsDashboard export gating', () => {
+  it('disables the export for fallback (sample) data', () => {
+    render(
+      <PerformanceMetricsDashboard
+        metrics={metrics}
+        timeSpent={timeSpent}
+        dataSource="fallback"
+      />
+    );
+    expect(screen.getByRole('button', { name: /export data/i })).toBeDisabled();
+    expect(screen.getByText(/sample data/i)).toBeInTheDocument();
+  });
+
+  it('enables the export for live data', () => {
+    render(
+      <PerformanceMetricsDashboard
+        metrics={metrics}
+        timeSpent={timeSpent}
+        dataSource="live"
+      />
+    );
+    const button = screen.getByRole('button', { name: /export data/i });
+    expect(button).toBeEnabled();
+    expect(screen.getByText(/live data/i)).toBeInTheDocument();
+  });
+
+  it('enables the export for cached data and labels its provenance', () => {
+    render(
+      <PerformanceMetricsDashboard
+        metrics={metrics}
+        timeSpent={timeSpent}
+        dataSource="cached"
+        lastVerifiedAt="2026-07-31T09:00:00.000Z"
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /export data/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByText(/last verified snapshot/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/usePerformanceMetrics.test.ts
+++ b/frontend/src/hooks/__tests__/usePerformanceMetrics.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { usePerformanceMetrics } from '../usePerformanceMetrics';
+import apiClient from '@/lib/api-client';
+import { generateMockMetrics } from '@/lib/analytics/performanceMetrics';
+
+vi.mock('@/lib/api-client', () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockGet = vi.mocked(apiClient.get);
+
+const LIVE_PAYLOAD = {
+  performance: {
+    coursesCompleted: 4,
+    coursesEnrolled: 6,
+    totalTimeSpentMinutes: 720,
+    currentStreakDays: 5,
+    averageScore: 88,
+  },
+  timeSpent: [
+    { date: 'Jul 30', minutes: 45 },
+    { date: 'Jul 31', minutes: 60 },
+  ],
+};
+
+const NETWORK_ERROR = Object.assign(new Error('Network Error'), {
+  isAxiosError: true,
+  code: 'ERR_NETWORK',
+  response: undefined,
+});
+
+describe('usePerformanceMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports live data on a successful fetch', async () => {
+    mockGet.mockResolvedValue({ data: LIVE_PAYLOAD });
+
+    const { result } = renderHook(() => usePerformanceMetrics('student-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/analytics/user/student-1');
+    expect(result.current.dataSource).toBe('live');
+    expect(result.current.isFallback).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.metrics.coursesCompleted).toBe(4);
+    expect(result.current.metrics.averageScore).toBe(88);
+    expect(result.current.timeSpent).toHaveLength(2);
+    expect(result.current.lastVerifiedAt).not.toBeNull();
+  });
+
+  it('treats an empty-but-successful response as live, not fallback', async () => {
+    mockGet.mockResolvedValue({ data: { performance: {} } });
+
+    const { result } = renderHook(() => usePerformanceMetrics());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.dataSource).toBe('live');
+    expect(result.current.isFallback).toBe(false);
+    expect(result.current.metrics.coursesCompleted).toBe(0);
+    expect(result.current.metrics.averageScore).toBe(0);
+  });
+
+  it('falls back to mock data when no live snapshot exists yet', async () => {
+    mockGet.mockRejectedValue(NETWORK_ERROR);
+
+    const { result } = renderHook(() => usePerformanceMetrics());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.dataSource).toBe('fallback');
+    expect(result.current.isFallback).toBe(true);
+    expect(result.current.lastVerifiedAt).toBeNull();
+    expect(result.current.error?.code).toBe('NETWORK_ERROR');
+    expect(result.current.error?.retriable).toBe(true);
+    expect(result.current.metrics).toEqual(generateMockMetrics());
+  });
+
+  it('keeps the last verified snapshot (cached) when a later refresh fails', async () => {
+    mockGet.mockResolvedValueOnce({ data: LIVE_PAYLOAD });
+
+    const { result } = renderHook(() => usePerformanceMetrics());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.dataSource).toBe('live');
+
+    const liveVerifiedAt = result.current.lastVerifiedAt;
+    const liveMetrics = result.current.metrics;
+
+    mockGet.mockRejectedValueOnce(NETWORK_ERROR);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    expect(result.current.dataSource).toBe('cached');
+    expect(result.current.isFallback).toBe(false);
+    expect(result.current.metrics).toEqual(liveMetrics);
+    expect(result.current.lastVerifiedAt).toBe(liveVerifiedAt);
+    expect(result.current.error?.code).toBe('NETWORK_ERROR');
+  });
+
+  it('recovers to live data after a failed refresh', async () => {
+    mockGet.mockResolvedValueOnce({ data: LIVE_PAYLOAD });
+    mockGet.mockRejectedValueOnce(NETWORK_ERROR);
+
+    const { result } = renderHook(() => usePerformanceMetrics());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.dataSource).toBe('live');
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(result.current.dataSource).toBe('cached');
+
+    mockGet.mockResolvedValueOnce({ data: LIVE_PAYLOAD });
+
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    expect(result.current.dataSource).toBe('live');
+    expect(result.current.error).toBeNull();
+    expect(result.current.isFallback).toBe(false);
+  });
+
+  it('uses the overview endpoint when no userId is given', async () => {
+    mockGet.mockResolvedValue({ data: LIVE_PAYLOAD });
+
+    const { result } = renderHook(() => usePerformanceMetrics());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/analytics/overview');
+  });
+});

--- a/frontend/src/hooks/usePerformanceMetrics.ts
+++ b/frontend/src/hooks/usePerformanceMetrics.ts
@@ -1,11 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import apiClient from '@/lib/api-client';
 import {
+  AnalyticsError,
+  DataSourceState,
   LearningMetrics,
   TimeSpentPoint,
   generateMockMetrics,
   generateMockTimeSpent,
   normalizeMetrics,
+  toAnalyticsError,
 } from '@/lib/analytics/performanceMetrics';
 
 /**
@@ -16,60 +19,117 @@ import {
  * {@link useAnalytics}, then normalises the payload into the strongly-typed
  * `LearningMetrics` shape the dashboard understands.
  *
- * Error handling / fallbacks (per the acceptance criteria): if the request
- * fails — common in local dev where the backend may be offline — we surface the
- * error *and* fall back to deterministic mock data so the dashboard still
- * renders something useful instead of a blank screen.
+ * Data-source transparency (per the issue): the hook never lets the UI present
+ * anything but live data as if it were a verified record. It tracks a
+ * `dataSource` state of `live` | `cached` | `fallback`:
+ *
+ *  - `live`: the request succeeded; the snapshot is freshly verified.
+ *  - `cached`: the latest request failed but a previously verified live snapshot
+ *    exists, so stale-but-real data is kept on screen instead of fake numbers.
+ *  - `fallback`: no live snapshot has ever been verified, so deterministic mock
+ *    data is shown purely so the dashboard remains explorable.
+ *
+ * Every failure is also normalised into a structured {@link AnalyticsError} and
+ * surfaced, so the UI can always explain exactly what it is showing.
  */
 export interface PerformanceMetricsResult {
   metrics: LearningMetrics;
   timeSpent: TimeSpentPoint[];
   isLoading: boolean;
-  /** Non-null when the live fetch failed and mock data is being shown. */
-  error: Error | null;
-  /** True when the displayed data is mock fallback rather than live. */
+  /** Structured error from the most recent failed analytics request, if any. */
+  error: AnalyticsError | null;
+  /** True when the displayed data is deterministic mock fallback, not learner progress. */
   isFallback: boolean;
+  /** What the displayed data actually is — live, cached (stale real) or fallback (mock). */
+  dataSource: DataSourceState;
+  /** ISO timestamp of the last verified live fetch; null when never live. */
+  lastVerifiedAt: string | null;
+  /** Re-runs the fetch. Safe to call repeatedly. */
+  retry: () => Promise<void>;
 }
 
 export function usePerformanceMetrics(userId?: string): PerformanceMetricsResult {
   const [metrics, setMetrics] = useState<LearningMetrics>(generateMockMetrics);
   const [timeSpent, setTimeSpent] = useState<TimeSpentPoint[]>(() => generateMockTimeSpent());
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [isFallback, setIsFallback] = useState(false);
+  const [error, setError] = useState<AnalyticsError | null>(null);
+  const [dataSource, setDataSource] = useState<DataSourceState>('fallback');
+  const [lastVerifiedAt, setLastVerifiedAt] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  // Guards: a monotonically increasing run id lets a stale in-flight request be
+  // ignored once a newer load() has started (covers retry races + unmount).
+  const runIdRef = useRef(0);
+  const timeSpentRef = useRef<TimeSpentPoint[]>(timeSpent);
+  const lastLiveRef = useRef<{
+    metrics: LearningMetrics;
+    timeSpent: TimeSpentPoint[];
+    verifiedAt: string;
+  } | null>(null);
 
-    async function load() {
-      setIsLoading(true);
-      try {
-        const response = await apiClient.get(
-          userId ? `/analytics/user/${userId}` : '/analytics/overview'
-        );
-        if (cancelled) return;
-        const payload = response.data ?? {};
-        setMetrics(normalizeMetrics(payload.performance ?? payload));
-        if (Array.isArray(payload.timeSpent) && payload.timeSpent.length > 0) {
-          setTimeSpent(payload.timeSpent as TimeSpentPoint[]);
-        }
-        setError(null);
-        setIsFallback(false);
-      } catch (err) {
-        if (cancelled) return;
-        // Graceful degradation: keep the mock data already in state.
-        setError(err as Error);
-        setIsFallback(true);
-      } finally {
-        if (!cancelled) setIsLoading(false);
+  const load = useCallback(async () => {
+    const runId = ++runIdRef.current;
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get(
+        userId ? `/analytics/user/${userId}` : '/analytics/overview'
+      );
+      if (runIdRef.current !== runId) return;
+
+      const payload = response.data ?? {};
+      const nextMetrics = normalizeMetrics(payload.performance ?? payload);
+      const nextTimeSpent =
+        Array.isArray(payload.timeSpent) && payload.timeSpent.length > 0
+          ? (payload.timeSpent as TimeSpentPoint[])
+          : timeSpentRef.current;
+      const verifiedAt = new Date().toISOString();
+
+      timeSpentRef.current = nextTimeSpent;
+      lastLiveRef.current = { metrics: nextMetrics, timeSpent: nextTimeSpent, verifiedAt };
+
+      setMetrics(nextMetrics);
+      setTimeSpent(nextTimeSpent);
+      setLastVerifiedAt(verifiedAt);
+      setDataSource('live');
+      setError(null);
+    } catch (err) {
+      if (runIdRef.current !== runId) return;
+
+      const analyticsError = toAnalyticsError(err);
+      const lastLive = lastLiveRef.current;
+      if (lastLive) {
+        // Keep the last verified snapshot rather than replacing real data with mock.
+        setMetrics(lastLive.metrics);
+        setTimeSpent(lastLive.timeSpent);
+        setLastVerifiedAt(lastLive.verifiedAt);
+        setDataSource('cached');
+      } else {
+        setLastVerifiedAt(null);
+        setDataSource('fallback');
       }
+      setError(analyticsError);
+    } finally {
+      if (runIdRef.current === runId) setIsLoading(false);
     }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
   }, [userId]);
 
-  return { metrics, timeSpent, isLoading, error, isFallback };
+  useEffect(() => {
+    load();
+    return () => {
+      // Invalidate any in-flight request when the hook unmounts.
+      runIdRef.current += 1;
+    };
+  }, [load]);
+
+  const retry = useCallback(() => load(), [load]);
+
+  return {
+    metrics,
+    timeSpent,
+    isLoading,
+    error,
+    isFallback: dataSource === 'fallback',
+    dataSource,
+    lastVerifiedAt,
+    retry,
+  };
 }

--- a/frontend/src/lib/analytics/__tests__/performanceMetrics.test.ts
+++ b/frontend/src/lib/analytics/__tests__/performanceMetrics.test.ts
@@ -4,7 +4,10 @@ import {
   formatDuration,
   evaluateAchievements,
   countEarnedBadges,
+  toAnalyticsError,
+  createMetricsExport,
   type LearningMetrics,
+  type AnalyticsError,
 } from '../performanceMetrics';
 
 const base: LearningMetrics = {
@@ -35,5 +38,101 @@ describe('performanceMetrics', () => {
     // finisher (100%) and time-scholar (>=600m) not.
     expect(earned).toBe(4);
     expect(badges.find((b) => b.id === 'finisher')?.earned).toBe(false);
+  });
+
+  describe('toAnalyticsError', () => {
+    it('classifies a network failure as retriable', () => {
+      const error = Object.assign(new Error('Network Error'), {
+        isAxiosError: true,
+        code: 'ERR_NETWORK',
+        response: undefined,
+      });
+      expect(toAnalyticsError(error)).toEqual({
+        code: 'NETWORK_ERROR',
+        message: 'Network Error',
+        retriable: true,
+      });
+    });
+
+    it('classifies a timeout as retriable', () => {
+      const error = Object.assign(new Error('timeout of 5000ms exceeded'), {
+        isAxiosError: true,
+        code: 'ECONNABORTED',
+        response: undefined,
+      });
+      expect(toAnalyticsError(error)).toEqual({
+        code: 'TIMEOUT',
+        message: 'timeout of 5000ms exceeded',
+        retriable: true,
+      });
+    });
+
+    it('marks 5xx responses as retriable and 4xx as not', () => {
+      const five = Object.assign(new Error('Service Unavailable'), {
+        isAxiosError: true,
+        response: { status: 503 },
+      });
+      const four = Object.assign(new Error('Not Found'), {
+        isAxiosError: true,
+        response: { status: 404 },
+      });
+      expect(toAnalyticsError(five).retriable).toBe(true);
+      expect(toAnalyticsError(five).code).toBe('HTTP_503');
+      expect(toAnalyticsError(four).retriable).toBe(false);
+      expect(toAnalyticsError(four).status).toBe(404);
+    });
+
+    it('uses the server-provided message when present', () => {
+      const error = Object.assign(new Error('Request failed with status code 400'), {
+        isAxiosError: true,
+        response: { status: 400, data: { message: 'Invalid cohort id' } },
+      });
+      expect(toAnalyticsError(error).message).toBe('Invalid cohort id');
+    });
+
+    it('passes structured errors through unchanged', () => {
+      const structured: AnalyticsError = {
+        code: 'HTTP_500',
+        message: 'boom',
+        retriable: true,
+        status: 500,
+      };
+      expect(toAnalyticsError(structured)).toBe(structured);
+    });
+
+    it('wraps unknown errors as non-retriable', () => {
+      expect(toAnalyticsError('kaput')).toEqual({
+        code: 'UNKNOWN_ERROR',
+        message: 'Unexpected analytics error',
+        retriable: false,
+      });
+    });
+  });
+
+  describe('createMetricsExport', () => {
+    it('labels live exports as live', () => {
+      const exportedAt = '2026-07-31T12:00:00.000Z';
+      const payload = createMetricsExport(base, { state: 'live', lastVerifiedAt: exportedAt }, exportedAt);
+      expect(payload.isLive).toBe(true);
+      expect(payload.source).toBe('live');
+      expect(payload.lastVerifiedAt).toBe(exportedAt);
+      expect(payload.exportedAt).toBe(exportedAt);
+      expect(payload.metrics).toEqual(base);
+    });
+
+    it('labels cached exports as non-live with provenance', () => {
+      const lastVerifiedAt = '2026-07-31T09:00:00.000Z';
+      const payload = createMetricsExport(base, { state: 'cached', lastVerifiedAt }, lastVerifiedAt);
+      expect(payload.isLive).toBe(false);
+      expect(payload.source).toBe('cached');
+      expect(payload.lastVerifiedAt).toBe(lastVerifiedAt);
+    });
+
+    it('labels fallback exports as non-live', () => {
+      const payload = createMetricsExport(base, { state: 'fallback', lastVerifiedAt: null });
+      expect(payload.isLive).toBe(false);
+      expect(payload.source).toBe('fallback');
+      expect(payload.lastVerifiedAt).toBeNull();
+    });
   });
 });

--- a/frontend/src/lib/analytics/performanceMetrics.ts
+++ b/frontend/src/lib/analytics/performanceMetrics.ts
@@ -237,6 +237,125 @@ export function normalizeMetrics(raw: unknown): LearningMetrics {
 }
 
 /**
+ * What a learner-progress dashboard is actually displaying.
+ *
+ *  - `live`: freshly fetched from the analytics API.
+ *  - `cached`: the last verified live snapshot, kept on screen because the most
+ *    recent refresh failed (so stale-but-real data is never mistaken for a
+ *    fresh record — but it is also never replaced with fake numbers).
+ *  - `fallback`: no live snapshot has ever been verified, so deterministic
+ *    sample data is shown purely so the UI is explorable.
+ *
+ * Dashboards must never present `cached` or `fallback` values as if they were
+ * live progress records.
+ */
+export type DataSourceState = 'live' | 'cached' | 'fallback';
+
+/** Structured error from an analytics request, safe to surface and log. */
+export interface AnalyticsError {
+  code: string;
+  message: string;
+  /** True when a retry may succeed (network/timeout/5xx), false when the request is unusable (4xx). */
+  retriable: boolean;
+  /** HTTP status when the failure came from a server response. */
+  status?: number;
+}
+
+/** Provenance metadata attached to whatever snapshot is on screen. */
+export interface MetricsSource {
+  state: DataSourceState;
+  /** ISO timestamp of the last verified live fetch; null when never live. */
+  lastVerifiedAt: string | null;
+  /** Structured error from the most recent failed analytics request. */
+  error: AnalyticsError | null;
+}
+
+/**
+ * Normalise an unknown thrown value into a structured {@link AnalyticsError}.
+ * Axios failures carry a shape we can classify (network/timeout vs HTTP status);
+ * anything else becomes an opaque but still structured error.
+ */
+export function toAnalyticsError(error: unknown): AnalyticsError {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    'message' in error &&
+    'retriable' in error
+  ) {
+    return error as AnalyticsError;
+  }
+
+  const err = error as {
+    isAxiosError?: boolean;
+    code?: string;
+    message?: string;
+    response?: { status?: number; data?: unknown };
+  };
+
+  const status = typeof err.response?.status === 'number' ? err.response.status : undefined;
+
+  if (err.isAxiosError && status === undefined) {
+    return {
+      code: err.code === 'ECONNABORTED' ? 'TIMEOUT' : 'NETWORK_ERROR',
+      message: err.message || 'Analytics endpoint is unreachable',
+      retriable: true,
+    };
+  }
+
+  if (status !== undefined) {
+    const responseData =
+      err.response && typeof err.response.data === 'object' && err.response.data !== null
+        ? (err.response.data as Record<string, unknown>)
+        : null;
+    return {
+      code: `HTTP_${status}`,
+      message:
+        (responseData && typeof responseData.message === 'string'
+          ? responseData.message
+          : err.message) || 'Analytics request failed',
+      retriable: status >= 500,
+      status,
+    };
+  }
+
+  return {
+    code: 'UNKNOWN_ERROR',
+    message: err.message || 'Unexpected analytics error',
+    retriable: false,
+  };
+}
+
+/** Snapshot of a metrics export. */
+export interface MetricsExportPayload {
+  exportedAt: string;
+  /** Provenance of the exported numbers — never claim non-live data as live. */
+  source: DataSourceState;
+  isLive: boolean;
+  lastVerifiedAt: string | null;
+  metrics: LearningMetrics;
+}
+
+/**
+ * Build an export payload that always carries its provenance. `isLive` is false
+ * for `cached` and `fallback` data, so a downstream consumer can never mistake
+ * sample or stale numbers for a verified learner record.
+ */
+export function createMetricsExport(
+  metrics: LearningMetrics,
+  source: Pick<MetricsSource, 'state' | 'lastVerifiedAt'>,
+  exportedAt = new Date().toISOString(),
+): MetricsExportPayload {
+  return {
+    exportedAt,
+    source: source.state,
+    isLive: source.state === 'live',
+    lastVerifiedAt: source.lastVerifiedAt,
+    metrics,
+  };
+}
+
+/**
  * Deterministic-ish mock metrics for local development and the fallback path.
  * Note: kept free of Math.random so snapshots are stable in tests.
  */


### PR DESCRIPTION
## Summary

Closes #888

Learner-progress dashboards can now always tell the difference between **live**, **cached**, and **fallback** data. Instead of silently swapping in sample numbers when the analytics API is unavailable, the performance-metrics dashboard states exactly what it is showing.

## What changed

### Data-source transparency
- **`usePerformanceMetrics`** now tracks a `dataSource` state: `live | cached | fallback`.
  - `live` — freshly verified from the analytics API.
  - `cached` — the most recent refresh failed, so the last **verified** snapshot is kept on screen (stale-but-real, never replaced with fake numbers).
  - `fallback` — no live snapshot has ever been verified; deterministic sample data is shown purely so the UI stays explorable.
- Errors are normalised into a structured `AnalyticsError` (network/timeout/HTTP classification + retriability) via `toAnalyticsError`, and `lastVerifiedAt` provenance is surfaced.

### UI (`DataSourceNotice`)
- Non-blocking, screen-reader-friendly (`role="status"`) indicator that distinguishes:
  - a subtle green **Live data** pill, or
  - an amber notice explaining the snapshot is the **last verified** one (with timestamp) or plain **sample data** — each with a **Retry** action.

### Export integrity
- Fallback (sample) values **cannot be exported** as learner progress — the export button is disabled.
- Cached data is exportable but the payload is always labelled via `createMetricsExport` with `source: "cached"`, `isLive: false`, and `lastVerifiedAt`, so a downstream consumer can never mistake non-live numbers for a verified record.

## Tests
- Hook tests cover **live, empty, failed, cached, and recovered** states (`usePerformanceMetrics.test.ts`).
- Lib tests for `toAnalyticsError` and `createMetricsExport` labelling (`performanceMetrics.test.ts`).
- Component tests for the notice (live/cached/fallback + retry) and export gating.

All new tests pass (`26/26` in the touched suites); the only failing suites in the repo are pre-existing and unrelated (theme/keyboard/tutorial/editor/monaco).