### PR TITLE
fix(backend): replace static Cargo dependency registry with maintainable update source #881

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "test:migrations": "echo 'No migrations tests'",
     "test:migrations": "bash scripts/test-migration-rollback.sh",
     "validate:curriculum": "tsx scripts/validate-curriculum.ts",
+    "refresh:dependency-registry": "tsx scripts/refresh-dependency-registry.ts",
 
     "bench": "tsx benchmarks/runBenchmarks.ts",
     "collaboration": "tsx src/collaborationServer.ts",

--- a/backend/scripts/refresh-dependency-registry.ts
+++ b/backend/scripts/refresh-dependency-registry.ts
@@ -1,0 +1,92 @@
+/**
+ * Refresh helper for the curated dependency registry (issue #881).
+ *
+ * Queries crates.io for every crate in the curated snapshot and prints the
+ * current vs. newest version for each. Maintainers review the output and
+ * commit the updated snapshot in `src/config/dependency-registry.ts`.
+ *
+ * The application itself never depends on this script or on crates.io — if
+ * this refresh fails, the committed snapshot keeps the service functional.
+ *
+ * Usage:
+ *   npm run refresh:dependency-registry   (from backend/)
+ *
+ * Exit code is 0 when every crate resolved, 1 when one or more failed.
+ */
+import {
+  getCrateRegistrySnapshot,
+  REGISTRY_METADATA,
+} from '../src/config/dependency-registry.js';
+
+const CRATES_IO_API = 'https://crates.io/api/v1/crates';
+const USER_AGENT = 'web3-student-lab-dependency-registry-refresh (backend maintainers)';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+interface CratesIoResponse {
+  crate?: {
+    newest_version?: string;
+  };
+}
+
+async function fetchNewestVersion(crateName: string): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${CRATES_IO_API}/${encodeURIComponent(crateName)}`, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`crates.io responded with HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as CratesIoResponse;
+    return data.crate?.newest_version;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main(): Promise<void> {
+  const snapshot = getCrateRegistrySnapshot();
+  const crateNames = Object.keys(snapshot);
+  const failures: string[] = [];
+  let changed = 0;
+
+  console.log(
+    `Refreshing ${crateNames.length} crate(s) from ${REGISTRY_METADATA.source} (owner: ${REGISTRY_METADATA.owner})`
+  );
+  console.log('');
+
+  for (const name of crateNames) {
+    const current = snapshot[name]?.version ?? 'unknown';
+    try {
+      const newest = await fetchNewestVersion(name);
+      if (!newest) {
+        throw new Error('crates.io returned no newest_version');
+      }
+      const status = newest === current ? 'up to date' : 'UPDATE AVAILABLE';
+      if (newest !== current) changed += 1;
+      console.log(`${name.padEnd(16)} ${current.padEnd(10)} -> ${newest.padEnd(10)} (${status})`);
+    } catch (error) {
+      failures.push(name);
+      console.error(`${name.padEnd(16)} FAILED: ${(error as Error).message}`);
+    }
+  }
+
+  console.log('');
+  if (failures.length > 0) {
+    console.error(
+      `Refresh incomplete: ${failures.length} crate(s) could not be resolved: ${failures.join(', ')}`
+    );
+    process.exitCode = 1;
+  } else if (changed > 0) {
+    console.log(
+      `${changed} crate(s) have updates. Review the versions above, then update ` +
+        '`src/config/dependency-registry.ts` and commit.'
+    );
+  } else {
+    console.log('All crates are up to date. No changes needed.');
+  }
+}
+
+main();

