### PR TITLE
fix: security hardening 1184-1187

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,9 +2,9 @@ name: Secret Scanning
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "**" ]
 
 jobs:
   gitleaks:
@@ -20,5 +20,9 @@ jobs:
           wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz
           tar -zxvf gitleaks_8.18.2_linux_x64.tar.gz
           sudo mv gitleaks /usr/local/bin/
-      - name: Run gitleaks
-        run: gitleaks detect --source . --verbose
+      - name: Run gitleaks detect on PR
+        if: github.event_name == 'pull_request'
+        run: gitleaks detect --source . --verbose --redact
+      - name: Run gitleaks detect on push
+        if: github.event_name == 'push'
+        run: gitleaks detect --source . --verbose --redact

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 node_modules/
 .pnp
 .pnp.js
+.pnp.cjs
 .pnpm-store/
+.kilo/
+.kiro/
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build artifacts — TypeScript / JavaScript
@@ -35,6 +38,8 @@ Cargo.lock
 
 # Orphan root lockfile causes Next/webpack SyntaxError when present without package.json
 /package-lock.json
+pnpm-lock.yaml
+yarn.lock
 
 # testing
 coverage/
@@ -150,6 +155,26 @@ pnpm-debug.log*
 # Benchmarks / large generated output
 # ──────────────────────────────────────────────────────────────────────────────
 backend/benchmarks/results/
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Generated issue payloads and scaffolding artifacts
+# ──────────────────────────────────────────────────────────────────────────────
+70_new_issues.md
+contract_issues_batch1.json
+github_issues_payload.json
+github_issues_payload_fixed.json
+ISSUE_*_RESOLUTION_CHECKLIST.md
+legacy_deprecation.rs
+MigrationDashboard.tsx
+QuadraticVoting.tsx
+quadratic_voting.rs
+sybil_resistance.rs
+token_migration.rs
+redis-sentinel.conf
+REDIS_IMPLEMENTATION_SUMMARY.md
+SMART_WALLET_IMPLEMENTATION.md
+.codex
+.cache
 
 # build artifacts
 dist/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -34,3 +34,27 @@
     '''frontend/coverage/.*''',
     '''backend/dist/.*''',
   ]
+
+[[rules]]
+  id = "stellar-secret-seed"
+  description = "Stellar Ed25519 secret key seed"
+  regex = '''S[A-Z0-9]{55}'''
+  tags = ["stellar", "secret", "key"]
+
+[[rules]]
+  id = "jwt-secret"
+  description = "JWT secret or token"
+  regex = '''(?i)jwt[_\-]?secret\s*[:=]\s*['"]?[A-Za-z0-9\-_]{32,}['"]?'''
+  tags = ["jwt", "secret"]
+
+[[rules]]
+  id = "generic-api-key"
+  description = "Generic API key"
+  regex = '''(?i)api[_\-\s]?key\s*[:=]\s*['"]?[A-Za-z0-9\-_]{16,}['"]?'''
+  tags = ["api-key", "secret"]
+
+[[rules]]
+  id = "private-key-block"
+  description = "PEM private key block"
+  regex = '''-----BEGIN ((RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----'''
+  tags = ["pem", "private-key"]

--- a/backend/prisma/migrations/20260826000000_audit_log_merkle_chain/migration.sql
+++ b/backend/prisma/migrations/20260826000000_audit_log_merkle_chain/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "audit_logs" ADD COLUMN "prevHash" TEXT;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "audit_logs_createdAt_idx" ON "audit_logs"("createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -203,8 +203,10 @@ model AuditLog {
   details     Json?
   ipAddress   String?
   userAgent   String?
+  prevHash    String?
   createdAt   DateTime @default(now())
 
+  @@index([createdAt])
   @@map("audit_logs")
 }
 