--- a/backend/src/config/dependency-registry.ts
+++ b/backend/src/config/dependency-registry.ts
@@ -1,0 +1,118 @@
+/**
+ * Cargo dependency registry — curated snapshot provider.
+ *
+ * This module is the single documented source of truth for the latest known
+ * versions of the Soroban/Stellar crates used by the dependency-update
+ * service (issue #881). Live update execution in
+ * `dependency-update.service.ts` only consumes the provider interface exported
+ * here; it never touches raw data, so the source can be swapped (e.g. for a
+ * live crates.io client) without changing service code.
+ *
+ * --- Ownership ---
+ * Maintained by the Web3 Student Lab backend/playground team.
+ * Last reviewed: 2026-07-20.
+ *
+ * --- Source ---
+ * crates.io registry metadata: https://crates.io/api/v1/crates/<crate>
+ *
+ * --- Refresh strategy ---
+ * This is a CURATED SNAPSHOT, not a live registry. It is refreshed on demand
+ * by running:
+ *
+ *   cd backend && npm run refresh:dependency-registry
+ *
+ * `scripts/refresh-dependency-registry.ts` queries crates.io for every crate
+ * below and prints an updated snapshot for maintainers to review and commit.
+ *
+ * --- Failure handling ---
+ * Runtime services never depend on crates.io. If an external registry refresh
+ * ever fails, the committed snapshot below keeps the application fully
+ * functional. The accessor functions are fail-safe: they never throw for
+ * unknown or malformed entries.
+ */
+
+export interface CrateRegistryEntry {
+  /** Latest known stable version of the crate. */
+  version: string;
+  /** Optional short release notes surfaced to users in dependency checks. */
+  releaseNotes?: string;
+}
+
+export interface CrateRegistryMetadata {
+  /** Team or maintainer responsible for the snapshot. */
+  owner: string;
+  /** ISO date of the last manual review/refresh of the snapshot. */
+  lastReviewed: string;
+  /** Where the version data originates. */
+  source: string;
+  /** How the snapshot is kept up to date. */
+  refreshStrategy: string;
+}
+
+export const REGISTRY_METADATA: CrateRegistryMetadata = {
+  owner: 'Web3 Student Lab backend/playground team',
+  lastReviewed: '2026-07-20',
+  source: 'crates.io registry metadata (https://crates.io/api/v1/crates/<crate>)',
+  refreshStrategy:
+    'Curated snapshot. Refresh with `npm run refresh:dependency-registry` (backend) and commit the resulting diff.',
+};
+
+/**
+ * Curated snapshot of the latest known versions for Soroban/Stellar crates.
+ * Do not edit ad hoc — run the refresh script and commit its output.
+ */
+const CURATED_REGISTRY: Readonly<Record<string, CrateRegistryEntry>> = {
+  'soroban-sdk': {
+    version: '26.1.0',
+    releaseNotes: 'Protocol 26 support, improved storage APIs, and security patches.',
+  },
+  'soroban-auth': {
+    version: '26.1.0',
+    releaseNotes: 'Improved authorization framework compatibility with Protocol 26.',
+  },
+  'stellar-xdr': {
+    version: '22.1.0',
+    releaseNotes: 'Updated XDR definitions for Stellar Protocol 22.',
+  },
+  'num-integer': { version: '0.1.46' },
+  'num-traits': { version: '0.2.19' },
+  serde: {
+    version: '1.0.219',
+    releaseNotes: 'Performance improvements and new derive macro features.',
+  },
+  serde_json: { version: '1.0.140' },
+  base64: { version: '0.22.1' },
+  hex: { version: '0.4.3' },
+  sha2: { version: '0.10.9' },
+  hmac: { version: '0.12.1' },
+  'ed25519-dalek': { version: '2.1.1' },
+};
+
+export function getCuratedLatestVersion(crateName: string): string | undefined {
+  return CURATED_REGISTRY[crateName]?.version;
+}
+
+export function getCuratedReleaseNotes(crateName: string): string | undefined {
+  return CURATED_REGISTRY[crateName]?.releaseNotes;
+}
+
+/** Returns a copy of the curated snapshot (callers cannot mutate it). */
+export function getCrateRegistrySnapshot(): Readonly<Record<string, CrateRegistryEntry>> {
+  return { ...CURATED_REGISTRY };
+}
+
+/**
+ * Contract the dependency-update service relies on. Implementations must be
+ * fail-safe for unknown crates (return `undefined`); the service wraps calls
+ * in its own guards so a throwing provider can never break the application.
+ */
+export interface DependencyRegistryProvider {
+  getLatestVersion(crateName: string): string | undefined;
+  getReleaseNotes(crateName: string): string | undefined;
+}
+
+/** Default provider backed by the curated snapshot. */
+export const curatedRegistryProvider: DependencyRegistryProvider = {
+  getLatestVersion: getCuratedLatestVersion,
+  getReleaseNotes: getCuratedReleaseNotes,
+};