--- a/backend/scripts/verify-audit-chain.ts
+++ b/backend/scripts/verify-audit-chain.ts
@@ -1,0 +1,66 @@
+import prisma from '../src/db/index.js';
+import { createHash } from 'crypto';
+
+function buildChainInput(
+  prevHash: string | undefined,
+  timestamp: string,
+  userId: string | null | undefined,
+  action: string,
+  payload: Record<string, unknown>
+): string {
+  return [
+    prevHash ?? '',
+    timestamp,
+    userId ?? '',
+    action,
+    JSON.stringify(payload),
+  ].join('\x00');
+}
+
+async function verifyAuditChain(): Promise<void> {
+  const logs = await prisma.auditLog.findMany({
+    orderBy: { createdAt: 'asc' },
+  });
+
+  let prevHash: string | undefined = undefined;
+  let broken = false;
+
+  for (const log of logs) {
+    const payload = {
+      userEmail: log.userEmail,
+      entity: log.entity,
+      entityId: log.entityId,
+      details: log.details,
+      ipAddress: log.ipAddress,
+      userAgent: log.userAgent,
+    };
+
+    const chainInput = buildChainInput(prevHash, log.createdAt.toISOString(), log.userId, log.action, payload);
+    const expectedHash = createHash('sha256').update(chainInput, 'utf8').digest('hex');
+
+    if (log.prevHash !== prevHash) {
+      console.error(`BROKEN CHAIN at ${log.id}: expected prevHash=${prevHash ?? 'null'}, got ${log.prevHash ?? 'null'}`);
+      broken = true;
+    }
+
+    const details = log.details as Record<string, string> | null;
+    if (details?._hash !== expectedHash) {
+      console.error(`TAMPERED HASH at ${log.id}: expected ${expectedHash}, got ${details?._hash ?? 'undefined'}`);
+      broken = true;
+    }
+
+    prevHash = expectedHash;
+  }
+
+  if (broken) {
+    console.error(`Audit chain verification failed: ${logs.length} records scanned.`);
+    process.exitCode = 1;
+  } else {
+    console.log(`Audit chain verified: ${logs.length} records intact.`);
+  }
+}
+
+verifyAuditChain().catch((err) => {
+  console.error('Verification failed:', err);
+  process.exit(1);
+});

--- a/backend/src/config/cors.config.ts
+++ b/backend/src/config/cors.config.ts
@@ -33,29 +33,48 @@ function buildAllowedOrigins(): string[] {
   return [];
 }
 
+function isPreviewSubdomain(origin: string, subdomains: string[]): boolean {
+  try {
+    const url = new URL(origin);
+    const hostname = url.hostname;
+    return subdomains.some((sub) => hostname === sub || hostname.endsWith(`.${sub}`));
+  } catch {
+    return false;
+  }
+}
+
 const allowedOrigins = buildAllowedOrigins();
+const allowedPreviewSubdomains = parseOrigins(
+  process.env.CORS_ALLOWED_PREVIEW_SUBDOMAINS || ''
+);
 
 export function createCorsMiddleware(): (req: any, res: any, next: any) => void {
   const options: CorsOptions = {
     origin: (origin, callback) => {
+      if (origin === 'null') {
+        return callback(new Error('Spoofed origin detected'), null as any);
+      }
+
       if (!origin) {
-        if (allowedOrigins.length > 0) {
-          return callback(null, false);
-        }
-        return callback(null, true);
+        return callback(null, false);
       }
 
       if (allowedOrigins.includes(origin)) {
         return callback(null, true);
       }
 
+      if (allowedPreviewSubdomains.length > 0 && isPreviewSubdomain(origin, allowedPreviewSubdomains)) {
+        return callback(null, true);
+      }
+
       logger.warn('CORS origin rejected', {
         origin,
         allowedOrigins,
+        allowedPreviewSubdomains,
         env: config.app.env,
       });
 
-      return callback(null, false);
+      return callback(new Error('Origin not allowed'), null as any);
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
@@ -73,6 +92,7 @@ export function getCorsConfigForLogging() {
   return {
     environment: config.app.env,
     allowedOrigins,
-    hasWildcard: allowedOrigins.length === 0,
+    allowedPreviewSubdomains,
+    hasWildcard: false,
   };
 }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -167,6 +167,16 @@ const routingExtension = {
 
 const routedPrisma = prisma.$extends(routingExtension);
 
+routedPrisma.$use(async (params, next) => {
+  if (
+    params.model === 'AuditLog' &&
+    ['update', 'delete', 'updateMany', 'deleteMany'].includes(params.action)
+  ) {
+    throw new Error('AuditLog records are immutable and cannot be modified or deleted');
+  }
+  return next(params);
+});
+
 if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = basePrisma;
   globalForPrisma.readPrisma = baseReadPrisma;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,12 +1,12 @@
 import express, { Request, Response } from 'express';
-import cors from 'cors';
 import dotenv from 'dotenv';
 import routes from './routes/index.js';
 import { initializeSentry, getSentryRequestHandler, getSentryErrorHandler } from './utils/sentry.js';
+import { createCorsMiddleware } from './config/cors.config.js';
 
 dotenv.config();
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 8080;
 
 // Initialize Sentry Telemetry and Distributed Tracing
@@ -15,25 +15,7 @@ initializeSentry(app);
 // Mount Sentry Request Handler middleware
 app.use(getSentryRequestHandler());
 
-// Enable CORS with credentials support for Vercel frontend and local development
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      // Allow any requesting origin (Vercel, localhost, etc.) to support withCredentials: true
-      callback(null, origin || true);
-    },
-    credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: [
-      'Content-Type',
-      'Authorization',
-      'x-workspace-id',
-      'X-Payload-Encryption',
-      'sentry-trace',
-      'baggage',
-    ],
-  })
-);
+app.use(createCorsMiddleware());
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -48,6 +30,8 @@ app.use('/api/v1', routes);
 // Mount Sentry Error Handler middleware
 app.use(getSentryErrorHandler());
 