--- a/backend/src/routes/dependencies.routes.ts
+++ b/backend/src/routes/dependencies.routes.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
-import { checkDependencies, updateDependencies } from '../services/dependency-update.service.js';
+import {
+  checkDependencies,
+  updateDependencies,
+  DependencyServiceError,
+} from '../services/dependency-update.service.js';
 import { validateRequest } from '../utils/validation.js';
 import logger from '../utils/logger.js';
 import { dependencyCheckSchema, dependencyUpdateSchema } from './dependencies.validation.schemas.js';
@@ -30,6 +34,10 @@ router.post('/update', validateRequest(dependencyUpdateSchema), async (req, res)
     res.json({ status: 'success', ...result });
   } catch (error) {
     logger.error('Error updating dependencies', error);
+    if (error instanceof DependencyServiceError) {
+      res.status(503).json({ status: 'error', code: error.code, message: error.message });
+      return;
+    }
     res.status(500).json({ status: 'error', message: 'Unable to update dependencies' });
   }
 });

--- a/backend/src/services/dependency-update.service.ts
+++ b/backend/src/services/dependency-update.service.ts
@@ -1,4 +1,8 @@
 import logger from '../utils/logger.js';
+import {
+  curatedRegistryProvider,
+  type DependencyRegistryProvider,
+} from '../config/dependency-registry.js';
 
 export interface CargoTomlDependency {
   name: string;
@@ -22,35 +26,107 @@ export interface DependencyUpdateResult {
   suggestedCargoToml: string;
 }
 
-// Simulated Soroban/Stellar Rust dependency registry (latest known versions)
-const REGISTRY: Record<string, string> = {
-  'soroban-sdk': '26.1.0',
-  'soroban-auth': '26.1.0',
-  'stellar-xdr': '22.1.0',
-  'num-integer': '0.1.46',
-  'num-traits': '0.2.19',
-  'serde': '1.0.219',
-  'serde_json': '1.0.140',
-  'base64': '0.22.1',
-  'hex': '0.4.3',
-  'sha2': '0.10.9',
-  'hmac': '0.12.1',
-  'ed25519-dalek': '2.1.1',
-};
+export type VersionUpdateType = 'major' | 'minor' | 'patch' | 'none';
 
-const RELEASE_NOTES: Record<string, string> = {
-  'soroban-sdk': 'Protocol 26 support, improved storage APIs, and security patches.',
-  'stellar-xdr': 'Updated XDR definitions for Stellar Protocol 22.',
-  'soroban-auth': 'Improved authorization framework compatibility with Protocol 26.',
-  'serde': 'Performance improvements and new derive macro features.',
-};
+/**
+ * Raised when the dependency registry provider cannot resolve versions for an
+ * update request. Carries a stable `code` so callers can surface an actionable
+ * message instead of a generic failure.
+ */
+export class DependencyServiceError extends Error {
+  constructor(
+    public readonly code: 'DEPENDENCY_REGISTRY_UNAVAILABLE',
+    message: string
+  ) {
+    super(message);
+    this.name = 'DependencyServiceError';
+  }
+}
 
-function compareVersions(a: string, b: string): 'major' | 'minor' | 'patch' | 'none' {
-  const [aMaj = 0, aMin = 0, aPat = 0] = a.split('.').map(Number);
-  const [bMaj = 0, bMin = 0, bPat = 0] = b.split('.').map(Number);
-  if (bMaj > aMaj) return 'major';
-  if (bMin > aMin) return 'minor';
-  if (bPat > aPat) return 'patch';
+interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+/**
+ * Matches `[v]major[.minor[.patch]][-prerelease][+build]`.
+ * Major is required; minor/patch default to 0; prerelease and build metadata
+ * identifiers follow semver's [0-9A-Za-z-] character set.
+ */
+const SEMVER_PATTERN =
+  /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseSemver(input: string): ParsedSemver | null {
+  if (typeof input !== 'string' || input.trim() === '') return null;
+  const match = input.trim().match(SEMVER_PATTERN);
+  if (!match) return null;
+
+  const major = Number(match[1]);
+  if (!Number.isSafeInteger(major) || major < 0) return null;
+  const minor = match[2] !== undefined ? Number(match[2]) : 0;
+  if (!Number.isSafeInteger(minor) || minor < 0) return null;
+  const patch = match[3] !== undefined ? Number(match[3]) : 0;
+  if (!Number.isSafeInteger(patch) || patch < 0) return null;
+  const prerelease = match[4] !== undefined ? match[4].split('.') : [];
+
+  return { major, minor, patch, prerelease };
+}
+
+/**
+ * Compare two prerelease identifier lists per semver rules:
+ * a list with no prerelease is the full release (sorts after any prerelease);
+ * numeric identifiers sort before alphanumeric ones, numeric identifiers
+ * compare numerically, alphanumeric identifiers compare lexically, and a
+ * shorter list sorts before a longer one when all shared parts are equal.
+ */
+function comparePrerelease(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const aPart = a[i];
+    const bPart = b[i];
+    if (aPart === undefined) return -1;
+    if (bPart === undefined) return 1;
+
+    const aNumeric = /^\d+$/.test(aPart) ? Number(aPart) : null;
+    const bNumeric = /^\d+$/.test(bPart) ? Number(bPart) : null;
+    if (aNumeric !== null && bNumeric !== null) {
+      if (aNumeric !== bNumeric) return aNumeric < bNumeric ? -1 : 1;
+      continue;
+    }
+    if (aNumeric !== null) return -1;
+    if (bNumeric !== null) return 1;
+    if (aPart !== bPart) return aPart < bPart ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Classify the update level needed to move from `current` to `latest`.
+ *
+ * Handles prerelease suffixes (`1.2.0-beta.1`), build metadata (`1.2.0+build`),
+ * optional `v` prefixes, and short forms such as `1.2`. A prerelease-only
+ * difference is treated as a patch-level change. Malformed or unparseable
+ * input returns `'none'` and never throws, so a bad registry entry cannot
+ * break dependency checks.
+ */
+export function compareVersions(current: string, latest: string): VersionUpdateType {
+  const from = parseSemver(current);
+  const to = parseSemver(latest);
+  if (!from || !to) return 'none';
+
+  if (to.major > from.major) return 'major';
+  if (to.major < from.major) return 'none';
+  if (to.minor > from.minor) return 'minor';
+  if (to.minor < from.minor) return 'none';
+  if (to.patch > from.patch) return 'patch';
+  if (to.patch < from.patch) return 'none';
+  if (comparePrerelease(from.prerelease, to.prerelease) < 0) return 'patch';
   return 'none';
 }
 
@@ -98,14 +174,25 @@ export function parseCargoTomlDependencies(cargoToml: string): Array<{ name: str
   return deps;
 }
 
-export async function checkDependencies(cargoToml: string): Promise<DependencyCheckResult> {
+export async function checkDependencies(
+  cargoToml: string,
+  registry: DependencyRegistryProvider = curatedRegistryProvider
+): Promise<DependencyCheckResult> {
   const parsed = parseCargoTomlDependencies(cargoToml);
   const cargoTomlHash = simpleHash(cargoToml);
 
   const dependencies: CargoTomlDependency[] = parsed.map(({ name, version }) => {
-    const latestVersion = REGISTRY[name] ?? version;
+    let latestVersion: string | undefined;
+    let releaseNotes: string | undefined;
+    try {
+      latestVersion = registry.getLatestVersion(name);
+      releaseNotes = registry.getReleaseNotes(name);
+    } catch (error) {
+      // A failing registry provider must never break dependency checks.
+      logger.warn(`Dependency registry provider failed for crate "${name}"`, error);
+    }
+    latestVersion ??= version;
     const updateType = compareVersions(version, latestVersion);
-    const releaseNotes = RELEASE_NOTES[name];
     return {
       name,
       currentVersion: version,
@@ -134,11 +221,13 @@ export async function checkDependencies(cargoToml: string): Promise<DependencyCh
 
 export async function updateDependencies(
   cargoToml: string,
-  dependenciesToUpdate: string[]
+  dependenciesToUpdate: string[],
+  registry: DependencyRegistryProvider = curatedRegistryProvider
 ): Promise<DependencyUpdateResult> {
   const parsed = parseCargoTomlDependencies(cargoToml);
   const updated: string[] = [];
   const failed: string[] = [];
+  const registryFailures: string[] = [];
   let updatedCargoToml = cargoToml;
 
   for (const depName of dependenciesToUpdate) {
@@ -147,7 +236,14 @@ export async function updateDependencies(
       failed.push(depName);
       continue;
     }
-    const latestVersion = REGISTRY[dep.name];
+    let latestVersion: string | undefined;
+    try {
+      latestVersion = registry.getLatestVersion(dep.name);
+    } catch (error) {
+      registryFailures.push(depName);
+      logger.warn(`Dependency registry provider failed for crate "${depName}"`, error);
+      continue;
+    }
     if (!latestVersion) {
       failed.push(depName);
       continue;
@@ -165,6 +261,14 @@ export async function updateDependencies(
       `$1"${latestVersion}"`
     );
     updated.push(depName);
+  }
+
+  if (registryFailures.length > 0) {
+    throw new DependencyServiceError(
+      'DEPENDENCY_REGISTRY_UNAVAILABLE',
+      `Could not resolve the latest version of: ${registryFailures.join(', ')}. ` +
+        'The dependency registry is temporarily unavailable; please retry the update later.'
+    );
   }
 
   logger.info('Dependency update completed', {

--- a/backend/tests/dependency-update.service.test.ts
+++ b/backend/tests/dependency-update.service.test.ts
@@ -3,6 +3,8 @@ import {
   parseCargoTomlDependencies,
   checkDependencies,
   updateDependencies,
+  compareVersions,
+  DependencyServiceError,
 } from '../src/services/dependency-update.service.js';
 
 const SAMPLE_TOML = `[package]
@@ -75,6 +77,81 @@ describe('checkDependencies', () => {
     const latest = '[dependencies]\nsoroban-sdk = "26.1.0"\n';
     const result = await checkDependencies(latest);
     expect(result.outdatedCount).toBe(0);
+  });
+});
+
+describe('compareVersions', () => {
+  it('classifies major, minor, and patch updates', () => {
+    expect(compareVersions('21.7.6', '26.1.0')).toBe('major');
+    expect(compareVersions('1.2.0', '1.3.0')).toBe('minor');
+    expect(compareVersions('1.2.3', '1.2.4')).toBe('patch');
+    expect(compareVersions('1.2.3', '1.2.3')).toBe('none');
+  });
+
+  it('returns none when the current version is newer than the registry entry', () => {
+    expect(compareVersions('27.0.0', '26.1.0')).toBe('none');
+    expect(compareVersions('1.3.0', '1.2.9')).toBe('none');
+    expect(compareVersions('1.2.5', '1.2.4')).toBe('none');
+  });
+
+  it('handles prerelease versions safely', () => {
+    expect(compareVersions('1.2.3-beta.1', '1.2.3')).toBe('patch');
+    expect(compareVersions('1.2.3', '1.2.3-beta.1')).toBe('none');
+    expect(compareVersions('1.2.3-alpha', '1.2.3-beta')).toBe('patch');
+    expect(compareVersions('1.2.3-beta.1', '1.2.3-beta.2')).toBe('patch');
+    expect(compareVersions('1.2.3-alpha.1', '1.2.3-alpha')).toBe('none');
+    expect(compareVersions('1.2.3-beta.1', '1.2.3-alpha.1')).toBe('none');
+    expect(compareVersions('1.0.0-alpha', '1.0.0-alpha.1')).toBe('patch');  });
+
+  it('handles build metadata, v prefixes, and short forms', () => {
+    expect(compareVersions('1.2.3+build.5', '1.2.4')).toBe('patch');
+    expect(compareVersions('v1.2.3', '1.2.4')).toBe('patch');
+    expect(compareVersions('v1.2.3', '1.2.3')).toBe('none');
+    expect(compareVersions('1.2', '1.2.0')).toBe('none');
+    expect(compareVersions('1.2', '1.3.0')).toBe('minor');
+    expect(compareVersions('1', '2.0.0')).toBe('major');
+  });
+
+  it('treats malformed input as no update without throwing', () => {
+    expect(compareVersions('', '1.2.3')).toBe('none');
+    expect(compareVersions('abc', '1.2.3')).toBe('none');
+    expect(compareVersions('1.2.3', 'not-a-version')).toBe('none');
+    expect(compareVersions('1..3', '1.2.3')).toBe('none');
+    expect(compareVersions('*', '1.2.3')).toBe('none');
+    expect(compareVersions('1.2.3.4', '1.2.3')).toBe('none');
+    expect(compareVersions('1.2.3', '1.2.3.4')).toBe('none');
+  });
+});
+
+describe('dependency registry provider resilience', () => {
+  it('checkDependencies does not break when the registry provider throws', async () => {
+    const failingRegistry = {
+      getLatestVersion: () => {
+        throw new Error('registry unavailable');
+      },
+      getReleaseNotes: () => {
+        throw new Error('registry unavailable');
+      },
+    };
+    const toml = '[dependencies]\nsoroban-sdk = "21.7.6"\n';
+    const result = await checkDependencies(toml, failingRegistry);
+    expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0]?.isOutdated).toBe(false);
+    expect(result.dependencies[0]?.latestVersion).toBe('21.7.6');
+  });
+
+  it('updateDependencies raises an actionable error when the registry provider throws', async () => {
+    const failingRegistry = {
+      getLatestVersion: () => {
+        throw new Error('registry unavailable');
+      },
+      getReleaseNotes: () => undefined,
+    };
+    const toml = '[dependencies]\nsoroban-sdk = "21.7.6"\n';
+    const error = await updateDependencies(toml, ['soroban-sdk'], failingRegistry).catch((e) => e);
+    expect(error).toBeInstanceOf(DependencyServiceError);
+    expect((error as DependencyServiceError).code).toBe('DEPENDENCY_REGISTRY_UNAVAILABLE');
+    expect((error as Error).message).toContain('soroban-sdk');
   });
 });
 


### PR DESCRIPTION
## Overview

This PR replaces the static, inline Cargo dependency registry in the backend dependency-update service with a maintainable, documented, and typed registry provider layer — fully separated from live update execution. It hardens semantic-version comparison against prerelease and malformed input, adds a curated-snapshot refresh workflow backed by crates.io, and guarantees that an external registry failure can never break the rest of the application.

## Related Issue

Closes [#881](https://github.com/StellarDevHub/Web3-Student-Lab/issues/881)

## Changes

### 📦 Registry as a documented provider layer

- **\[ADD\]** `backend/src/config/dependency-registry.ts`
  - Single source of truth for the latest known Soroban/Stellar crate versions (`CrateRegistryEntry`, `REGISTRY_METADATA` with owner / source / refresh strategy).
  - Fail-safe accessors and a typed `DependencyRegistryProvider` contract; the service only consumes the provider interface, never raw data.
- **\[MODIFY\]** `backend/src/services/dependency-update.service.ts`
  - Removed the inline static `REGISTRY` / `RELEASE_NOTES` constants in favor of the config-layer provider (injectable for tests, default = curated snapshot).
  - Registry provider calls are guarded — a throwing provider degrades to "not outdated" instead of breaking dependency checks.

### 🔄 Maintainable update source

- **\[ADD\]** `backend/scripts/refresh-dependency-registry.ts` + `refresh:dependency-registry` npm script
  - Queries crates.io for every curated crate (timeout + User-Agent), prints current → newest, exits non-zero on partial failures so a failed refresh never silently poisons the snapshot.
- **\[ADD\]** Documented refresh strategy: curated snapshot reviewed and committed by maintainers; the application itself never depends on crates.io at runtime.

### 🛡️ Semantic version edge cases

- **\[MODIFY\]** `compareVersions` rewritten with strict semver parsing
  - Handles prerelease suffixes (`1.2.3-beta.1`), build metadata (`1.2.3+build.5`), optional `v` prefixes, short forms (`1.2`), and extra segments.
  - Malformed input returns `none` and never throws, so a bad registry entry cannot break dependency checks.

### ❗ Actionable service errors

- **\[ADD\]** `DependencyServiceError` (stable code `DEPENDENCY_REGISTRY_UNAVAILABLE`) raised when an update cannot resolve versions from the registry.
- **\[MODIFY\]** `dependencies.routes.ts` maps it to `503` with the failing crate names and a retry hint, instead of a generic `500`.

### ✅ Tests

- **\[ADD\]** `compareVersions` coverage: major/minor/patch, current-newer-than-registry, prerelease ordering, build metadata, v-prefixes, short forms, malformed input.
- **\[ADD\]** Registry provider resilience: `checkDependencies` survives a throwing provider; `updateDependencies` raises the actionable error.
- Existing coverage retained: simple dependencies, inline tables, unknown packages, update flows.

## Verification Results

```
npx tsc --noEmit  → no errors in dependency-update / dependency-registry files (no @ts-nocheck)
npx jest tests/dependency-update.service.test.ts --runInBand --forceExit
✅ 19/19 passed

npm run refresh:dependency-registry (live crates.io)
✅ 12/12 crates resolved (9 with updates detected, snapshot intentionally left for maintainer review)

Route smoke test (tsx, live HTTP)
✅ POST /dependencies/check → 200 with outdated detection
✅ POST /dependencies/update → 200 with suggested Cargo.toml
✅ unknown crate → reported in failed[]
```

| Acceptance Criteria | Status |
|---|---|
| Dependency-update service builds without `ts-nocheck` | ✅ No `@ts-nocheck`; zero tsc errors in service/registry files |
| Version comparison handles common prerelease and malformed input safely | ✅ Strict semver parser, malformed → `none`, never throws |
| Registry data has a documented ownership and update strategy | ✅ `REGISTRY_METADATA` + curated snapshot + crates.io refresh script |
| Unit tests cover simple dependencies, inline tables, unknown packages, and version edge cases | ✅ 19/19 passed |
| Service failures return actionable errors | ✅ `DependencyServiceError` → `503` with code and failing crate names |

## Note

`tests/dependency-update.routes.test.ts` cannot load because of a pre-existing syntax error in `src/routes/courses.ts:106` on `main` (unrelated to this PR).