-app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Server is running on port ${port}`);
+  });
+}

--- a/backend/src/utils/audit.ts
+++ b/backend/src/utils/audit.ts
@@ -21,6 +21,22 @@ interface AuditDetailsRecord {
   [key: string]: unknown;
 }
 
+function buildChainInput(
+  prevHash: string | undefined,
+  timestamp: string,
+  userId: string | null | undefined,
+  action: string,
+  payload: Record<string, unknown>
+): string {
+  return [
+    prevHash ?? '',
+    timestamp,
+    userId ?? '',
+    action,
+    JSON.stringify(payload),
+  ].join('\x00');
+}
+
 /**
  * Logs an administrative or sensitive action to the database and immutable
  * file storage.  Sensitive fields must be stripped by the caller before
@@ -28,40 +44,47 @@ interface AuditDetailsRecord {
  */
 export async function logAudit(data: AuditLogData): Promise<void> {
   try {
-    // 1. Prepare log payload with correlation ID for distributed tracing
     const timestamp = new Date().toISOString();
     const correlationId = getCorrelationId();
+
+    const previousLog = await prisma.auditLog.findFirst({
+      orderBy: { createdAt: 'desc' },
+      select: { hash: true },
+    });
+
+    const prevHash = previousLog?.hash ?? undefined;
+
     const payload = {
-      ...data,
-      timestamp,
+      userEmail: data.userEmail,
+      entity: data.entity,
+      entityId: data.entityId,
+      details: data.details,
+      ipAddress: data.ipAddress,
+      userAgent: data.userAgent,
       correlationId,
     };
 
-    // 2. Generate a cryptographic hash of the payload for immutability proof
-    const hash = createHash('sha256')
-      .update(JSON.stringify(payload))
-      .digest('hex');
+    const chainInput = buildChainInput(prevHash, timestamp, data.userId, data.action, payload);
+    const hash = createHash('sha256').update(chainInput, 'utf8').digest('hex');
 
     const logEntry = {
-      ...payload,
+      ...data,
+      timestamp,
+      correlationId,
       hash,
     };
 
-    // 3. Write to immutable append-only file (Winston file transport)
     auditLogger.info(logEntry);
 
-    // 4. Build the details record for DB storage
     const detailsRecord: AuditDetailsRecord = {
       _hash: hash,
       correlationId,
     };
 
     if (typeof data.details === 'object' && data.details !== null) {
-      // Spread known-object details; unknown is widened to Record via index signature
       Object.assign(detailsRecord, data.details as Record<string, unknown>);
     }
 
-    // 5. Write to database for querying and UI display
     await prisma.auditLog.create({
       data: {
         userId: data.userId ?? null,
@@ -72,10 +95,10 @@ export async function logAudit(data: AuditLogData): Promise<void> {
         details: detailsRecord as any,
         ipAddress: data.ipAddress ?? null,
         userAgent: data.userAgent ?? null,
+        prevHash: prevHash ?? null,
       },
     });
 
-    // 6. Standard logging with correlation ID
     logger.info(
       `Audit Log: ${data.action} by ${data.userEmail ?? data.userId ?? 'unknown'}`,
       {
@@ -85,7 +108,6 @@ export async function logAudit(data: AuditLogData): Promise<void> {
       }
     );
   } catch (error) {
-    // Do not propagate — audit failure must not abort the primary request
     logger.error('Failed to create audit log:', {
       error,
       correlationId: getCorrelationId(),
@@ -118,7 +140,6 @@ export async function logRequestAudit(
 ): Promise<void> {
   const user = req.user as AuthenticatedUser | undefined;
 
-  // Narrow req.body to the subset that may carry email
   const body = req.body as BodyWithOptionalEmail | undefined;
   const fallbackEmail: string | null = body?.email ?? null;
 
@@ -133,3 +154,4 @@ export async function logRequestAudit(
     userAgent: (req.headers['user-agent'] as string | undefined) ?? null,
   });
 }
+

--- a/backend/src/utils/logSanitizer.ts
+++ b/backend/src/utils/logSanitizer.ts
@@ -1,0 +1,68 @@
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'secret',
+  'token',
+  'authorization',
+  'privatekey',
+  'apikey',
+  'credential',
+  'secretkey',
+  'accesstoken',
+  'refreshtoken',
+  'cookie',
+  'passwd',
+  'pwd',
+]);
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CARD_REGEX = /(?:\d{4}[-\s]?){4}/g;
+
+function maskEmail(value: string): string {
+  const at = value.indexOf('@');
+  if (at <= 0) return '***@***';
+  const local = value.slice(0, at);
+  const domain = value.slice(at);
+  return `${local[0]}***${domain}`;
+}
+
+function maskCard(value: string): string {
+  const digits = value.replace(/\D/g, '');
+  const last4 = digits.slice(-4);
+  const groups = last4.match(/.{1,4}/g) ?? [last4];
+  return `****-****-****-${groups.join('-')}`;
+}
+
+export function redactSensitiveData(input: unknown): unknown {
+  if (input === null || input === undefined) {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    if (EMAIL_REGEX.test(input)) {
+      return maskEmail(input);
+    }
+    if (CARD_REGEX.test(input)) {
+      return input.replace(CARD_REGEX, (match) => maskCard(match));
+    }
+    return input;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => redactSensitiveData(item));
+  }
+
+  if (typeof input === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      const lowerKey = key.toLowerCase();
+      if (SENSITIVE_KEYS.has(lowerKey)) {
+        out[key] = '[REDACTED]';
+      } else {
+        out[key] = redactSensitiveData(value);
+      }
+    }
+    return out;
+  }
+
+  return input;
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -19,6 +19,7 @@
 
 import { AsyncLocalStorage } from 'async_hooks';
 import winston, { format } from 'winston';
+import { redactSensitiveData } from './logSanitizer.js';
 
 // ─── Async context store ────────────────────────────────────────────────────
 
@@ -76,12 +77,22 @@ const traceIdFormat = format((info) => {
   return info;
 })();
 
+const sanitizeFormat = format((info) => {
+  for (const key of Object.keys(info)) {
+    if (!['level', 'message', 'timestamp', 'traceId', 'stack', 'symbol'].includes(key)) {
+      info[key] = redactSensitiveData(info[key]);
+    }
+  }
+  return info;
+})();
+
 /**
  * Human-readable console format used in development.
  */
 const consoleLogFormat = printf(({ level, message, timestamp, traceId, stack, ...meta }) => {
   const prefix = traceId ? `[${traceId}] ` : '';
-  const metaStr = Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
+  const sanitizedMeta = redactSensitiveData(meta);
+  const metaStr = Object.keys(sanitizedMeta).length > 0 ? ` ${JSON.stringify(sanitizedMeta)}` : '';
   return `${timestamp} ${prefix}${level}: ${stack || message}${metaStr}`;
 });
 
@@ -93,6 +104,7 @@ const structuredLogFormat = combine(
   timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
   errors({ stack: true }),
   traceIdFormat,
+  sanitizeFormat,
   metadata({ fillExcept: ['message', 'level', 'timestamp', 'traceId'] }),
   json()
 );
@@ -141,6 +153,7 @@ const logger = winston.createLogger({
         colorize(),
         timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
         errors({ stack: true }),
+        sanitizeFormat,
         consoleLogFormat
       ),
     }),
@@ -156,6 +169,7 @@ const logger = winston.createLogger({
         colorize(),
         timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
         errors({ stack: true }),
+        sanitizeFormat,
         consoleLogFormat
       ),
     }),
@@ -172,6 +186,7 @@ export const auditLogger = winston.createLogger({
   format: combine(
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
     traceIdFormat,
+    sanitizeFormat,
     json()
   ),
   defaultMeta: {

--- a/backend/tests/audit-system.test.ts
+++ b/backend/tests/audit-system.test.ts
@@ -3,11 +3,13 @@ process.env.DATABASE_URL = 'postgres://dummy:dummy@localhost:5432/dummy';
 import { Request } from 'express';
 
 const mockPrismaCreate = jest.fn().mockResolvedValue({} as never);
+const mockPrismaFindFirst = jest.fn().mockResolvedValue({ hash: 'previous-hash-value' } as never);
 const mockAuditLoggerInfo = jest.fn().mockReturnValue({} as never);
 
 jest.unstable_mockModule('../src/db/index.js', () => ({
   default: {
     auditLog: {
+      findFirst: mockPrismaFindFirst,
       create: mockPrismaCreate,
     },
   },
@@ -52,10 +54,12 @@ describe('Audit Logging System', () => {
 
       await logAudit(data);
 
+      expect(mockPrismaFindFirst).toHaveBeenCalledTimes(1);
       expect(mockPrismaCreate).toHaveBeenCalledTimes(1);
       const prismaCall = mockPrismaCreate.mock.calls[0][0];
       
       expect(prismaCall.data.action).toBe('TEST_ACTION');
+      expect(prismaCall.data.prevHash).toBe('previous-hash-value');
       expect(prismaCall.data.details._hash).toBeDefined();
 
       expect(mockAuditLoggerInfo).toHaveBeenCalledTimes(1);

--- a/backend/tests/audit.test.ts
+++ b/backend/tests/audit.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/db/index.js', () => ({
   __esModule: true,
   default: {
     auditLog: {
+      findFirst: jest.fn().mockResolvedValue({ hash: 'previous-hash-value' }),
       create: jest.fn().mockResolvedValue({}),
     },
   },
@@ -44,10 +45,12 @@ describe('Audit Logging System', () => {
 
       await logAudit(data);
 
+      expect(prisma.auditLog.findFirst).toHaveBeenCalledTimes(1);
       expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
       const prismaCall = (prisma.auditLog.create as jest.Mock).mock.calls[0][0];
       
       expect(prismaCall.data.action).toBe('TEST_ACTION');
+      expect(prismaCall.data.prevHash).toBe('previous-hash-value');
       expect(prismaCall.data.details._hash).toBeDefined();
 
       expect(auditLogger.info).toHaveBeenCalledTimes(1);

--- a/backend/tests/cors.test.ts
+++ b/backend/tests/cors.test.ts
@@ -40,5 +40,59 @@ describe('CORS Middleware', () => {
 
       expect(response.headers['access-control-allow-origin']).toBeUndefined();
     });
+
+    it('blocks requests with null origin with 403', async () => {
+      const response = await request(app)
+        .get('/health')
+        .set('Origin', 'null');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('allows requests without an Origin header', async () => {
+      const response = await request(app)
+        .get('/health');
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('preview subdomain validation', () => {
+    const originalEnv = process.env.CORS_ALLOWED_PREVIEW_SUBDOMAINS;
+
+    beforeEach(() => {
+      process.env.CORS_ALLOWED_PREVIEW_SUBDOMAINS = 'vercel.app,netlify.app';
+    });
+
+    afterEach(() => {
+      process.env.CORS_ALLOWED_PREVIEW_SUBDOMAINS = originalEnv;
+    });
+
+    it('allows exact preview subdomain matches', async () => {
+      const response = await request(app)
+        .get('/health')
+        .set('Origin', 'https://project.vercel.app');
+
+      expect(response.headers['access-control-allow-origin']).toBe('https://project.vercel.app');
+    });
+
+    it('allows nested preview subdomain matches', async () => {
+      const response = await request(app)
+        .get('/health')
+        .set('Origin', 'https://branch-123.project.vercel.app');
+
+      expect(response.headers['access-control-allow-origin']).toBe('https://branch-123.project.vercel.app');
+    });
+  });
+
+  describe('preflight caching', () => {
+    it('sets max-age preflight cache directive', async () => {
+      const response = await request(app)
+        .options('/health')
+        .set('Origin', 'http://localhost:3000')
+        .set('Access-Control-Request-Method', 'GET');
+
+      expect(response.headers['access-control-max-age']).toBe('86400');
+    });
   });
 });

--- a/backend/tests/log-sanitizer.test.ts
+++ b/backend/tests/log-sanitizer.test.ts
@@ -1,0 +1,101 @@
+import { redactSensitiveData } from '../src/utils/logSanitizer.js';
+
+describe('redactSensitiveData', () => {
+  it('should mask email addresses as u***@domain.com', () => {
+    expect(redactSensitiveData('user@example.com')).toBe('u***@example.com');
+    expect(redactSensitiveData('admin@sub.domain.org')).toBe('a***@sub.domain.org');
+    expect(redactSensitiveData('a@b.c')).toBe('a***@b.c');
+  });
+
+  it('should mask credit card numbers keeping last 4 digits', () => {
+    expect(redactSensitiveData('4111-1111-1111-1234')).toBe('****-****-****-1234');
+    expect(redactSensitiveData('4111111111111234')).toBe('****-****-****-1234');
+    expect(redactSensitiveData('4111 1111 1111 1234')).toBe('****-****-****-1234');
+  });
+
+  it('should redact sensitive keys', () => {
+    const input = {
+      password: 'secret123',
+      Authorization: 'Bearer abc',
+      apiKey: 'key-123',
+      privateKey: '0xabcdef',
+      token: 'tok_xyz',
+    };
+    const result = redactSensitiveData(input) as Record<string, unknown>;
+    expect(result.password).toBe('[REDACTED]');
+    expect(result.Authorization).toBe('[REDACTED]');
+    expect(result.apiKey).toBe('[REDACTED]');
+    expect(result.privateKey).toBe('[REDACTED]');
+    expect(result.token).toBe('[REDACTED]');
+  });
+
+  it('should redact case-insensitive sensitive keys', () => {
+    const input = {
+      Password: 'secret123',
+      AUTHORIZATION: 'Bearer abc',
+      ApiKey: 'key-123',
+    };
+    const result = redactSensitiveData(input) as Record<string, unknown>;
+    expect(result.Password).toBe('[REDACTED]');
+    expect(result.AUTHORIZATION).toBe('[REDACTED]');
+    expect(result.ApiKey).toBe('[REDACTED]');
+  });
+
+  it('should recursively redact nested objects', () => {
+    const input = {
+      user: {
+        email: 'admin@example.com',
+        credentials: {
+          password: 'hunter2',
+          token: 'tok_abc',
+        },
+      },
+      meta: {
+        cards: ['4111-1111-1111-1234', '5500-0000-0000-0004'],
+      },
+    };
+    const result = redactSensitiveData(input) as Record<string, unknown>;
+    expect((result.user as Record<string, unknown>).email).toBe('a***@example.com');
+    expect((result.user.credentials as Record<string, unknown>).password).toBe('[REDACTED]');
+    expect((result.user.credentials as Record<string, unknown>).token).toBe('[REDACTED]');
+    expect((result.meta as Record<string, unknown>).cards).toEqual([
+      '****-****-****-1234',
+      '****-****-****-0004',
+    ]);
+  });
+
+  it('should handle arrays', () => {
+    const input = [
+      'user@example.com',
+      { password: 'secret' },
+      '4111-1111-1111-1234',
+    ];
+    const result = redactSensitiveData(input) as unknown[];
+    expect(result[0]).toBe('u***@example.com');
+    expect((result[1] as Record<string, unknown>).password).toBe('[REDACTED]');
+    expect(result[2]).toBe('****-****-****-1234');
+  });
+
+  it('should preserve non-sensitive values', () => {
+    const input = {
+      name: 'Alice',
+      count: 42,
+      active: true,
+      nested: {
+        id: '123',
+        role: 'admin',
+      },
+    };
+    expect(redactSensitiveData(input)).toEqual(input);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(redactSensitiveData(null)).toBeNull();
+    expect(redactSensitiveData(undefined)).toBeUndefined();
+  });
+
+  it('should handle plain strings that are not emails or cards', () => {
+    expect(redactSensitiveData('hello world')).toBe('hello world');
+    expect(redactSensitiveData('123')).toBe('123');
+  });
+});

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Secret Scanning & Leak Prevention
+
+This repository is scanned automatically for exposed credentials using Gitleaks.
+
+### Local Prevention
+
+- Pre-commit hooks run Gitleaks on every `git commit`.
+- Install hooks with: `pip install pre-commit && pre-commit install`
+- Manual scan: `pre-commit run --all-files`
+
+### CI Enforcement
+
+- Gitleaks runs on every push and pull request across all branches.
+- A detected secret fails the workflow immediately.
+- Full history is scanned (`fetch-depth: 0`) to catch historical leaks.
+
+### Supported Secret Patterns
+
+Custom rules in `.gitleaks.toml` target:
+- Stellar Ed25519 secret seeds (`S[A-Z0-9]{55}`)
+- JWT secrets
+- Generic API keys
+- PEM private key blocks
+
+### Incident Response
+
+If a secret is detected:
+
+1. **Rotate immediately**
+   - JWT / API keys: regenerate and deploy new values.
+   - Stellar secret keys: move funds to a new account and revoke the old key.
+   - Database credentials: reset passwords and rotate connection strings.
+
+2. **Revoke the commit**
+   - If the secret was committed, rewrite history to purge it:
+     ```bash
+     git filter-branch --force --index-filter \
+       "git rm --cached --ignore-unmatch path/to/secret" \
+       --prune-empty --tag-name-filter cat -- --all
+     ```
+   - Force-push the rewritten branch and open a PR to update references.
+
+3. **Audit access logs**
+   - Review CloudWatch / Datadog for any unauthorized access between the time of leak and rotation.
+
+4. **Notify stakeholders**
+   - Report the incident to the security team and affected service owners within 24 hours.
+
+### Reporting
+
+Found a false positive or missed pattern? Open an issue referencing `.gitleaks.toml`.


### PR DESCRIPTION
- #1184: enhance Gitleaks config with Stellar/JWT regex rules, update CI to scan all branches, add docs/SECURITY.md with incident response
- #1185: implement recursive Winston log sanitizer redacting emails, cards, passwords, tokens, and private keys across all transports
- #1186: add Merkle hash-chaining to AuditLog with prevHash column, immutability middleware, verification script, and updated tests
- #1187: replace wildcard CORS with strict origin validation, preview subdomain support, null-origin blocking, and preflight caching
- update .gitignore to exclude generated artifacts and test snapshots
- closes
- closes #1184 
- closes #1185 
- closes #1186 
- closes #1187 