### PR TITLE
feat(simulators): Merkle proofs, XDR inspector, storage model, reorg & finality (#1159, #1161, #1162, #1163)

### DIFF
--- a/frontend/src/app/consensus-simulator/page.tsx
+++ b/frontend/src/app/consensus-simulator/page.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+/**
+ * Reorg and finality simulator (Issue #1163).
+ *
+ * Distinct from `/chain-reorg`, which animates two racing chains with random
+ * hashes and declares a winner. This one models branches concretely, so a
+ * reorg names the transactions it reverted, and contrasts that with SCP, where
+ * the same attack cannot be attempted at all.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  BLOCK_TIME_SECONDS,
+  branchWork,
+  branches,
+  canonicalChain,
+  confirmationDepth,
+  confirmationsForRisk,
+  createChain,
+  forkChain,
+  mineBlock,
+  reversalProbability,
+  simulateDoubleSpend,
+  stateAtTick,
+  type ChainState,
+  type ConsensusModel,
+} from '@/lib/consensus-simulator';
+
+const HONEST_TX = 'tx-payment';
+
+export default function ConsensusSimulatorPage() {
+  const [model, setModel] = useState<ConsensusModel>('pow');
+  const [chain, setChain] = useState<ChainState>(() => createChain('pow'));
+  const [scrubTick, setScrubTick] = useState<number | null>(null);
+  const [hashPower, setHashPower] = useState(0.3);
+  const [confirmations, setConfirmations] = useState(6);
+
+  // Scrubbing replays history rather than showing a snapshot, so the scrubbed
+  // view and the live view come from the same fork-choice code.
+  const view = useMemo(
+    () => (scrubTick === null ? chain : stateAtTick(chain, scrubTick)),
+    [chain, scrubTick]
+  );
+
+  const canonical = canonicalChain(view);
+  const allBranches = branches(view);
+  const depth = confirmationDepth(view, HONEST_TX);
+
+  const attack = useMemo(
+    () => simulateDoubleSpend(model, { hashPower, merchantConfirmations: confirmations, amount: 100 }),
+    [model, hashPower, confirmations]
+  );
+
+  function reset(next: ConsensusModel) {
+    setModel(next);
+    setChain(createChain(next));
+    setScrubTick(null);
+  }
+
+  function act(fn: (s: ChainState) => ChainState) {
+    setChain((prev) => fn(prev));
+    setScrubTick(null); // return to live after acting
+  }
+
+  const safeConfirmations = confirmationsForRisk(hashPower);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white">Reorg &amp; Finality Simulator</h1>
+        <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+          &ldquo;Confirmed&rdquo; and &ldquo;final&rdquo; are not the same thing. Under
+          proof-of-work a block is only ever <em>probably</em> permanent; under SCP a closed ledger
+          cannot be rewritten at all. Build both and see what an attacker can actually do to each.
+        </p>
+      </header>
+
+      {/* ── Model switch ────────────────────────────────────────────────── */}
+      <section className="mb-8 flex flex-wrap gap-3">
+        {(['pow', 'scp'] as ConsensusModel[]).map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => reset(m)}
+            className={`rounded-xl border px-4 py-3 text-left transition-colors ${
+              model === m
+                ? 'border-emerald-400/60 bg-emerald-500/10'
+                : 'border-white/10 bg-white/5 hover:bg-white/10'
+            }`}
+          >
+            <div className="text-sm font-semibold text-white">
+              {m === 'pow' ? 'Proof of Work (Nakamoto)' : 'Stellar Consensus Protocol'}
+            </div>
+            <div className="mt-1 text-xs text-zinc-400">
+              {m === 'pow'
+                ? `~${BLOCK_TIME_SECONDS.pow / 60} min blocks · probabilistic finality`
+                : `~${BLOCK_TIME_SECONDS.scp}s ledgers · deterministic finality`}
+            </div>
+          </button>
+        ))}
+      </section>
+
+      {/* ── Chain controls ──────────────────────────────────────────────── */}
+      <section className="mb-8 rounded-xl border border-white/10 bg-white/5 p-5">
+        <div className="mb-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => act((s) => mineBlock(s))}
+            className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-zinc-950"
+          >
+            {model === 'pow' ? 'Mine block' : 'Close ledger'}
+          </button>
+          <button
+            type="button"
+            onClick={() => act((s) => mineBlock(s, { txIds: [HONEST_TX] }))}
+            className="rounded-lg border border-white/15 px-3 py-1.5 text-xs text-zinc-200"
+          >
+            Include payment
+          </button>
+          <button
+            type="button"
+            onClick={() => act((s) => forkChain(s, 'attacker', 0))}
+            className="rounded-lg border border-amber-400/40 px-3 py-1.5 text-xs text-amber-200"
+          >
+            Fork from genesis
+          </button>
+          <button
+            type="button"
+            onClick={() => act((s) => mineBlock(s, { branch: 'attacker', work: 3 }))}
+            className="rounded-lg border border-red-400/40 px-3 py-1.5 text-xs text-red-200"
+          >
+            Mine on attacker branch (3× work)
+          </button>
+          <button
+            type="button"
+            onClick={() => reset(model)}
+            className="rounded-lg border border-white/15 px-3 py-1.5 text-xs text-zinc-400"
+          >
+            Reset
+          </button>
+        </div>
+
+        {/* Branch views */}
+        <div className="space-y-4">
+          {(allBranches.length ? allBranches : ['main']).map((branch) => {
+            const isCanonical = branch === view.canonicalBranch;
+            const blocks = view.blocks
+              .filter((b) => b.branch === branch || b.id === 'genesis')
+              .sort((a, b) => a.height - b.height);
+
+            return (
+              <div key={branch}>
+                <div className="mb-1 flex items-center gap-2 text-xs">
+                  <span className={isCanonical ? 'text-emerald-300' : 'text-zinc-500'}>
+                    {branch}
+                  </span>
+                  {isCanonical && (
+                    <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] text-emerald-200">
+                      canonical
+                    </span>
+                  )}
+                  <span className="text-zinc-600">work {branchWork(view, branch)}</span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {blocks.map((block) => (
+                    <div
+                      key={block.id}
+                      className={`rounded-md border px-2 py-1 font-mono text-[11px] ${
+                        isCanonical
+                          ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                          : 'border-white/10 bg-white/5 text-zinc-500 line-through'
+                      }`}
+                      title={`${block.id} · ${block.hash}`}
+                    >
+                      #{block.height}
+                      {block.txIds.length > 0 && (
+                        <span className="ml-1 text-amber-300">◆{block.txIds.length}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-4 rounded-lg border border-white/10 bg-zinc-950/60 p-3 text-xs">
+          <span className="text-zinc-500">Payment status: </span>
+          {depth === null ? (
+            <span className="text-red-300">
+              not on the canonical chain — reverted or never included
+            </span>
+          ) : (
+            <span className="text-emerald-300">
+              {depth} confirmation{depth === 1 ? '' : 's'}
+              {model === 'scp' ? ' · final' : ` · ${(reversalProbability(hashPower, depth) * 100).toFixed(4)}% reversible at ${(hashPower * 100).toFixed(0)}% hash power`}
+            </span>
+          )}
+        </div>
+
+        {/* Timeline scrubber */}
+        {chain.tick > 0 && (
+          <div className="mt-4">
+            <label htmlFor="scrub" className="block text-xs text-zinc-500">
+              Timeline — inspect the chain as it stood at any point
+              {scrubTick !== null && (
+                <button
+                  type="button"
+                  onClick={() => setScrubTick(null)}
+                  className="ml-2 text-emerald-400 underline"
+                >
+                  back to live
+                </button>
+              )}
+            </label>
+            <input
+              id="scrub"
+              type="range"
+              min={0}
+              max={chain.tick}
+              value={scrubTick ?? chain.tick}
+              onChange={(e) => setScrubTick(Number(e.target.value))}
+              className="mt-1 w-full accent-emerald-400"
+            />
+          </div>
+        )}
+      </section>
+
+      {/* ── Event log ───────────────────────────────────────────────────── */}
+      {view.events.length > 0 && (
+        <section className="mb-8 rounded-xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-3 text-lg font-semibold text-white">Event log</h2>
+          <ul className="space-y-1.5 text-xs">
+            {[...view.events].reverse().map((event, i) => (
+              <li
+                key={`${event.tick}-${i}`}
+                className={
+                  event.kind === 'reorg'
+                    ? 'text-red-300'
+                    : event.kind === 'finalized'
+                      ? 'text-emerald-300'
+                      : event.kind === 'fork'
+                        ? 'text-amber-300'
+                        : 'text-zinc-500'
+                }
+              >
+                <span className="mr-2 font-mono text-zinc-600">t{event.tick}</span>
+                {event.message}
+                {event.revertedTxIds && event.revertedTxIds.length > 0 && (
+                  <span className="ml-1 font-mono text-red-200">
+                    [{event.revertedTxIds.join(', ')}]
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* ── Double-spend lab ────────────────────────────────────────────── */}
+      <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+        <h2 className="text-lg font-semibold text-white">Double-spend lab</h2>
+        <p className="mt-1 text-xs text-zinc-400">
+          The attacker pays a merchant, waits for the merchant to ship, then releases a privately
+          mined branch that spends the same funds elsewhere.
+        </p>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="power" className="block text-xs text-zinc-500">
+              Attacker hash power: {(hashPower * 100).toFixed(0)}%
+            </label>
+            <input
+              id="power"
+              type="range"
+              min={5}
+              max={70}
+              value={hashPower * 100}
+              onChange={(e) => setHashPower(Number(e.target.value) / 100)}
+              className="mt-1 w-full accent-red-400"
+            />
+          </div>
+          <div>
+            <label htmlFor="confs" className="block text-xs text-zinc-500">
+              Merchant waits: {confirmations} confirmation{confirmations === 1 ? '' : 's'}
+            </label>
+            <input
+              id="confs"
+              type="range"
+              min={1}
+              max={20}
+              value={confirmations}
+              onChange={(e) => setConfirmations(Number(e.target.value))}
+              className="mt-1 w-full accent-emerald-400"
+            />
+          </div>
+        </div>
+
+        <div
+          className={`mt-4 rounded-lg border p-4 ${
+            attack.succeeded
+              ? 'border-red-400/40 bg-red-500/10'
+              : 'border-emerald-400/40 bg-emerald-500/10'
+          }`}
+        >
+          <div className={`text-sm font-semibold ${attack.succeeded ? 'text-red-200' : 'text-emerald-200'}`}>
+            {attack.succeeded ? 'Double-spend succeeded' : 'Double-spend failed'}
+          </div>
+          <ol className="mt-2 space-y-1 text-xs text-zinc-300">
+            {attack.narrative.map((line, i) => (
+              <li key={i}>{i + 1}. {line}</li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="mt-4 grid gap-3 text-xs sm:grid-cols-2">
+          <div className="rounded-lg border border-white/10 bg-zinc-950/60 p-3">
+            <div className="text-zinc-500">Reversal probability at {confirmations} confirmations</div>
+            <div className="mt-1 font-mono text-lg text-white">
+              {model === 'scp' ? '0%' : `${(attack.reversalProbability * 100).toFixed(6)}%`}
+            </div>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-zinc-950/60 p-3">
+            <div className="text-zinc-500">Confirmations for &lt;0.1% risk</div>
+            <div className="mt-1 font-mono text-lg text-white">
+              {model === 'scp'
+                ? '1 (final immediately)'
+                : Number.isFinite(safeConfirmations)
+                  ? safeConfirmations
+                  : 'no safe number'}
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-3 text-xs text-zinc-500">
+          Push hash power to 50% or above and the safe confirmation count stops existing — that is
+          what a 51% attack means. Switch to SCP and the same slider does nothing to safety: an
+          attacker with that much influence can stall the network, but stalling is a liveness
+          failure, not a reversal.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/merkle-simulator/page.tsx
+++ b/frontend/src/app/merkle-simulator/page.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+/**
+ * Interactive Merkle tree visualiser (Issue #1159).
+ *
+ * Distinct from `/merkle-tree`, which is a fixed airdrop-verification demo
+ * built on the FNV-1a `stableHash`. This one takes student input, hashes with
+ * real SHA-256, and exists to make three things visible: the audit path, the
+ * step-by-step root reconstruction, and the tamper cascade.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  buildMerkleTree,
+  exportProofBundle,
+  getPathNodeIds,
+  getProof,
+  getSiblingNodeIds,
+  simulateTamper,
+  verifyProof,
+  type MerkleNode,
+  type MerkleProofStep,
+  type MerkleTree,
+  type TamperResult,
+  type VerificationResult,
+} from '@/lib/merkle-sha256';
+
+const DEFAULT_LEAVES = ['alice', 'bob', 'carol', 'dave', 'erin', 'frank'];
+
+/** First 10 hex chars — enough to compare visually, short enough to fit. */
+function short(hash: string): string {
+  return `${hash.slice(0, 10)}…`;
+}
+
+export default function MerkleSimulatorPage() {
+  const [rawInput, setRawInput] = useState(DEFAULT_LEAVES.join('\n'));
+  const [tree, setTree] = useState<MerkleTree | null>(null);
+  const [building, setBuilding] = useState(false);
+  const [selectedLeaf, setSelectedLeaf] = useState<number | null>(null);
+  const [verification, setVerification] = useState<VerificationResult | null>(null);
+  const [visibleSteps, setVisibleSteps] = useState(0);
+  const [tamper, setTamper] = useState<TamperResult | null>(null);
+  const [tamperValue, setTamperValue] = useState('');
+
+  const leafValues = useMemo(
+    () => rawInput.split('\n').map((l) => l.trim()).filter(Boolean),
+    [rawInput]
+  );
+
+  const rebuild = useCallback(async () => {
+    setBuilding(true);
+    // Clear derived state: a proof or cascade computed against the previous
+    // tree is meaningless once the leaves change, and showing it would be
+    // actively misleading.
+    setSelectedLeaf(null);
+    setVerification(null);
+    setVisibleSteps(0);
+    setTamper(null);
+    setTree(await buildMerkleTree(leafValues));
+    setBuilding(false);
+  }, [leafValues]);
+
+  useEffect(() => {
+    void rebuild();
+    // Build once on mount; afterwards the student drives it with the button,
+    // so a keystroke does not re-hash the whole tree.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const proof: MerkleProofStep[] = useMemo(
+    () => (tree && selectedLeaf !== null ? getProof(tree, selectedLeaf) : []),
+    [tree, selectedLeaf]
+  );
+
+  const pathIds = useMemo(
+    () => (tree && selectedLeaf !== null ? new Set(getPathNodeIds(tree, selectedLeaf)) : new Set<string>()),
+    [tree, selectedLeaf]
+  );
+
+  const siblingIds = useMemo(
+    () => (tree ? new Set(getSiblingNodeIds(tree, proof)) : new Set<string>()),
+    [tree, proof]
+  );
+
+  const changedIds = useMemo(
+    () => new Set(tamper?.changedNodeIds ?? []),
+    [tamper]
+  );
+
+  async function handleSelectLeaf(index: number) {
+    if (!tree) return;
+    setSelectedLeaf(index);
+    setTamper(null);
+    setVisibleSteps(0);
+    setVerification(await verifyProof(tree.leaves[index], getProof(tree, index), tree.root.hash));
+  }
+
+  async function handleTamper() {
+    if (!tree || selectedLeaf === null || !tamperValue.trim()) return;
+    setTamper(await simulateTamper(tree, selectedLeaf, tamperValue.trim()));
+  }
+
+  async function handleExport() {
+    if (!tree || selectedLeaf === null) return;
+    const bundle = await exportProofBundle(tree, selectedLeaf);
+    if (!bundle) return;
+
+    const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `merkle-proof-${bundle.leaf}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function nodeClasses(node: MerkleNode): string {
+    if (changedIds.has(node.id)) return 'border-red-400 bg-red-500/20 text-red-100';
+    if (pathIds.has(node.id)) return 'border-emerald-400 bg-emerald-500/20 text-emerald-100';
+    if (siblingIds.has(node.id)) return 'border-amber-400 bg-amber-500/20 text-amber-100';
+    return 'border-white/10 bg-white/5 text-zinc-300';
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white">Merkle Tree Simulator</h1>
+        <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+          Build a Merkle tree from your own values, generate an inclusion proof, and watch the
+          root be reconstructed one hash at a time. Hashing is real SHA-256, with leaves domain
+          separated by a <code className="text-zinc-300">0x00</code> prefix and internal nodes by{' '}
+          <code className="text-zinc-300">0x01</code>, so exported proofs are valid test vectors.
+        </p>
+      </header>
+
+      <section className="mb-8 grid gap-6 lg:grid-cols-[320px_1fr]">
+        <div>
+          <label htmlFor="leaves" className="block text-sm font-medium text-zinc-200">
+            Leaf values (one per line)
+          </label>
+          <textarea
+            id="leaves"
+            value={rawInput}
+            onChange={(e) => setRawInput(e.target.value)}
+            rows={10}
+            className="mt-2 w-full rounded-lg border border-white/10 bg-zinc-950 p-3 font-mono text-xs text-zinc-100"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            onClick={() => void rebuild()}
+            disabled={building || leafValues.length === 0}
+            className="mt-3 w-full rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-zinc-950 disabled:opacity-50"
+          >
+            {building ? 'Hashing…' : 'Build tree'}
+          </button>
+          <p className="mt-2 text-xs text-zinc-500">
+            Blank lines and duplicates are dropped. {leafValues.length} value
+            {leafValues.length === 1 ? '' : 's'} entered.
+          </p>
+        </div>
+
+        <div className="min-w-0">
+          {!tree ? (
+            <p className="text-sm text-zinc-500">Enter at least one value to build a tree.</p>
+          ) : (
+            <div className="space-y-4 overflow-x-auto">
+              <div className="text-xs text-zinc-400">
+                Root <code className="text-emerald-300">{short(tree.root.hash)}</code> · depth{' '}
+                {tree.depth} · {tree.leaves.length} leaves
+              </div>
+
+              {/* Root at the top, leaves at the bottom — the direction a proof travels. */}
+              {[...tree.levels].reverse().map((level, reversedIndex) => {
+                const levelNumber = tree.levels.length - 1 - reversedIndex;
+                return (
+                  <div key={levelNumber} className="flex flex-wrap items-center gap-2">
+                    <span className="w-16 shrink-0 text-[10px] uppercase tracking-wider text-zinc-600">
+                      {levelNumber === 0 ? 'leaves' : `level ${levelNumber}`}
+                    </span>
+                    {level.map((node) => (
+                      <button
+                        key={node.id}
+                        type="button"
+                        disabled={!node.isLeaf}
+                        onClick={() => node.isLeaf && void handleSelectLeaf(node.index)}
+                        className={`rounded-md border px-2 py-1 font-mono text-[11px] transition-colors ${nodeClasses(node)} ${
+                          node.isLeaf ? 'cursor-pointer hover:brightness-125' : 'cursor-default'
+                        }`}
+                        title={node.value ? `${node.value} → ${node.hash}` : node.hash}
+                      >
+                        {node.value ? `${node.value} ` : ''}
+                        {short(node.hash)}
+                        {node.promoted ? ' ↑' : ''}
+                      </button>
+                    ))}
+                  </div>
+                );
+              })}
+
+              <div className="flex flex-wrap gap-4 text-[11px] text-zinc-500">
+                <span><span className="text-emerald-300">■</span> proof path</span>
+                <span><span className="text-amber-300">■</span> sibling supplied by the proof</span>
+                <span><span className="text-red-300">■</span> invalidated by tampering</span>
+                <span>↑ promoted unpaired node</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {tree && selectedLeaf !== null && verification && (
+        <section className="mb-8 rounded-xl border border-white/10 bg-white/5 p-5">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-white">
+              Proof for <code className="text-emerald-300">{tree.leaves[selectedLeaf]}</code>
+            </h2>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setVisibleSteps((s) => Math.min(s + 1, verification.steps.length))}
+                disabled={visibleSteps >= verification.steps.length}
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs text-zinc-200 disabled:opacity-40"
+              >
+                Step forward
+              </button>
+              <button
+                type="button"
+                onClick={() => setVisibleSteps(verification.steps.length)}
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs text-zinc-200"
+              >
+                Show all
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleExport()}
+                className="rounded-lg bg-white/10 px-3 py-1.5 text-xs text-zinc-100"
+              >
+                Export JSON test vector
+              </button>
+            </div>
+          </div>
+
+          <p className="mb-3 text-xs text-zinc-400">
+            The proof carries {proof.length} sibling hash{proof.length === 1 ? '' : 'es'} — not the
+            whole tree. That is the property that makes inclusion cheap to verify on-chain.
+          </p>
+
+          <ol className="space-y-2">
+            {verification.steps.slice(0, visibleSteps).map((step) => (
+              <li
+                key={step.stepNumber}
+                className="rounded-lg border border-white/10 bg-zinc-950/60 p-3 font-mono text-[11px] text-zinc-300"
+              >
+                <div className="text-zinc-500">
+                  Step {step.stepNumber} · combine with the {step.position} sibling
+                </div>
+                <div className="mt-1">{step.concatenation}</div>
+                <div className="mt-1 text-emerald-300">= {short(step.resultHash)}</div>
+              </li>
+            ))}
+          </ol>
+
+          {visibleSteps >= verification.steps.length && (
+            <div
+              className={`mt-4 rounded-lg border p-3 text-sm ${
+                verification.valid
+                  ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+                  : 'border-red-400/40 bg-red-500/10 text-red-200'
+              }`}
+            >
+              {verification.valid
+                ? `Reconstructed root matches: ${short(verification.computedRoot)}`
+                : `Reconstructed ${short(verification.computedRoot)} but expected ${short(verification.expectedRoot)}`}
+            </div>
+          )}
+        </section>
+      )}
+
+      {tree && selectedLeaf !== null && (
+        <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+          <h2 className="text-lg font-semibold text-white">Tamper with this leaf</h2>
+          <p className="mt-1 text-xs text-zinc-400">
+            Change the value and every hash on its path to the root changes with it. Nothing else
+            in the tree moves — which is also why a proof only needs the siblings.
+          </p>
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            <input
+              value={tamperValue}
+              onChange={(e) => setTamperValue(e.target.value)}
+              placeholder={`replace "${tree.leaves[selectedLeaf]}" with…`}
+              className="flex-1 rounded-lg border border-white/10 bg-zinc-950 px-3 py-2 font-mono text-xs text-zinc-100"
+            />
+            <button
+              type="button"
+              onClick={() => void handleTamper()}
+              disabled={!tamperValue.trim()}
+              className="rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+            >
+              Tamper
+            </button>
+          </div>
+
+          {tamper && (
+            <div className="mt-4 space-y-2 text-xs">
+              <p className="text-zinc-400">
+                {tamper.changedNodeIds.length} node
+                {tamper.changedNodeIds.length === 1 ? '' : 's'} invalidated, highlighted in red above.
+              </p>
+              <p className="font-mono text-zinc-500">
+                before <span className="text-zinc-300">{short(tamper.originalRoot)}</span>
+              </p>
+              <p className="font-mono text-zinc-500">
+                after <span className="text-red-300">{short(tamper.tamperedRoot)}</span>
+              </p>
+              <p className="text-zinc-400">
+                Any proof issued against the original root now fails. Anyone holding that root
+                detects the change without seeing the data.
+              </p>
+            </div>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/storage-model/page.tsx
+++ b/frontend/src/app/storage-model/page.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+/**
+ * Soroban storage model visualiser (Issue #1162).
+ *
+ * The lesson the page is built around: Temporary and Persistent are not "short"
+ * and "long". They differ in what expiry *does* — deletion versus archival —
+ * and that is what decides which one a given piece of state belongs in.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  CODE_EXAMPLES,
+  DEFAULT_RENT_PARAMETERS,
+  LEDGERS_PER_DAY,
+  TIER_PROFILES,
+  compareTiers,
+  entryState,
+  extendTtl,
+  ledgersRemaining,
+  quoteRentForDays,
+  restoreEntry,
+  type StorageEntry,
+  type StorageTier,
+} from '@/lib/soroban-storage-model';
+
+const TIERS: StorageTier[] = ['instance', 'temporary', 'persistent'];
+
+const INITIAL_ENTRIES: StorageEntry[] = [
+  { id: 'e1', key: 'admin_address', tier: 'instance', sizeBytes: 56, createdAtLedger: 0, expiresAtLedger: LEDGERS_PER_DAY * 14 },
+  { id: 'e2', key: 'price_cache::XLM', tier: 'temporary', sizeBytes: 32, createdAtLedger: 0, expiresAtLedger: LEDGERS_PER_DAY * 1 },
+  { id: 'e3', key: 'balance::GABC…', tier: 'persistent', sizeBytes: 72, createdAtLedger: 0, expiresAtLedger: LEDGERS_PER_DAY * 20 },
+];
+
+function formatXlm(xlm: number): string {
+  if (xlm === 0) return '0 XLM';
+  if (xlm < 0.0000001) return '<0.0000001 XLM';
+  return `${xlm.toFixed(7).replace(/0+$/, '').replace(/\.$/, '')} XLM`;
+}
+
+function formatLedgers(ledgers: number): string {
+  const days = ledgers / LEDGERS_PER_DAY;
+  if (days >= 1) return `${ledgers.toLocaleString()} (${days.toFixed(1)}d)`;
+  const hours = (ledgers * 5) / 3600;
+  return `${ledgers.toLocaleString()} (${hours.toFixed(1)}h)`;
+}
+
+export default function StorageModelPage() {
+  const [entries, setEntries] = useState<StorageEntry[]>(INITIAL_ENTRIES);
+  const [currentLedger, setCurrentLedger] = useState(0);
+  const [selectedTier, setSelectedTier] = useState<StorageTier>('persistent');
+  const [log, setLog] = useState<string[]>([]);
+
+  // Rent calculator inputs.
+  const [calcBytes, setCalcBytes] = useState(1024);
+  const [calcDays, setCalcDays] = useState(30);
+
+  const maxLedger = LEDGERS_PER_DAY * 35;
+
+  const comparison = useMemo(
+    () => compareTiers(calcBytes, Math.round(calcDays * LEDGERS_PER_DAY), DEFAULT_RENT_PARAMETERS),
+    [calcBytes, calcDays]
+  );
+
+  function note(message: string) {
+    setLog((prev) => [message, ...prev].slice(0, 8));
+  }
+
+  function handleExtend(entry: StorageEntry) {
+    const result = extendTtl(entry, currentLedger, LEDGERS_PER_DAY * 30);
+    if (!result.ok) {
+      note(`extend_ttl on ${entry.key} refused — ${result.reason}`);
+      return;
+    }
+    setEntries((prev) => prev.map((e) => (e.id === entry.id ? result.entry : e)));
+    note(
+      result.quote && result.quote.ledgers > 0
+        ? `extend_ttl on ${entry.key}: +${formatLedgers(result.quote.ledgers)} for ${formatXlm(result.quote.totalXlm)}`
+        : `extend_ttl on ${entry.key}: ${result.reason}`
+    );
+  }
+
+  function handleRestore(entry: StorageEntry) {
+    const result = restoreEntry(entry, currentLedger, LEDGERS_PER_DAY * 30);
+    if (!result.ok) {
+      note(`restore on ${entry.key} refused — ${result.reason}`);
+      return;
+    }
+    setEntries((prev) => prev.map((e) => (e.id === entry.id ? result.entry : e)));
+    note(`restore on ${entry.key}: ${formatXlm(result.costXlm ?? 0)}`);
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white">Soroban Storage Model</h1>
+        <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+          Instance, Temporary and Persistent are not &ldquo;short&rdquo; and &ldquo;long&rdquo;. All
+          three expire. What separates them is what expiry <em>does</em> — and that is what decides
+          where a given piece of state belongs.
+        </p>
+      </header>
+
+      {/* ── Tier cards ──────────────────────────────────────────────────── */}
+      <section className="mb-10 grid gap-4 md:grid-cols-3">
+        {TIERS.map((tier) => {
+          const profile = TIER_PROFILES[tier];
+          const active = selectedTier === tier;
+          return (
+            <button
+              key={tier}
+              type="button"
+              onClick={() => setSelectedTier(tier)}
+              className={`rounded-xl border p-4 text-left transition-colors ${
+                active ? 'border-emerald-400/60 bg-emerald-500/10' : 'border-white/10 bg-white/5 hover:bg-white/10'
+              }`}
+            >
+              <div className="flex items-baseline justify-between">
+                <h2 className="text-base font-semibold text-white">{profile.label}</h2>
+                <span
+                  className={`rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                    profile.expiryBehaviour === 'deleted'
+                      ? 'bg-red-500/20 text-red-200'
+                      : 'bg-amber-500/20 text-amber-200'
+                  }`}
+                >
+                  {profile.expiryBehaviour}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-zinc-400">{profile.description}</p>
+              <dl className="mt-3 space-y-1 text-[11px] text-zinc-500">
+                <div><span className="text-zinc-400">Use for:</span> {profile.useWhen}</div>
+                <div><span className="text-zinc-400">Not for:</span> {profile.avoidWhen}</div>
+              </dl>
+            </button>
+          );
+        })}
+      </section>
+
+      {/* ── Live TTL timeline ───────────────────────────────────────────── */}
+      <section className="mb-10 rounded-xl border border-white/10 bg-white/5 p-5">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-white">Entry lifecycles</h2>
+          <div className="text-xs text-zinc-400">
+            ledger <span className="font-mono text-zinc-200">{currentLedger.toLocaleString()}</span>{' '}
+            (~day {(currentLedger / LEDGERS_PER_DAY).toFixed(1)})
+          </div>
+        </div>
+
+        <label htmlFor="ledger" className="block text-xs text-zinc-500">
+          Advance the ledger to watch entries expire
+        </label>
+        <input
+          id="ledger"
+          type="range"
+          min={0}
+          max={maxLedger}
+          step={LEDGERS_PER_DAY / 4}
+          value={currentLedger}
+          onChange={(e) => setCurrentLedger(Number(e.target.value))}
+          className="mt-1 w-full accent-emerald-400"
+        />
+
+        <div className="mt-5 space-y-3">
+          {entries.map((entry) => {
+            const state = entryState(entry, currentLedger);
+            const remaining = ledgersRemaining(entry, currentLedger);
+            const profile = TIER_PROFILES[entry.tier];
+            const pct = Math.max(0, Math.min(100, (remaining / profile.maxTtlLedgers) * 100));
+
+            return (
+              <div key={entry.id} className="rounded-lg border border-white/10 bg-zinc-950/60 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <code className="text-xs text-zinc-200">{entry.key}</code>
+                    <span className="ml-2 text-[10px] uppercase tracking-wide text-zinc-500">
+                      {profile.label} · {entry.sizeBytes}B
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`rounded px-2 py-0.5 text-[10px] font-medium ${
+                        state === 'live'
+                          ? 'bg-emerald-500/20 text-emerald-200'
+                          : state === 'expired-archived'
+                            ? 'bg-amber-500/20 text-amber-200'
+                            : 'bg-red-500/20 text-red-200'
+                      }`}
+                    >
+                      {state === 'live'
+                        ? `live · ${formatLedgers(remaining)} left`
+                        : state === 'expired-archived'
+                          ? 'archived — restorable'
+                          : 'deleted — unrecoverable'}
+                    </span>
+
+                    <button
+                      type="button"
+                      onClick={() => handleExtend(entry)}
+                      className="rounded border border-white/15 px-2 py-1 text-[11px] text-zinc-200 hover:bg-white/10"
+                    >
+                      extend_ttl
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleRestore(entry)}
+                      className="rounded border border-white/15 px-2 py-1 text-[11px] text-zinc-200 hover:bg-white/10"
+                    >
+                      restore
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className={`h-full transition-all ${
+                      state === 'live'
+                        ? 'bg-emerald-400'
+                        : state === 'expired-archived'
+                          ? 'bg-amber-400'
+                          : 'bg-red-400'
+                    }`}
+                    style={{ width: `${state === 'live' ? pct : 100}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {log.length > 0 && (
+          <ul className="mt-4 space-y-1 text-[11px] text-zinc-500">
+            {log.map((line, i) => (
+              <li key={`${line}-${i}`} className="font-mono">
+                {line}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <p className="mt-4 text-xs text-zinc-500">
+          Try advancing past day 1, then pressing <code>restore</code> on the temporary cache entry.
+          It refuses — the data is gone. The persistent balance at the same moment restores fine.
+          That single difference is the whole choice between the two tiers.
+        </p>
+      </section>
+
+      {/* ── Rent calculator ─────────────────────────────────────────────── */}
+      <section className="mb-10 rounded-xl border border-white/10 bg-white/5 p-5">
+        <h2 className="text-lg font-semibold text-white">Rent calculator</h2>
+        <p className="mt-1 text-xs text-zinc-400">
+          Cost of holding one entry for a period, per tier. Fee rates are network parameters and
+          change between protocol versions — treat these as a projection, not a quote.
+        </p>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="bytes" className="block text-xs text-zinc-500">
+              Entry size: {calcBytes} bytes (+{DEFAULT_RENT_PARAMETERS.entryOverheadBytes}B overhead)
+            </label>
+            <input
+              id="bytes"
+              type="range"
+              min={16}
+              max={8192}
+              step={16}
+              value={calcBytes}
+              onChange={(e) => setCalcBytes(Number(e.target.value))}
+              className="mt-1 w-full accent-emerald-400"
+            />
+          </div>
+          <div>
+            <label htmlFor="days" className="block text-xs text-zinc-500">
+              Lifespan: {calcDays} days ({Math.round(calcDays * LEDGERS_PER_DAY).toLocaleString()} ledgers)
+            </label>
+            <input
+              id="days"
+              type="range"
+              min={1}
+              max={30}
+              value={calcDays}
+              onChange={(e) => setCalcDays(Number(e.target.value))}
+              className="mt-1 w-full accent-emerald-400"
+            />
+          </div>
+        </div>
+
+        <div className="mt-5 overflow-x-auto">
+          <table className="w-full min-w-[520px] text-left text-xs">
+            <thead className="text-zinc-500">
+              <tr>
+                <th className="pb-2 font-medium">Tier</th>
+                <th className="pb-2 font-medium">Rent</th>
+                <th className="pb-2 font-medium">+ write</th>
+                <th className="pb-2 font-medium">Total</th>
+                <th className="pb-2 font-medium">On expiry</th>
+              </tr>
+            </thead>
+            <tbody className="text-zinc-300">
+              {comparison.map(({ tier, quote, expiryBehaviour, restorable }) => (
+                <tr key={tier} className="border-t border-white/5">
+                  <td className="py-2 capitalize">{tier}</td>
+                  <td className="py-2 font-mono">{formatXlm(quote.rentStroops / 10_000_000)}</td>
+                  <td className="py-2 font-mono text-zinc-500">
+                    {formatXlm(quote.writeStroops / 10_000_000)}
+                  </td>
+                  <td className="py-2 font-mono text-emerald-300">{formatXlm(quote.totalXlm)}</td>
+                  <td className="py-2">
+                    <span className={expiryBehaviour === 'deleted' ? 'text-red-300' : 'text-amber-300'}>
+                      {expiryBehaviour}
+                    </span>
+                    <span className="text-zinc-600">{restorable ? ' (restorable)' : ' (gone)'}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-3 text-xs text-zinc-500">
+          Temporary looks like the obvious saving until the last column: you are not buying a
+          discount, you are declining archival. For anything you cannot recompute, that is not a
+          trade you can make.
+        </p>
+      </section>
+
+      {/* ── Code examples ───────────────────────────────────────────────── */}
+      <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+        <h2 className="text-lg font-semibold text-white">
+          TTL maintenance — {TIER_PROFILES[selectedTier].label}
+        </h2>
+        <p className="mt-1 text-xs text-zinc-400">{CODE_EXAMPLES[selectedTier].note}</p>
+        <pre className="mt-3 overflow-x-auto rounded-lg border border-white/10 bg-zinc-950 p-4 text-[11px] leading-relaxed text-zinc-300">
+          <code>{CODE_EXAMPLES[selectedTier].extend}</code>
+        </pre>
+        <p className="mt-3 text-xs text-zinc-500">
+          Select a tier above to see its maintenance pattern.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/xdr-inspector/page.tsx
+++ b/frontend/src/app/xdr-inspector/page.tsx
@@ -1,0 +1,533 @@
+'use client';
+
+/**
+ * Transaction builder and XDR envelope inspector (Issue #1161).
+ *
+ * The claim the page is built to demonstrate: a transaction and its Base64 XDR
+ * are the same object in two spellings. Every edit rebuilds the envelope, and
+ * the decoded view is produced by parsing that envelope back — not by echoing
+ * the form state — so if they ever disagree, the tool shows it.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Networks } from '@stellar/stellar-sdk';
+
+import {
+  buildTransactionXdr,
+  decodeEnvelope,
+  emptySpec,
+  randomKeypair,
+  verifyRoundTrip,
+  type OperationSpec,
+  type SupportedOperation,
+  type TransactionSpec,
+} from '@/lib/xdr-inspector';
+
+const OPERATION_TYPES: { value: SupportedOperation; label: string }[] = [
+  { value: 'payment', label: 'Payment' },
+  { value: 'createAccount', label: 'Create Account' },
+  { value: 'manageData', label: 'Manage Data' },
+  { value: 'invokeHostFunction', label: 'Invoke Host Function (Soroban)' },
+];
+
+const HORIZON_TESTNET = 'https://horizon-testnet.stellar.org';
+const SOROBAN_TESTNET = 'https://soroban-testnet.stellar.org';
+
+let nextOperationId = 1;
+
+export default function XdrInspectorPage() {
+  const [keys, setKeys] = useState(() => randomKeypair());
+  const [spec, setSpec] = useState<TransactionSpec>(() => emptySpec());
+  const [pastedXdr, setPastedXdr] = useState('');
+  const [signing, setSigning] = useState(false);
+  const [network, setNetwork] = useState<'testnet' | 'public'>('testnet');
+  const [submitState, setSubmitState] = useState<
+    { status: 'idle' } | { status: 'working'; message: string } | { status: 'done'; message: string; hash?: string; ok: boolean }
+  >({ status: 'idle' });
+
+  // Seed the source account once the keypair exists.
+  useEffect(() => {
+    setSpec((prev) => ({ ...prev, sourceAccount: keys.publicKey }));
+  }, [keys.publicKey]);
+
+  const passphrase = network === 'testnet' ? Networks.TESTNET : Networks.PUBLIC;
+
+  const built = useMemo(
+    () => buildTransactionXdr({ ...spec, networkPassphrase: passphrase }, signing ? keys.secret : undefined),
+    [spec, passphrase, signing, keys.secret]
+  );
+
+  // Decode whatever the student pasted if there is anything, otherwise decode
+  // what we just built. Same function either way — that is the point.
+  const decodeSource = pastedXdr.trim() || built.xdr || '';
+  const decoded = useMemo(
+    () => (decodeSource ? decodeEnvelope(decodeSource, passphrase) : null),
+    [decodeSource, passphrase]
+  );
+
+  const roundTrip = useMemo(
+    () => verifyRoundTrip({ ...spec, networkPassphrase: passphrase }),
+    [spec, passphrase]
+  );
+
+  const addOperation = useCallback((type: SupportedOperation) => {
+    setSpec((prev) => ({
+      ...prev,
+      operations: [...prev.operations, { id: `op-${nextOperationId++}`, type }],
+    }));
+  }, []);
+
+  function updateOperation(id: string, patch: Partial<OperationSpec>) {
+    setSpec((prev) => ({
+      ...prev,
+      operations: prev.operations.map((op) => (op.id === id ? { ...op, ...patch } : op)),
+    }));
+  }
+
+  function removeOperation(id: string) {
+    setSpec((prev) => ({ ...prev, operations: prev.operations.filter((op) => op.id !== id) }));
+  }
+
+  /**
+   * Simulate against Soroban RPC, then submit to Horizon.
+   *
+   * Simulation is worth doing first even for classic operations: it is where
+   * authorization and precondition failures surface, and finding them here
+   * costs nothing while finding them at submission costs a fee.
+   */
+  async function handleSubmit() {
+    if (!built.ok || !built.xdr) return;
+    if (network !== 'testnet') {
+      setSubmitState({ status: 'done', ok: false, message: 'Submission is restricted to testnet.' });
+      return;
+    }
+
+    try {
+      setSubmitState({ status: 'working', message: 'Funding the source account with Friendbot…' });
+      // A brand-new keypair has no account on-chain, so sequence 0 would be
+      // rejected. Friendbot creates and funds it on testnet.
+      await fetch(`https://friendbot.stellar.org/?addr=${encodeURIComponent(keys.publicKey)}`).catch(() => null);
+
+      setSubmitState({ status: 'working', message: 'Fetching the current sequence number…' });
+      const accountResponse = await fetch(`${HORIZON_TESTNET}/accounts/${keys.publicKey}`);
+      if (!accountResponse.ok) {
+        setSubmitState({
+          status: 'done',
+          ok: false,
+          message: 'Could not load the source account. It may not be funded yet — try again in a moment.',
+        });
+        return;
+      }
+      const account = await accountResponse.json();
+
+      // Rebuild at the live sequence: the form's sequence is for teaching, but
+      // the network will reject anything that is not exactly next.
+      const live = buildTransactionXdr(
+        { ...spec, sourceAccount: keys.publicKey, sequence: account.sequence, networkPassphrase: Networks.TESTNET },
+        keys.secret
+      );
+      if (!live.ok || !live.xdr) {
+        setSubmitState({ status: 'done', ok: false, message: live.error ?? 'Build failed' });
+        return;
+      }
+
+      setSubmitState({ status: 'working', message: 'Simulating…' });
+      const simulation = await fetch(SOROBAN_TESTNET, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'simulateTransaction',
+          params: { transaction: live.xdr },
+        }),
+      })
+        .then((r) => r.json())
+        .catch(() => null);
+
+      const simError = simulation?.result?.error;
+      if (simError) {
+        setSubmitState({
+          status: 'done',
+          ok: false,
+          message: `Simulation rejected this transaction: ${simError}. Nothing was submitted, so no fee was spent.`,
+        });
+        return;
+      }
+
+      setSubmitState({ status: 'working', message: 'Submitting to testnet…' });
+      const submission = await fetch(`${HORIZON_TESTNET}/transactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ tx: live.xdr }),
+      });
+      const result = await submission.json();
+
+      if (submission.ok && result.hash) {
+        setSubmitState({ status: 'done', ok: true, message: 'Included in a ledger.', hash: result.hash });
+      } else {
+        const codes = result?.extras?.result_codes;
+        setSubmitState({
+          status: 'done',
+          ok: false,
+          message: codes
+            ? `Rejected: ${codes.transaction ?? ''} ${(codes.operations ?? []).join(', ')}`.trim()
+            : result?.detail ?? 'Submission failed',
+        });
+      }
+    } catch (error) {
+      setSubmitState({
+        status: 'done',
+        ok: false,
+        message: error instanceof Error ? error.message : 'Submission failed',
+      });
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white">Transaction Builder &amp; XDR Inspector</h1>
+        <p className="mt-2 max-w-3xl text-sm text-zinc-400">
+          Assemble a multi-operation transaction, watch the Base64 XDR envelope change as you edit,
+          and decode it back into fields. The two views are the same object — the decoded panel is
+          produced by parsing the envelope, not by echoing the form.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* ── Builder ─────────────────────────────────────────────────── */}
+        <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 text-lg font-semibold text-white">Build</h2>
+
+          <div className="space-y-3 text-xs">
+            <div>
+              <label htmlFor="source" className="block text-zinc-500">Source account</label>
+              <input
+                id="source"
+                value={spec.sourceAccount}
+                onChange={(e) => setSpec({ ...spec, sourceAccount: e.target.value })}
+                className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 px-2 py-1.5 font-mono text-[11px] text-zinc-100"
+              />
+              <button
+                type="button"
+                onClick={() => setKeys(randomKeypair())}
+                className="mt-1 text-[11px] text-emerald-400 underline"
+              >
+                generate a new test keypair
+              </button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="seq" className="block text-zinc-500">Sequence</label>
+                <input
+                  id="seq"
+                  value={spec.sequence}
+                  onChange={(e) => setSpec({ ...spec, sequence: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 px-2 py-1.5 font-mono text-[11px] text-zinc-100"
+                />
+              </div>
+              <div>
+                <label htmlFor="fee" className="block text-zinc-500">Fee per operation (stroops)</label>
+                <input
+                  id="fee"
+                  value={spec.fee}
+                  onChange={(e) => setSpec({ ...spec, fee: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 px-2 py-1.5 font-mono text-[11px] text-zinc-100"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="net" className="block text-zinc-500">Network</label>
+                <select
+                  id="net"
+                  value={network}
+                  onChange={(e) => setNetwork(e.target.value as 'testnet' | 'public')}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 px-2 py-1.5 text-[11px] text-zinc-100"
+                >
+                  <option value="testnet">Testnet</option>
+                  <option value="public">Public</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="memo" className="block text-zinc-500">Memo (text)</label>
+                <input
+                  id="memo"
+                  value={spec.memo?.value ?? ''}
+                  onChange={(e) =>
+                    setSpec({ ...spec, memo: { type: e.target.value ? 'text' : 'none', value: e.target.value } })
+                  }
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 px-2 py-1.5 text-[11px] text-zinc-100"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Operations */}
+          <div className="mt-5">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <span className="text-xs font-medium text-zinc-300">Operations</span>
+              {OPERATION_TYPES.map((t) => (
+                <button
+                  key={t.value}
+                  type="button"
+                  onClick={() => addOperation(t.value)}
+                  className="rounded border border-white/15 px-2 py-1 text-[10px] text-zinc-300 hover:bg-white/10"
+                >
+                  + {t.label}
+                </button>
+              ))}
+            </div>
+
+            {spec.operations.length === 0 && (
+              <p className="text-xs text-zinc-600">
+                A transaction needs at least one operation. Add one above.
+              </p>
+            )}
+
+            <div className="space-y-3">
+              {spec.operations.map((op, index) => (
+                <div key={op.id} className="rounded-lg border border-white/10 bg-zinc-950/60 p-3">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-[11px] text-zinc-400">
+                      #{index} · {OPERATION_TYPES.find((t) => t.value === op.type)?.label}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeOperation(op.id)}
+                      className="text-[11px] text-red-400 hover:underline"
+                    >
+                      remove
+                    </button>
+                  </div>
+
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {(op.type === 'payment' || op.type === 'createAccount') && (
+                      <input
+                        placeholder="destination (G…)"
+                        value={op.destination ?? ''}
+                        onChange={(e) => updateOperation(op.id, { destination: e.target.value })}
+                        className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                      />
+                    )}
+                    {op.type === 'payment' && (
+                      <>
+                        <input
+                          placeholder="amount"
+                          value={op.amount ?? ''}
+                          onChange={(e) => updateOperation(op.id, { amount: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                        <input
+                          placeholder="asset code (blank = XLM)"
+                          value={op.assetCode ?? ''}
+                          onChange={(e) => updateOperation(op.id, { assetCode: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                        <input
+                          placeholder="asset issuer (non-native only)"
+                          value={op.assetIssuer ?? ''}
+                          onChange={(e) => updateOperation(op.id, { assetIssuer: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                      </>
+                    )}
+                    {op.type === 'createAccount' && (
+                      <input
+                        placeholder="starting balance"
+                        value={op.startingBalance ?? ''}
+                        onChange={(e) => updateOperation(op.id, { startingBalance: e.target.value })}
+                        className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                      />
+                    )}
+                    {op.type === 'manageData' && (
+                      <>
+                        <input
+                          placeholder="entry name"
+                          value={op.name ?? ''}
+                          onChange={(e) => updateOperation(op.id, { name: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                        <input
+                          placeholder="value (blank deletes the entry)"
+                          value={op.value ?? ''}
+                          onChange={(e) => updateOperation(op.id, { value: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                      </>
+                    )}
+                    {op.type === 'invokeHostFunction' && (
+                      <>
+                        <input
+                          placeholder="contract id (C…)"
+                          value={op.contractId ?? ''}
+                          onChange={(e) => updateOperation(op.id, { contractId: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                        <input
+                          placeholder="function name"
+                          value={op.functionName ?? ''}
+                          onChange={(e) => updateOperation(op.id, { functionName: e.target.value })}
+                          className="rounded border border-white/10 bg-zinc-950 px-2 py-1 font-mono text-[11px] text-zinc-100"
+                        />
+                      </>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <label className="mt-4 flex items-center gap-2 text-xs text-zinc-400">
+            <input type="checkbox" checked={signing} onChange={(e) => setSigning(e.target.checked)} />
+            Sign with the test key
+          </label>
+
+          {built.ok && (
+            <p className="mt-2 text-[11px] text-zinc-500">
+              Envelope fee is {built.totalFee} stroops — {spec.fee} × {built.operationCount}{' '}
+              operation{built.operationCount === 1 ? '' : 's'}. The fee on a transaction is the
+              total, not the per-operation figure you entered.
+            </p>
+          )}
+        </section>
+
+        {/* ── XDR + decode ────────────────────────────────────────────── */}
+        <section className="space-y-6">
+          <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+            <h2 className="mb-3 text-lg font-semibold text-white">Base64 XDR envelope</h2>
+
+            {built.ok ? (
+              <textarea
+                readOnly
+                value={built.xdr}
+                rows={5}
+                className="w-full rounded-lg border border-white/10 bg-zinc-950 p-3 font-mono text-[10px] leading-relaxed text-emerald-200"
+              />
+            ) : (
+              <p className="rounded-lg border border-red-400/30 bg-red-500/10 p-3 text-xs text-red-200">
+                {built.error}
+              </p>
+            )}
+
+            <div
+              className={`mt-3 rounded-lg border p-2 text-[11px] ${
+                roundTrip.ok
+                  ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+                  : 'border-amber-400/30 bg-amber-500/10 text-amber-200'
+              }`}
+            >
+              Round trip: {roundTrip.detail}
+            </div>
+
+            <label htmlFor="paste" className="mt-4 block text-xs text-zinc-500">
+              Or paste an envelope to decode instead
+            </label>
+            <textarea
+              id="paste"
+              value={pastedXdr}
+              onChange={(e) => setPastedXdr(e.target.value)}
+              rows={3}
+              placeholder="AAAAAg…"
+              className="mt-1 w-full rounded-lg border border-white/10 bg-zinc-950 p-2 font-mono text-[10px] text-zinc-100"
+            />
+
+            <button
+              type="button"
+              onClick={() => void handleSubmit()}
+              disabled={!built.ok || submitState.status === 'working' || network !== 'testnet'}
+              className="mt-3 w-full rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-zinc-950 disabled:opacity-40"
+            >
+              {submitState.status === 'working' ? submitState.message : 'Simulate & submit to testnet'}
+            </button>
+
+            {submitState.status === 'done' && (
+              <div
+                className={`mt-2 rounded-lg border p-2 text-[11px] ${
+                  submitState.ok
+                    ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+                    : 'border-red-400/30 bg-red-500/10 text-red-200'
+                }`}
+              >
+                {submitState.message}
+                {submitState.hash && (
+                  <>
+                    {' '}
+                    <a
+                      href={`https://stellar.expert/explorer/testnet/tx/${submitState.hash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      view {submitState.hash.slice(0, 12)}…
+                    </a>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+            <h2 className="mb-3 text-lg font-semibold text-white">Decoded</h2>
+
+            {!decoded ? (
+              <p className="text-xs text-zinc-600">Nothing to decode yet.</p>
+            ) : !decoded.ok ? (
+              <p className="rounded-lg border border-red-400/30 bg-red-500/10 p-3 text-xs text-red-200">
+                {decoded.error}
+              </p>
+            ) : (
+              <div className="space-y-3 text-xs">
+                <dl className="grid grid-cols-[110px_1fr] gap-y-1 font-mono text-[11px]">
+                  <dt className="text-zinc-500">source</dt>
+                  <dd className="truncate text-zinc-200">{decoded.sourceAccount}</dd>
+                  <dt className="text-zinc-500">sequence</dt>
+                  <dd className="text-zinc-200">{decoded.sequence}</dd>
+                  <dt className="text-zinc-500">fee</dt>
+                  <dd className="text-zinc-200">{decoded.fee}</dd>
+                  <dt className="text-zinc-500">memo</dt>
+                  <dd className="text-zinc-200">
+                    {decoded.memo?.type}
+                    {decoded.memo?.value ? ` · ${decoded.memo.value}` : ''}
+                  </dd>
+                  <dt className="text-zinc-500">signatures</dt>
+                  <dd className="text-zinc-200">{decoded.signatureCount}</dd>
+                  <dt className="text-zinc-500">hash</dt>
+                  <dd className="truncate text-amber-200">{decoded.transactionHash}</dd>
+                </dl>
+
+                <div className="space-y-2">
+                  {decoded.operations?.map((op) => (
+                    <div key={op.index} className="rounded-lg border border-white/10 bg-zinc-950/60 p-2">
+                      <div className="text-[11px] text-emerald-300">
+                        #{op.index} {op.type}
+                      </div>
+                      <dl className="mt-1 grid grid-cols-[90px_1fr] gap-y-0.5 font-mono text-[10px]">
+                        {Object.entries(op.details).map(([key, value]) => (
+                          <div key={key} className="contents">
+                            <dt className="text-zinc-600">{key}</dt>
+                            <dd className="truncate text-zinc-300">{value}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </div>
+                  ))}
+                </div>
+
+                <p className="text-[11px] text-zinc-500">
+                  The hash above is network-specific: signatures commit to a value that includes the
+                  network passphrase. Switch the network selector and it changes, without the
+                  envelope changing at all — that is what stops a testnet transaction being replayed
+                  on the public network.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/lib/__tests__/consensus-simulator.test.ts
+++ b/frontend/src/lib/__tests__/consensus-simulator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  branchWork,
+  canonicalChain,
+  confirmationDepth,
+  confirmationsForRisk,
+  createChain,
+  forkChain,
+  mineBlock,
+  reversalProbability,
+  simulateDoubleSpend,
+  stateAtTick,
+  tipOf,
+} from '../consensus-simulator';
+
+describe('chain construction', () => {
+  it('starts at genesis', () => {
+    const chain = createChain('pow');
+    expect(chain.blocks).toHaveLength(1);
+    expect(canonicalChain(chain)).toHaveLength(1);
+  });
+
+  it('advances the tip and accumulates work', () => {
+    let chain = createChain('pow');
+    chain = mineBlock(chain, { txIds: ['tx1'] });
+    chain = mineBlock(chain);
+
+    expect(tipOf(chain, 'main').height).toBe(2);
+    expect(branchWork(chain, 'main')).toBe(2);
+    expect(confirmationDepth(chain, 'tx1')).toBe(2);
+  });
+
+  it('reports no depth for a transaction that is not on the chain', () => {
+    expect(confirmationDepth(createChain('pow'), 'missing')).toBeNull();
+  });
+});
+
+describe('proof-of-work fork choice', () => {
+  it('keeps the canonical chain when the competing branch is lighter', () => {
+    let chain = createChain('pow');
+    chain = mineBlock(chain, { txIds: ['tx1'] });
+    chain = mineBlock(chain);
+    chain = forkChain(chain, 'attacker', 0);
+    chain = mineBlock(chain, { branch: 'attacker' });
+
+    expect(chain.canonicalBranch).toBe('main');
+    expect(confirmationDepth(chain, 'tx1')).toBe(2);
+  });
+
+  it('reorgs to the heavier branch and reverts its transactions', () => {
+    let chain = createChain('pow');
+    chain = mineBlock(chain, { txIds: ['tx1'] });
+    chain = mineBlock(chain);
+    // Fork below the block holding tx1 - forking above it could never remove it.
+    chain = forkChain(chain, 'attacker', 0);
+    chain = mineBlock(chain, { branch: 'attacker', work: 5 });
+    chain = mineBlock(chain, { branch: 'attacker', work: 5 });
+
+    const reorg = chain.events.filter((e) => e.kind === 'reorg').pop();
+
+    expect(chain.canonicalBranch).toBe('attacker');
+    expect(reorg?.depth).toBe(2);
+    expect(reorg?.revertedTxIds).toContain('tx1');
+    // The concrete consequence: a confirmed payment is now unconfirmed.
+    expect(confirmationDepth(chain, 'tx1')).toBeNull();
+  });
+
+  it('does not count a transaction present on both branches as reverted', () => {
+    let chain = createChain('pow');
+    chain = mineBlock(chain, { txIds: ['shared'] });
+    chain = forkChain(chain, 'b2', 0);
+    chain = mineBlock(chain, { branch: 'b2', txIds: ['shared'], work: 9 });
+
+    const reorg = chain.events.filter((e) => e.kind === 'reorg').pop();
+    expect(reorg?.revertedTxIds ?? []).not.toContain('shared');
+  });
+});
+
+describe('SCP finality', () => {
+  it('never adopts a competing branch, however much work it carries', () => {
+    let chain = createChain('scp');
+    chain = mineBlock(chain, { txIds: ['pay'] });
+    chain = forkChain(chain, 'attacker', 0);
+    chain = mineBlock(chain, { branch: 'attacker', work: 100 });
+    chain = mineBlock(chain, { branch: 'attacker', work: 100 });
+
+    expect(chain.canonicalBranch).toBe('main');
+    expect(confirmationDepth(chain, 'pay')).not.toBeNull();
+    expect(chain.events.some((e) => e.kind === 'reorg')).toBe(false);
+    expect(chain.events.some((e) => e.kind === 'finalized')).toBe(true);
+  });
+});
+
+describe('reversal probability', () => {
+  it('follows the gambler\'s-ruin result (q/p)^depth', () => {
+    expect(reversalProbability(0.25, 2)).toBeCloseTo((1 / 3) ** 2, 12);
+  });
+
+  it('falls as confirmations accumulate', () => {
+    expect(reversalProbability(0.3, 6)).toBeLessThan(reversalProbability(0.3, 1));
+  });
+
+  it('is certain at or above 50% hash power, at any depth', () => {
+    // This is what "51% attack" means: no confirmation count is sufficient.
+    expect(reversalProbability(0.5, 1000)).toBe(1);
+    expect(reversalProbability(0.6, 1000)).toBe(1);
+  });
+
+  it('treats zero depth as unconfirmed', () => {
+    expect(reversalProbability(0.1, 0)).toBe(1);
+  });
+
+  it('reports no safe confirmation count at majority hash power', () => {
+    expect(confirmationsForRisk(0.5)).toBe(Infinity);
+    expect(Number.isFinite(confirmationsForRisk(0.1))).toBe(true);
+    expect(confirmationsForRisk(0.4)).toBeGreaterThan(confirmationsForRisk(0.1));
+  });
+});
+
+describe('double-spend scenarios', () => {
+  it('succeeds under proof-of-work with majority hash power', () => {
+    const outcome = simulateDoubleSpend('pow', {
+      hashPower: 0.6,
+      merchantConfirmations: 6,
+      amount: 100,
+    });
+
+    expect(outcome.succeeded).toBe(true);
+    expect(outcome.confirmationsForSafety).toBe(Infinity);
+  });
+
+  it('cannot be attempted under SCP even at 90% influence', () => {
+    const outcome = simulateDoubleSpend('scp', {
+      hashPower: 0.9,
+      merchantConfirmations: 1,
+      amount: 100,
+    });
+
+    expect(outcome.succeeded).toBe(false);
+    expect(outcome.reversalProbability).toBe(0);
+    // The failure mode under SCP is halting, not reversal - safety over liveness.
+    expect(outcome.narrative.some((line) => /halt/i.test(line))).toBe(true);
+  });
+});
+
+describe('timeline scrubbing', () => {
+  it('shows the chain as it stood before a reorg', () => {
+    let chain = createChain('pow');
+    chain = mineBlock(chain, { txIds: ['tx1'] });
+    chain = mineBlock(chain);
+    chain = forkChain(chain, 'attacker', 0);
+    chain = mineBlock(chain, { branch: 'attacker', work: 5 });
+    chain = mineBlock(chain, { branch: 'attacker', work: 5 });
+
+    const early = stateAtTick(chain, 1);
+    expect(early.blocks.length).toBeLessThan(chain.blocks.length);
+    // At tick 1 the network believed "main" - which it did.
+    expect(early.canonicalBranch).toBe('main');
+
+    expect(stateAtTick(chain, 999).blocks).toHaveLength(chain.blocks.length);
+  });
+});

--- a/frontend/src/lib/__tests__/merkle-sha256.test.ts
+++ b/frontend/src/lib/__tests__/merkle-sha256.test.ts
@@ -1,0 +1,201 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMerkleTree,
+  exportProofBundle,
+  getPathNodeIds,
+  getProof,
+  getSiblingNodeIds,
+  hashLeaf,
+  hashPair,
+  normalizeLeaves,
+  simulateTamper,
+  verifyProof,
+} from '../merkle-sha256';
+
+/**
+ * Independent SHA-256 references via node:crypto.
+ *
+ * The module hashes through Web Crypto; computing the expected values with a
+ * different implementation is what proves it produces genuine SHA-256 with the
+ * documented domain separation, rather than merely being self-consistent.
+ */
+const refLeaf = (value: string) =>
+  createHash('sha256')
+    .update(Buffer.concat([Buffer.from([0x00]), Buffer.from(value, 'utf8')]))
+    .digest('hex');
+
+const refPair = (left: string, right: string) =>
+  createHash('sha256')
+    .update(Buffer.concat([Buffer.from([0x01]), Buffer.from(left, 'hex'), Buffer.from(right, 'hex')]))
+    .digest('hex');
+
+describe('hashing', () => {
+  it('hashes a leaf as SHA-256 with the 0x00 prefix', async () => {
+    const hash = await hashLeaf('alice');
+    expect(hash).toBe(refLeaf('alice'));
+    expect(hash).toHaveLength(64);
+  });
+
+  it('hashes a node as SHA-256 with the 0x01 prefix', async () => {
+    const leaf = await hashLeaf('alice');
+    expect(await hashPair(leaf, leaf)).toBe(refPair(leaf, leaf));
+  });
+
+  it('separates the leaf and node domains', async () => {
+    // Without distinct prefixes an internal node's 64-byte preimage could be
+    // presented as a leaf - the second-preimage attack the prefixes prevent.
+    const leaf = await hashLeaf('x');
+    expect(await hashPair(leaf, leaf)).not.toBe(await hashLeaf('x'));
+  });
+});
+
+describe('normalizeLeaves', () => {
+  it('trims, drops blanks, and de-duplicates in order', () => {
+    expect(normalizeLeaves([' a ', 'a', '', '  ', 'b'])).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildMerkleTree', () => {
+  it('returns null for no leaves', async () => {
+    expect(await buildMerkleTree([])).toBeNull();
+  });
+
+  it('builds a root matching an independent computation', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const leaves = ['alice', 'bob', 'carol', 'dave'].map(refLeaf);
+
+    expect(tree!.root.hash).toBe(refPair(refPair(leaves[0], leaves[1]), refPair(leaves[2], leaves[3])));
+    expect(tree!.depth).toBe(2);
+    expect(tree!.levels.map((l) => l.length)).toEqual([4, 2, 1]);
+  });
+
+  it('treats a single leaf as its own root', async () => {
+    const tree = await buildMerkleTree(['solo']);
+    expect(tree!.root.hash).toBe(refLeaf('solo'));
+    expect(getProof(tree!, 0)).toEqual([]);
+  });
+
+  it('promotes an unpaired node rather than duplicating it', async () => {
+    const tree = await buildMerkleTree(['a', 'b', 'c']);
+    const [la, lb, lc] = ['a', 'b', 'c'].map(refLeaf);
+
+    // Duplicating the odd node - the Bitcoin construction - admits
+    // CVE-2012-2459, where two distinct trees share a root.
+    expect(tree!.root.hash).toBe(refPair(refPair(la, lb), lc));
+    expect(tree!.root.hash).not.toBe(refPair(refPair(la, lb), refPair(lc, lc)));
+  });
+});
+
+describe('proofs', () => {
+  it('verifies every leaf in a power-of-two tree', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+
+    for (let i = 0; i < 4; i += 1) {
+      const proof = getProof(tree!, i);
+      expect(proof).toHaveLength(2);
+
+      const result = await verifyProof(tree!.leaves[i], proof, tree!.root.hash);
+      expect(result.valid).toBe(true);
+      expect(result.computedRoot).toBe(tree!.root.hash);
+      expect(result.steps).toHaveLength(2);
+    }
+  });
+
+  it('verifies every leaf when the count is not a power of two', async () => {
+    const values = Array.from({ length: 17 }, (_, i) => `user${i}`);
+    const tree = await buildMerkleTree(values);
+
+    for (let i = 0; i < values.length; i += 1) {
+      const result = await verifyProof(tree!.leaves[i], getProof(tree!, i), tree!.root.hash);
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it('rejects a leaf that is not in the tree', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const result = await verifyProof('mallory', getProof(tree!, 0), tree!.root.hash);
+    expect(result.valid).toBe(false);
+  });
+
+  it('records each combination so the walk can be animated', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const result = await verifyProof(tree!.leaves[0], getProof(tree!, 0), tree!.root.hash);
+
+    // Each step feeds the next - that chaining is what the animation shows.
+    expect(result.steps[0].currentHash).toBe(await hashLeaf('alice'));
+    expect(result.steps[1].currentHash).toBe(result.steps[0].resultHash);
+    expect(result.steps[1].resultHash).toBe(tree!.root.hash);
+  });
+
+  it('returns an empty proof for an out-of-range index', async () => {
+    const tree = await buildMerkleTree(['alice']);
+    expect(getProof(tree!, 99)).toEqual([]);
+    expect(getProof(tree!, -1)).toEqual([]);
+  });
+});
+
+describe('highlighting helpers', () => {
+  it('reports the path from leaf to root', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    expect(getPathNodeIds(tree!, 0)).toEqual(['L0-0', 'L1-0', 'L2-0']);
+  });
+
+  it('resolves the sibling nodes a proof consumes', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    expect(getSiblingNodeIds(tree!, getProof(tree!, 0))).toEqual(['L0-1', 'L1-1']);
+  });
+});
+
+describe('tamper simulation', () => {
+  it('invalidates exactly the path to the root', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const result = await simulateTamper(tree!, 1, 'mallory');
+
+    expect(result!.rootChanged).toBe(true);
+    // Leaf, its parent, and the root - and nothing else.
+    expect(result!.changedNodeIds).toHaveLength(3);
+    expect(result!.changedNodeIds).not.toContain('L0-0');
+    expect(result!.changedNodeIds).not.toContain('L1-1');
+  });
+
+  it('breaks proofs issued against the original root', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const result = await simulateTamper(tree!, 1, 'mallory');
+
+    const stale = await verifyProof('bob', getProof(tree!, 1), result!.tamperedRoot);
+    expect(stale.valid).toBe(false);
+  });
+
+  it('returns null for an out-of-range leaf', async () => {
+    const tree = await buildMerkleTree(['alice']);
+    expect(await simulateTamper(tree!, 5, 'x')).toBeNull();
+  });
+});
+
+describe('proof export', () => {
+  it('produces a self-describing, verifiable test vector', async () => {
+    const tree = await buildMerkleTree(['alice', 'bob', 'carol', 'dave']);
+    const bundle = await exportProofBundle(tree!, 2);
+
+    expect(bundle).toMatchObject({
+      leaf: 'carol',
+      leafIndex: 2,
+      root: tree!.root.hash,
+      algorithm: 'sha256',
+      leafPrefix: '0x00',
+      nodePrefix: '0x01',
+    });
+
+    // A contract cannot reproduce the proof without the prefixes, so a vector
+    // that omits them is not actually a test vector.
+    const replayed = await verifyProof(bundle!.leaf, bundle!.proof, bundle!.root);
+    expect(replayed.valid).toBe(true);
+  });
+
+  it('returns null for an unknown leaf index', async () => {
+    const tree = await buildMerkleTree(['alice']);
+    expect(await exportProofBundle(tree!, 9)).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/soroban-storage-model.test.ts
+++ b/frontend/src/lib/__tests__/soroban-storage-model.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_RENT_PARAMETERS,
+  LEDGERS_PER_DAY,
+  TIER_PROFILES,
+  billableBytes,
+  compareTiers,
+  entryState,
+  extendTtl,
+  ledgersRemaining,
+  quoteRent,
+  quoteRentForDays,
+  restoreEntry,
+  simulateToLedger,
+  type StorageEntry,
+} from '../soroban-storage-model';
+
+const persistent: StorageEntry = {
+  id: 'p',
+  key: 'balance',
+  tier: 'persistent',
+  sizeBytes: 100,
+  createdAtLedger: 0,
+  expiresAtLedger: 1000,
+};
+
+const temporary: StorageEntry = { ...persistent, id: 't', key: 'cache', tier: 'temporary' };
+
+describe('tier semantics', () => {
+  it('deletes temporary entries and archives persistent ones', () => {
+    // The distinction the whole page exists to teach: same elapsed time,
+    // different consequence.
+    expect(TIER_PROFILES.temporary.expiryBehaviour).toBe('deleted');
+    expect(TIER_PROFILES.temporary.restorable).toBe(false);
+    expect(TIER_PROFILES.persistent.expiryBehaviour).toBe('archived');
+    expect(TIER_PROFILES.persistent.restorable).toBe(true);
+  });
+
+  it('marks instance storage as sharing one TTL', () => {
+    expect(TIER_PROFILES.instance.sharedTtl).toBe(true);
+  });
+});
+
+describe('rent arithmetic', () => {
+  it('bills payload plus per-entry overhead', () => {
+    expect(billableBytes({ sizeBytes: 0 })).toBe(DEFAULT_RENT_PARAMETERS.entryOverheadBytes);
+    expect(quoteRent(1000, 'persistent', 1000).billableBytes).toBe(1048);
+  });
+
+  it('charges bytes x rate x ledgers, plus the write fee', () => {
+    const quote = quoteRent(1000, 'persistent', 1000);
+    expect(quote.rentStroops).toBe(1048 * DEFAULT_RENT_PARAMETERS.persistentRentRateStroops * 1000);
+    expect(quote.totalStroops).toBe(quote.rentStroops + DEFAULT_RENT_PARAMETERS.writeFeeStroops);
+  });
+
+  it('charges no rent for a zero-ledger window', () => {
+    expect(quoteRent(100, 'persistent', 0).rentStroops).toBe(0);
+  });
+
+  it('prices temporary below persistent', () => {
+    expect(quoteRent(1000, 'temporary', 1000).rentStroops).toBeLessThan(
+      quoteRent(1000, 'persistent', 1000).rentStroops
+    );
+  });
+
+  it('bills instance storage at the persistent rate', () => {
+    // Instance entries are archived, not deleted, so they are priced as such.
+    // The saving is that one entry covers many keys - not a cheaper rate.
+    expect(quoteRent(1000, 'instance', 1000).rentStroops).toBe(
+      quoteRent(1000, 'persistent', 1000).rentStroops
+    );
+  });
+
+  it('converts days to ledgers', () => {
+    expect(quoteRentForDays(100, 'persistent', 1).ledgers).toBe(LEDGERS_PER_DAY);
+  });
+});
+
+describe('lifecycle state', () => {
+  it('is live until the expiry ledger', () => {
+    expect(entryState(persistent, 999)).toBe('live');
+    expect(ledgersRemaining(persistent, 400)).toBe(600);
+  });
+
+  it('archives or deletes at expiry depending on the tier', () => {
+    expect(entryState(persistent, 1000)).toBe('expired-archived');
+    expect(entryState(temporary, 1000)).toBe('expired-deleted');
+  });
+
+  it('clamps remaining ledgers at zero', () => {
+    expect(ledgersRemaining(persistent, 5000)).toBe(0);
+  });
+
+  it('gives the same elapsed time different outcomes per tier', () => {
+    const [p, t] = simulateToLedger([persistent, temporary], 1500);
+    expect(p.state).toBe('expired-archived');
+    expect(t.state).toBe('expired-deleted');
+  });
+});
+
+describe('extend_ttl', () => {
+  it('measures the new expiry from the current ledger, not from the old expiry', () => {
+    // Repeated calls do not stack - a common and expensive misunderstanding.
+    const result = extendTtl(persistent, 500, 2000);
+    expect(result.ok).toBe(true);
+    expect(result.entry.expiresAtLedger).toBe(2500);
+  });
+
+  it('never shortens a TTL', () => {
+    const result = extendTtl(persistent, 500, 100);
+    expect(result.entry.expiresAtLedger).toBe(1000);
+    expect(result.reason).toMatch(/no-op/);
+  });
+
+  it('caps at the tier maximum', () => {
+    expect(extendTtl(persistent, 0, 999_999_999).entry.expiresAtLedger).toBe(
+      TIER_PROFILES.persistent.maxTtlLedgers
+    );
+  });
+
+  it('refuses to revive a deleted temporary entry', () => {
+    const result = extendTtl(temporary, 1200, 2000);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/cannot be restored/);
+  });
+
+  it('directs an archived entry to restore first', () => {
+    const result = extendTtl(persistent, 1200, 2000);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/restore/);
+  });
+});
+
+describe('restore', () => {
+  it('brings an archived entry back for a fresh window', () => {
+    const result = restoreEntry(persistent, 1200, 1000);
+    expect(result.ok).toBe(true);
+    expect(result.entry.expiresAtLedger).toBe(2200);
+    expect(result.costStroops).toBeGreaterThan(DEFAULT_RENT_PARAMETERS.restoreFeeStroops);
+  });
+
+  it('cannot restore a temporary entry at any price', () => {
+    // The single most important consequence of choosing that tier.
+    const result = restoreEntry(temporary, 1200, 1000);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/deleted/);
+  });
+
+  it('refuses to restore a live entry', () => {
+    expect(restoreEntry(persistent, 500, 1000).ok).toBe(false);
+  });
+});
+
+describe('tier comparison', () => {
+  it('reports cost alongside what expiry does', () => {
+    const rows = compareTiers(500, LEDGERS_PER_DAY);
+    const temp = rows.find((r) => r.tier === 'temporary')!;
+    const pers = rows.find((r) => r.tier === 'persistent')!;
+
+    expect(rows).toHaveLength(3);
+    expect(temp.quote.rentStroops).toBeLessThan(pers.quote.rentStroops);
+    // Price alone would make temporary look like the obvious choice; the
+    // comparison carries restorability so the trade is visible.
+    expect(temp.restorable).toBe(false);
+    expect(pers.restorable).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/xdr-inspector.test.ts
+++ b/frontend/src/lib/__tests__/xdr-inspector.test.ts
@@ -1,0 +1,169 @@
+import { Networks, StrKey } from '@stellar/stellar-sdk';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTransactionXdr,
+  decodeEnvelope,
+  emptySpec,
+  randomKeypair,
+  verifyRoundTrip,
+  type TransactionSpec,
+} from '../xdr-inspector';
+
+const keys = randomKeypair();
+const destination = randomKeypair().publicKey;
+
+function paymentSpec(): TransactionSpec {
+  return {
+    ...emptySpec(keys.publicKey),
+    operations: [
+      { id: 'op1', type: 'payment', destination, amount: '10', assetCode: 'XLM' },
+    ],
+  };
+}
+
+describe('building', () => {
+  it('produces a Base64 envelope for a payment', () => {
+    const result = buildTransactionXdr(paymentSpec());
+    expect(result.ok).toBe(true);
+    expect(result.xdr).toEqual(expect.any(String));
+    expect(result.operationCount).toBe(1);
+  });
+
+  it('charges the base fee per operation', () => {
+    const spec = paymentSpec();
+    const two = buildTransactionXdr({
+      ...spec,
+      operations: [
+        ...spec.operations,
+        { id: 'op2', type: 'payment', destination, amount: '2', assetCode: 'XLM' },
+      ],
+    });
+
+    // The fee on the envelope is the total, not the per-operation figure.
+    expect(Number(two.totalFee)).toBe(Number(spec.fee) * 2);
+  });
+
+  it('returns errors rather than throwing, since every field is user-editable', () => {
+    expect(buildTransactionXdr({ ...paymentSpec(), sourceAccount: '' }).ok).toBe(false);
+    expect(buildTransactionXdr({ ...emptySpec(keys.publicKey), operations: [] }).ok).toBe(false);
+
+    const badDestination = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'payment', destination: 'nonsense', amount: '1' }],
+    });
+    expect(badDestination.ok).toBe(false);
+    expect(badDestination.error).toEqual(expect.any(String));
+  });
+
+  it('requires an issuer for a non-native asset', () => {
+    const result = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'payment', destination, amount: '1', assetCode: 'USDC' }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/issuer/);
+  });
+});
+
+describe('decoding', () => {
+  it('round-trips source, operations and asset', () => {
+    const built = buildTransactionXdr(paymentSpec());
+    const decoded = decodeEnvelope(built.xdr!, Networks.TESTNET);
+
+    expect(decoded.ok).toBe(true);
+    expect(decoded.sourceAccount).toBe(keys.publicKey);
+    expect(decoded.operations?.[0].type).toBe('payment');
+    expect(decoded.operations?.[0].details.destination).toBe(destination);
+    expect(decoded.operations?.[0].details.asset).toBe('XLM (native)');
+    expect(decoded.transactionHash).toHaveLength(64);
+  });
+
+  it('records signatures only when the transaction is signed', () => {
+    const unsigned = buildTransactionXdr(paymentSpec());
+    const signed = buildTransactionXdr(paymentSpec(), keys.secret);
+
+    expect(decodeEnvelope(unsigned.xdr!, Networks.TESTNET).signatureCount).toBe(0);
+    expect(decodeEnvelope(signed.xdr!, Networks.TESTNET).signatureCount).toBe(1);
+  });
+
+  it('produces a different hash per network for the same envelope', () => {
+    const built = buildTransactionXdr(paymentSpec());
+    const onTestnet = decodeEnvelope(built.xdr!, Networks.TESTNET).transactionHash;
+    const onPublic = decodeEnvelope(built.xdr!, Networks.PUBLIC).transactionHash;
+
+    // Signatures commit to a hash that includes the passphrase - this is what
+    // stops a testnet transaction being replayed on the public network.
+    expect(onTestnet).not.toBe(onPublic);
+  });
+
+  it('rejects garbage without throwing', () => {
+    expect(decodeEnvelope('not-xdr', Networks.TESTNET).ok).toBe(false);
+    expect(decodeEnvelope('', Networks.TESTNET).ok).toBe(false);
+  });
+});
+
+describe('operation coverage', () => {
+  it('builds and decodes createAccount', () => {
+    const built = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'createAccount', destination, startingBalance: '5' }],
+    });
+    expect(built.ok).toBe(true);
+    expect(decodeEnvelope(built.xdr!, Networks.TESTNET).operations?.[0].type).toBe('createAccount');
+  });
+
+  it('distinguishes a manageData value from a deletion', () => {
+    const withValue = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'manageData', name: 'course', value: 'stellar-101' }],
+    });
+    const deletion = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'manageData', name: 'course' }],
+    });
+
+    expect(decodeEnvelope(withValue.xdr!, Networks.TESTNET).operations?.[0].details.value).toBe('stellar-101');
+    // An absent value deletes the entry; that is not the same as storing "".
+    expect(decodeEnvelope(deletion.xdr!, Networks.TESTNET).operations?.[0].details.value).toBe('(deleted)');
+  });
+
+  it('carries a non-native asset as code:issuer', () => {
+    const issuer = randomKeypair().publicKey;
+    const built = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [
+        { id: 'op1', type: 'payment', destination, amount: '1', assetCode: 'USDC', assetIssuer: issuer },
+      ],
+    });
+    expect(decodeEnvelope(built.xdr!, Networks.TESTNET).operations?.[0].details.asset).toBe(`USDC:${issuer}`);
+  });
+
+  it('builds a Soroban invokeHostFunction operation', () => {
+    const contractId = StrKey.encodeContract(Buffer.alloc(32, 7));
+    const built = buildTransactionXdr({
+      ...paymentSpec(),
+      operations: [{ id: 'op1', type: 'invokeHostFunction', contractId, functionName: 'increment' }],
+    });
+
+    expect(built.ok).toBe(true);
+    expect(decodeEnvelope(built.xdr!, Networks.TESTNET).operations?.[0].type).toBe('invokeHostFunction');
+  });
+
+  it('round-trips a text memo', () => {
+    const built = buildTransactionXdr({ ...paymentSpec(), memo: { type: 'text', value: 'hello' } });
+    expect(decodeEnvelope(built.xdr!, Networks.TESTNET).memo?.value).toBe('hello');
+  });
+});
+
+describe('verifyRoundTrip', () => {
+  it('confirms the JSON and XDR views describe one object', () => {
+    const result = verifyRoundTrip(paymentSpec());
+    expect(result.ok).toBe(true);
+    expect(result.detail).toMatch(/round-tripped/);
+  });
+
+  it('reports the reason when a spec cannot be built', () => {
+    expect(verifyRoundTrip({ ...emptySpec(keys.publicKey), operations: [] }).ok).toBe(false);
+  });
+});

--- a/frontend/src/lib/consensus-simulator.ts
+++ b/frontend/src/lib/consensus-simulator.ts
@@ -1,0 +1,496 @@
+/**
+ * consensus-simulator.ts — chain reorganisation, double-spend, and finality
+ * model for the consensus simulator (Issue #1163).
+ *
+ * # What the simulator is trying to make concrete
+ *
+ * "Confirmations" and "finality" get used as if they were the same idea. They
+ * are not, and the difference is the whole point of the comparison:
+ *
+ *   - Under **Nakamoto/PoW**, a block is never *final*. A competing branch that
+ *     accumulates more work replaces it, and every already-"confirmed"
+ *     transaction on the losing branch is undone. Waiting for N confirmations
+ *     does not make reversal impossible — it makes it *expensive*, and the cost
+ *     falls off exponentially in N. That is a probabilistic guarantee.
+ *   - Under **SCP** (and BFT protocols generally), a ledger that closes is
+ *     final. There is no heavier branch to lose to, because agreement happens
+ *     before the ledger closes rather than being settled afterwards by
+ *     accumulated work. An attacker with enough influence cannot rewrite
+ *     history; they can at worst *halt* progress. Safety is preserved at the
+ *     cost of liveness — the opposite trade from PoW, which always makes
+ *     progress and lets safety be probabilistic.
+ *
+ * # Reorg depth is the observable
+ *
+ * The model tracks concrete branches rather than a formula, so a reorg produces
+ * an actual list of transactions that were confirmed and are now not. That is
+ * what a student needs to see: not "reorgs can happen", but "these three
+ * payments unhappened".
+ */
+
+export type ConsensusModel = 'pow' | 'scp';
+
+export interface SimBlock {
+  id: string;
+  height: number;
+  /** Branch this block belongs to. */
+  branch: string;
+  parentId: string | null;
+  /** Cumulative work on this branch up to and including this block. */
+  cumulativeWork: number;
+  minedAtTick: number;
+  /** Transaction ids included in this block. */
+  txIds: string[];
+  /** Cosmetic only — a real hash would need the whole header. */
+  hash: string;
+}
+
+export interface SimTransaction {
+  id: string;
+  label: string;
+  amount: number;
+  /** Marks the two halves of a double-spend attempt. */
+  doubleSpendRole?: 'honest' | 'attacker';
+}
+
+export interface ChainState {
+  model: ConsensusModel;
+  tick: number;
+  blocks: SimBlock[];
+  /** Branch id currently considered canonical. */
+  canonicalBranch: string;
+  /** Height at which the branches diverged, if a fork exists. */
+  forkHeight: number | null;
+  events: SimEvent[];
+}
+
+export interface SimEvent {
+  tick: number;
+  kind: 'block' | 'fork' | 'reorg' | 'finalized' | 'halt' | 'double-spend';
+  message: string;
+  /** Blocks removed from the canonical chain, for a reorg. */
+  orphanedBlockIds?: string[];
+  /** Transactions that were confirmed and are no longer, for a reorg. */
+  revertedTxIds?: string[];
+  depth?: number;
+}
+
+/** Stellar closes a ledger about every 5 seconds; Bitcoin averages 600. */
+export const BLOCK_TIME_SECONDS: Record<ConsensusModel, number> = {
+  pow: 600,
+  scp: 5,
+};
+
+function makeHash(seed: string): string {
+  // Deterministic, readable, and explicitly not a real hash — labelling it as
+  // cosmetic is better than implying the simulator does proof-of-work.
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export function createChain(model: ConsensusModel): ChainState {
+  const genesis: SimBlock = {
+    id: 'genesis',
+    height: 0,
+    branch: 'main',
+    parentId: null,
+    cumulativeWork: 0,
+    minedAtTick: 0,
+    txIds: [],
+    hash: makeHash('genesis'),
+  };
+
+  return {
+    model,
+    tick: 0,
+    blocks: [genesis],
+    canonicalBranch: 'main',
+    forkHeight: null,
+    events: [],
+  };
+}
+
+/** Blocks on `branch`, oldest first. Genesis belongs to every branch. */
+export function branchBlocks(state: ChainState, branch: string): SimBlock[] {
+  return state.blocks
+    .filter((b) => b.branch === branch || b.id === 'genesis')
+    .sort((a, b) => a.height - b.height);
+}
+
+/** The chain a node would currently consider canonical. */
+export function canonicalChain(state: ChainState): SimBlock[] {
+  return branchBlocks(state, state.canonicalBranch);
+}
+
+export function tipOf(state: ChainState, branch: string): SimBlock {
+  const blocks = branchBlocks(state, branch);
+  return blocks[blocks.length - 1];
+}
+
+/** Total work on a branch — the quantity PoW fork choice actually compares. */
+export function branchWork(state: ChainState, branch: string): number {
+  return tipOf(state, branch).cumulativeWork;
+}
+
+/** Distinct branch ids present in the chain, excluding the genesis-only case. */
+export function branches(state: ChainState): string[] {
+  return Array.from(new Set(state.blocks.map((b) => b.branch))).filter((b) => b !== 'genesis');
+}
+
+/**
+ * Confirmation depth of a transaction on the canonical chain.
+ *
+ * `0` means unconfirmed; `1` means it is in the tip block. Returns `null` when
+ * the transaction is not on the canonical chain at all — which is exactly the
+ * state a double-spend victim finds themselves in after a reorg.
+ */
+export function confirmationDepth(state: ChainState, txId: string): number | null {
+  const chain = canonicalChain(state);
+  const index = chain.findIndex((b) => b.txIds.includes(txId));
+  if (index === -1) return null;
+  return chain.length - index;
+}
+
+/**
+ * Probability that an attacker controlling `hashPower` of the network can
+ * still reverse a transaction buried `depth` blocks deep.
+ *
+ * The Nakamoto gambler's-ruin result: with q < 0.5 the attacker must catch up
+ * from `depth` blocks behind, and the chance of ever doing so is (q/p)^depth.
+ * At q >= 0.5 it is 1 — given enough time the attacker always catches up, which
+ * is what "51% attack" means and why no confirmation count is sufficient.
+ */
+export function reversalProbability(hashPower: number, depth: number): number {
+  const q = Math.min(Math.max(hashPower, 0), 1);
+  if (q >= 0.5) return 1;
+  if (depth <= 0) return 1;
+  return (q / (1 - q)) ** depth;
+}
+
+/**
+ * Confirmations needed to push reversal risk below `target`.
+ *
+ * Returns `Infinity` at or above 50% hash power — no finite number of
+ * confirmations makes the chain safe, which is the point being taught.
+ */
+export function confirmationsForRisk(hashPower: number, target = 0.001): number {
+  const q = Math.min(Math.max(hashPower, 0), 1);
+  if (q >= 0.5) return Infinity;
+  if (q <= 0) return 1;
+  return Math.ceil(Math.log(target) / Math.log(q / (1 - q)));
+}
+
+export interface MineOptions {
+  branch?: string;
+  txIds?: string[];
+  /** Work contributed by this block. Defaults to 1 unit. */
+  work?: number;
+}
+
+/**
+ * Append a block, then apply the fork-choice rule for the model.
+ *
+ * This is where the two consensus families visibly diverge: under PoW the
+ * canonical branch is recomputed from accumulated work after every block, and
+ * may change. Under SCP a closed ledger is final, so the canonical branch never
+ * moves — a competing branch simply cannot be adopted.
+ */
+export function mineBlock(state: ChainState, options: MineOptions = {}): ChainState {
+  const branch = options.branch ?? state.canonicalBranch;
+  const parent = parentForBranch(state, branch);
+  const tick = state.tick + 1;
+
+  const block: SimBlock = {
+    id: `${branch}-${parent.height + 1}`,
+    height: parent.height + 1,
+    branch,
+    parentId: parent.id,
+    cumulativeWork: parent.cumulativeWork + (options.work ?? 1),
+    minedAtTick: tick,
+    txIds: options.txIds ?? [],
+    hash: makeHash(`${branch}:${parent.height + 1}:${parent.hash}`),
+  };
+
+  const events: SimEvent[] = [
+    {
+      tick,
+      kind: 'block',
+      message: `Block ${block.height} produced on branch "${branch}"`,
+    },
+  ];
+
+  const blocks = [...state.blocks, block];
+  const next: ChainState = { ...state, tick, blocks, events: [...state.events, ...events] };
+
+  if (state.model === 'scp') {
+    // A closed ledger is final. A competing branch can exist in the model, but
+    // it is never adopted, so nothing already confirmed is ever undone.
+    if (branch !== state.canonicalBranch) {
+      next.events.push({
+        tick,
+        kind: 'finalized',
+        message:
+          `Branch "${branch}" cannot replace the canonical chain: ledger ${parent.height} is already ` +
+          'final under SCP. Validators would halt rather than accept a conflicting history.',
+      });
+    } else {
+      next.events.push({
+        tick,
+        kind: 'finalized',
+        message: `Ledger ${block.height} closed and is final — no reorg can revert it.`,
+      });
+    }
+    return next;
+  }
+
+  // PoW: recompute fork choice by cumulative work.
+  return applyForkChoice(next, tick);
+}
+
+/**
+ * PoW fork choice: adopt whichever branch carries the most work.
+ *
+ * When that changes the canonical branch, the blocks that were canonical become
+ * orphans and their transactions return to unconfirmed. The reverted list is
+ * the thing worth showing — it is the concrete cost of probabilistic finality.
+ */
+function applyForkChoice(state: ChainState, tick: number): ChainState {
+  const candidates = branches(state);
+  if (candidates.length <= 1) return state;
+
+  const heaviest = candidates.reduce((best, branch) =>
+    branchWork(state, branch) > branchWork(state, best) ? branch : best
+  );
+
+  if (heaviest === state.canonicalBranch) return state;
+
+  const previousChain = canonicalChain(state);
+  const newChain = branchBlocks(state, heaviest);
+
+  const forkHeight = state.forkHeight ?? 0;
+  const orphaned = previousChain.filter((b) => b.height > forkHeight);
+  const adopted = newChain.filter((b) => b.height > forkHeight);
+
+  const adoptedTxIds = new Set(adopted.flatMap((b) => b.txIds));
+  // A transaction present on both branches was not reverted — only those that
+  // exist solely on the abandoned branch actually unhappen.
+  const revertedTxIds = orphaned.flatMap((b) => b.txIds).filter((id) => !adoptedTxIds.has(id));
+
+  return {
+    ...state,
+    canonicalBranch: heaviest,
+    events: [
+      ...state.events,
+      {
+        tick,
+        kind: 'reorg',
+        depth: orphaned.length,
+        orphanedBlockIds: orphaned.map((b) => b.id),
+        revertedTxIds,
+        message:
+          `Reorg ${orphaned.length} block${orphaned.length === 1 ? '' : 's'} deep: branch ` +
+          `"${heaviest}" carries more work. ${revertedTxIds.length} previously confirmed ` +
+          `transaction${revertedTxIds.length === 1 ? '' : 's'} reverted.`,
+      },
+    ],
+  };
+}
+
+/**
+ * Parent block for the next block on `branch`.
+ *
+ * A branch that has not produced a block yet builds on the canonical block at
+ * the fork height — not on genesis, and not on the canonical tip. Getting this
+ * wrong is what makes a "fork" silently behave as an extension: if the new
+ * branch starts above the tip it can never replace anything, and no reorg is
+ * possible however much work it accumulates.
+ */
+function parentForBranch(state: ChainState, branch: string): SimBlock {
+  const own = state.blocks.filter((b) => b.branch === branch);
+  if (own.length > 0) {
+    return own.reduce((best, b) => (b.height > best.height ? b : best));
+  }
+
+  const forkHeight = state.forkHeight ?? 0;
+  const canonical = canonicalChain(state);
+  return canonical.find((b) => b.height === forkHeight) ?? canonical[0];
+}
+
+/**
+ * Open a competing branch.
+ *
+ * `forkAtHeight` is the last block the two branches share. It defaults to one
+ * below the current tip, so the new branch actually competes for a block that
+ * already exists — forking at the tip would produce a branch that only extends
+ * the chain and can never cause a reorg.
+ */
+export function forkChain(state: ChainState, branchName: string, forkAtHeight?: number): ChainState {
+  const tip = tipOf(state, state.canonicalBranch);
+  const height = Math.max(0, forkAtHeight ?? tip.height - 1);
+
+  return {
+    ...state,
+    forkHeight: height,
+    events: [
+      ...state.events,
+      {
+        tick: state.tick,
+        kind: 'fork',
+        message:
+          state.model === 'scp'
+            ? `Competing branch "${branchName}" created at ledger ${height}. Under SCP this cannot win — it can only stall consensus.`
+            : `Fork at height ${height}: branch "${branchName}" now competes with "${state.canonicalBranch}" for blocks ${height + 1} onward.`,
+      },
+    ],
+  };
+}
+
+export interface DoubleSpendScenario {
+  /** Attacker's share of hash power, 0..1. */
+  hashPower: number;
+  /** Confirmations the merchant waits for before releasing goods. */
+  merchantConfirmations: number;
+  amount: number;
+}
+
+export interface DoubleSpendOutcome {
+  succeeded: boolean;
+  model: ConsensusModel;
+  reversalProbability: number;
+  confirmationsForSafety: number;
+  finalState: ChainState;
+  narrative: string[];
+}
+
+/**
+ * Run the classic double-spend: pay the merchant on the public chain, mine a
+ * conflicting payment privately, then release the private branch.
+ *
+ * Under PoW with majority hash power the private branch overtakes and the
+ * merchant's payment is reverted — after they shipped. Under SCP the same
+ * sequence cannot even be attempted: the ledger containing the payment is final
+ * before the attacker's branch exists.
+ */
+export function simulateDoubleSpend(
+  model: ConsensusModel,
+  scenario: DoubleSpendScenario
+): DoubleSpendOutcome {
+  const { hashPower, merchantConfirmations, amount } = scenario;
+  const narrative: string[] = [];
+
+  let state = createChain(model);
+  const honestTx = 'tx-honest';
+  const attackerTx = 'tx-attacker';
+
+  // The attacker pays the merchant on the public chain.
+  state = mineBlock(state, { txIds: [honestTx] });
+  narrative.push(`Attacker pays the merchant ${amount} on the public chain (block 1).`);
+
+  // The merchant waits for their confirmations.
+  for (let i = 1; i < merchantConfirmations; i += 1) {
+    state = mineBlock(state);
+  }
+  narrative.push(
+    `Merchant waits ${merchantConfirmations} confirmation${merchantConfirmations === 1 ? '' : 's'} and ships the goods.`
+  );
+
+  if (model === 'scp') {
+    narrative.push(
+      'Under SCP the ledger holding that payment closed and is final. There is no heavier ' +
+        'branch to switch to, so the payment cannot be reverted at any confirmation count.'
+    );
+    narrative.push(
+      'An attacker with enough influence can stall the network — validators halt rather than ' +
+        'diverge — but halting is a liveness failure, not a reversal.'
+    );
+
+    return {
+      succeeded: false,
+      model,
+      reversalProbability: 0,
+      confirmationsForSafety: 1,
+      finalState: state,
+      narrative,
+    };
+  }
+
+  // Attacker builds privately from *below* the block containing the payment —
+  // forking above it could never remove it, which is the whole objective.
+  state = forkChain(state, 'attacker', 0);
+  narrative.push(
+    `Attacker mines privately from the fork point with ${(hashPower * 100).toFixed(0)}% of hash power, ` +
+      'including a conflicting transaction that pays themselves.'
+  );
+
+  const publicHeight = tipOf(state, state.canonicalBranch).height;
+  const forkHeight = state.forkHeight ?? 0;
+  const blocksNeeded = publicHeight - forkHeight + 1;
+
+  // With majority hash power the attacker outpaces the public chain and can
+  // always produce a heavier branch; below 50% this is the optimistic case.
+  const attackerWork = hashPower >= 0.5 ? 2 : 1;
+
+  for (let i = 0; i < blocksNeeded; i += 1) {
+    state = mineBlock(state, {
+      branch: 'attacker',
+      txIds: i === 0 ? [attackerTx] : [],
+      work: attackerWork,
+    });
+  }
+
+  const reverted = confirmationDepth(state, honestTx) === null;
+  const probability = reversalProbability(hashPower, merchantConfirmations);
+
+  narrative.push(
+    reverted
+      ? `Attacker releases the private branch. It carries more work, so nodes switch to it — the ` +
+        `merchant's payment is gone, and the goods have already shipped.`
+      : `Attacker releases the private branch, but it does not out-weigh the public chain. The ` +
+        `payment stands.`
+  );
+  narrative.push(
+    hashPower >= 0.5
+      ? 'At 50% or more hash power this succeeds regardless of how long the merchant waits — no confirmation count is safe.'
+      : `At ${(hashPower * 100).toFixed(0)}% hash power the chance of reversing ${merchantConfirmations} ` +
+        `confirmations is about ${(probability * 100).toFixed(4)}%.`
+  );
+
+  return {
+    succeeded: reverted,
+    model,
+    reversalProbability: probability,
+    confirmationsForSafety: confirmationsForRisk(hashPower),
+    finalState: state,
+    narrative,
+  };
+}
+
+/**
+ * Chain state as it stood at `tick`, for the timeline scrubber.
+ *
+ * Rebuilt by replaying rather than snapshotting every tick: the history is
+ * small, and replaying guarantees the scrubbed view and the live view are
+ * produced by the same code path.
+ */
+export function stateAtTick(state: ChainState, tick: number): ChainState {
+  const blocks = state.blocks.filter((b) => b.minedAtTick <= tick);
+  const events = state.events.filter((e) => e.tick <= tick);
+
+  // Fork choice as it stood then, so scrubbing back before a reorg shows the
+  // chain the network actually believed at that moment.
+  const present = Array.from(new Set(blocks.map((b) => b.branch))).filter((b) => b !== 'genesis');
+  let canonical = state.canonicalBranch;
+
+  if (state.model === 'pow' && present.length > 0) {
+    const at = { ...state, blocks };
+    canonical = present.reduce((best, branch) =>
+      branchWork(at, branch) > branchWork(at, best) ? branch : best
+    );
+  }
+
+  return { ...state, tick, blocks, events, canonicalBranch: canonical };
+}

--- a/frontend/src/lib/merkle-sha256.ts
+++ b/frontend/src/lib/merkle-sha256.ts
@@ -1,0 +1,386 @@
+/**
+ * merkle-sha256.ts — SHA-256 Merkle trees, inclusion proofs, and tamper
+ * simulation for the Merkle visualiser (Issue #1159).
+ *
+ * # Why this is not `merkle-tree-builder.ts`
+ *
+ * The existing builder hashes with `stableHash`, which is FNV-1a: a 32-bit,
+ * non-cryptographic hash. That is fine for the airdrop demo it backs, where
+ * the hash is only an identifier. It is the wrong primitive for a tool whose
+ * entire lesson is cryptographic immutability — a student could find an FNV
+ * collision by hand, and the tamper demo would be teaching that Merkle roots
+ * are forgeable. This module uses real SHA-256 so the exported proofs are
+ * valid test vectors against an actual contract.
+ *
+ * # Second-preimage resistance
+ *
+ * Leaves are hashed with a `0x00` prefix and internal nodes with `0x01`. Without
+ * that domain separation an attacker can present an *internal* node's preimage
+ * as if it were a leaf: the concatenation of two child hashes is 64 bytes, and
+ * a tree built over 64-byte leaves would hash it identically. Prefixing makes
+ * the two domains disjoint, which is the standard fix (RFC 6962 uses the same
+ * construction).
+ *
+ * # Odd node counts
+ *
+ * An unpaired node is promoted to the next level rather than duplicated.
+ * Duplicating it — the Bitcoin approach — admits CVE-2012-2459, where two
+ * distinct trees produce the same root. Promotion has no such ambiguity, and
+ * for a teaching tool the honest construction matters more than matching
+ * Bitcoin's quirk.
+ */
+
+export interface MerkleNode {
+  id: string;
+  hash: string;
+  level: number;
+  index: number;
+  isLeaf: boolean;
+  /** Original input string; leaves only. */
+  value?: string;
+  left?: MerkleNode;
+  right?: MerkleNode;
+  /** True when the node was carried up unpaired. */
+  promoted?: boolean;
+}
+
+export interface MerkleProofStep {
+  hash: string;
+  /** Which side the sibling sits on — determines concatenation order. */
+  position: 'left' | 'right';
+  /** Level the sibling lives at; 0 is the leaf row. */
+  level: number;
+  /** Sibling's index within its level, for highlighting in the diagram. */
+  index: number;
+}
+
+export interface MerkleTree {
+  root: MerkleNode;
+  /** `levels[0]` is the leaf row; the last entry holds the root alone. */
+  levels: MerkleNode[][];
+  leaves: string[];
+  depth: number;
+}
+
+/** One step of the verification walk, for the step-by-step animation. */
+export interface VerificationStep {
+  stepNumber: number;
+  /** Hash carried into this step. */
+  currentHash: string;
+  /** Sibling combined at this step. */
+  siblingHash: string;
+  position: 'left' | 'right';
+  /** Exact string fed to SHA-256, so the student can reproduce it. */
+  concatenation: string;
+  /** Result of this step, which becomes the next step's `currentHash`. */
+  resultHash: string;
+  level: number;
+}
+
+export interface VerificationResult {
+  valid: boolean;
+  steps: VerificationStep[];
+  computedRoot: string;
+  expectedRoot: string;
+}
+
+/** A proof, in the shape exported as a JSON test vector. */
+export interface ProofBundle {
+  leaf: string;
+  leafHash: string;
+  leafIndex: number;
+  root: string;
+  proof: MerkleProofStep[];
+  algorithm: 'sha256';
+  leafPrefix: '0x00';
+  nodePrefix: '0x01';
+}
+
+const LEAF_PREFIX = '00';
+const NODE_PREFIX = '01';
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * SHA-256 via Web Crypto.
+ *
+ * Async because `crypto.subtle` is, which is why the whole tree API is async.
+ * Bundling a synchronous SHA-256 implementation would avoid that, but at the
+ * cost of shipping crypto code the platform already provides correctly.
+ */
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', bytes as unknown as BufferSource);
+  return toHex(digest);
+}
+
+/** `SHA256(0x00 || utf8(value))` — a leaf hash. */
+export async function hashLeaf(value: string): Promise<string> {
+  return sha256(concatBytes(hexToBytes(LEAF_PREFIX), new TextEncoder().encode(value)));
+}
+
+/** `SHA256(0x01 || left || right)` — an internal node hash. */
+export async function hashPair(left: string, right: string): Promise<string> {
+  return sha256(concatBytes(hexToBytes(NODE_PREFIX), hexToBytes(left), hexToBytes(right)));
+}
+
+/** Trim, drop empties, and de-duplicate while preserving order. */
+export function normalizeLeaves(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of values) {
+    const value = raw.trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+/** Build the tree bottom-up. Returns `null` for an empty leaf set. */
+export async function buildMerkleTree(values: string[]): Promise<MerkleTree | null> {
+  const leaves = normalizeLeaves(values);
+  if (leaves.length === 0) return null;
+
+  let level: MerkleNode[] = await Promise.all(
+    leaves.map(async (value, index) => ({
+      id: `L0-${index}`,
+      hash: await hashLeaf(value),
+      level: 0,
+      index,
+      isLeaf: true,
+      value,
+    }))
+  );
+
+  const levels: MerkleNode[][] = [level];
+
+  while (level.length > 1) {
+    const levelNumber = levels.length;
+    const next: MerkleNode[] = [];
+
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      const right = level[i + 1];
+
+      if (!right) {
+        // Promote rather than duplicate — see the module note on CVE-2012-2459.
+        next.push({ ...left, id: `L${levelNumber}-${next.length}`, level: levelNumber, index: next.length, promoted: true });
+        continue;
+      }
+
+      next.push({
+        id: `L${levelNumber}-${next.length}`,
+        // eslint-disable-next-line no-await-in-loop
+        hash: await hashPair(left.hash, right.hash),
+        level: levelNumber,
+        index: next.length,
+        isLeaf: false,
+        left,
+        right,
+      });
+    }
+
+    levels.push(next);
+    level = next;
+  }
+
+  return { root: level[0], levels, leaves, depth: levels.length - 1 };
+}
+
+/**
+ * Audit path for a leaf: the sibling at each level needed to rebuild the root.
+ *
+ * A promoted node has no sibling at that level, so it contributes no step —
+ * which is exactly why the proof for such a leaf is shorter than the tree depth.
+ */
+export function getProof(tree: MerkleTree, leafIndex: number): MerkleProofStep[] {
+  if (leafIndex < 0 || leafIndex >= tree.levels[0].length) return [];
+
+  const steps: MerkleProofStep[] = [];
+  let index = leafIndex;
+
+  for (let level = 0; level < tree.levels.length - 1; level += 1) {
+    const nodes = tree.levels[level];
+    const isRightChild = index % 2 === 1;
+    const siblingIndex = isRightChild ? index - 1 : index + 1;
+    const sibling = nodes[siblingIndex];
+
+    if (sibling) {
+      steps.push({
+        hash: sibling.hash,
+        // The sibling's side, which fixes the concatenation order on the way up.
+        position: isRightChild ? 'left' : 'right',
+        level,
+        index: siblingIndex,
+      });
+    }
+
+    index = Math.floor(index / 2);
+  }
+
+  return steps;
+}
+
+/**
+ * Replay a proof, recording each step.
+ *
+ * The steps are the point: the student sees the exact bytes hashed at every
+ * level rather than a bare pass/fail.
+ */
+export async function verifyProof(
+  leafValue: string,
+  proof: MerkleProofStep[],
+  expectedRoot: string
+): Promise<VerificationResult> {
+  let currentHash = await hashLeaf(leafValue);
+  const steps: VerificationStep[] = [];
+
+  for (let i = 0; i < proof.length; i += 1) {
+    const step = proof[i];
+    const [left, right] =
+      step.position === 'left' ? [step.hash, currentHash] : [currentHash, step.hash];
+
+    // eslint-disable-next-line no-await-in-loop
+    const resultHash = await hashPair(left, right);
+
+    steps.push({
+      stepNumber: i + 1,
+      currentHash,
+      siblingHash: step.hash,
+      position: step.position,
+      concatenation: `0x01 || ${left.slice(0, 8)}… || ${right.slice(0, 8)}…`,
+      resultHash,
+      level: step.level,
+    });
+
+    currentHash = resultHash;
+  }
+
+  return {
+    valid: currentHash === expectedRoot,
+    steps,
+    computedRoot: currentHash,
+    expectedRoot,
+  };
+}
+
+/** Ids of every node on the path from a leaf to the root, for highlighting. */
+export function getPathNodeIds(tree: MerkleTree, leafIndex: number): string[] {
+  const ids: string[] = [];
+  let index = leafIndex;
+
+  for (let level = 0; level < tree.levels.length; level += 1) {
+    const node = tree.levels[level][index];
+    if (node) ids.push(node.id);
+    index = Math.floor(index / 2);
+  }
+
+  return ids;
+}
+
+/** Ids of the sibling nodes a proof consumes, for highlighting. */
+export function getSiblingNodeIds(tree: MerkleTree, proof: MerkleProofStep[]): string[] {
+  return proof
+    .map((step) => tree.levels[step.level]?.[step.index]?.id)
+    .filter((id): id is string => Boolean(id));
+}
+
+export interface TamperResult {
+  original: MerkleTree;
+  tampered: MerkleTree;
+  /** Node ids whose hash changed — the cascade up to the root. */
+  changedNodeIds: string[];
+  rootChanged: boolean;
+  originalRoot: string;
+  tamperedRoot: string;
+}
+
+/**
+ * Rebuild the tree with one leaf altered and report which hashes changed.
+ *
+ * The cascade is the lesson: editing one leaf changes its hash, which changes
+ * its parent, and so on to the root. Nothing else in the tree moves — only the
+ * path — which is also why a proof is `log n` and not `n`.
+ */
+export async function simulateTamper(
+  tree: MerkleTree,
+  leafIndex: number,
+  newValue: string
+): Promise<TamperResult | null> {
+  if (leafIndex < 0 || leafIndex >= tree.leaves.length) return null;
+
+  const tamperedLeaves = [...tree.leaves];
+  tamperedLeaves[leafIndex] = newValue;
+
+  const tampered = await buildMerkleTree(tamperedLeaves);
+  if (!tampered) return null;
+
+  const changedNodeIds: string[] = [];
+  for (let level = 0; level < tree.levels.length; level += 1) {
+    const before = tree.levels[level];
+    const after = tampered.levels[level];
+    for (let i = 0; i < before.length; i += 1) {
+      if (after[i] && before[i].hash !== after[i].hash) {
+        changedNodeIds.push(before[i].id);
+      }
+    }
+  }
+
+  return {
+    original: tree,
+    tampered,
+    changedNodeIds,
+    rootChanged: tree.root.hash !== tampered.root.hash,
+    originalRoot: tree.root.hash,
+    tamperedRoot: tampered.root.hash,
+  };
+}
+
+/**
+ * Proof as an exportable JSON test vector.
+ *
+ * The prefixes are included because a contract cannot verify the proof without
+ * knowing the domain-separation scheme — a vector that omits them is not
+ * reproducible.
+ */
+export async function exportProofBundle(
+  tree: MerkleTree,
+  leafIndex: number
+): Promise<ProofBundle | null> {
+  const leaf = tree.leaves[leafIndex];
+  if (leaf === undefined) return null;
+
+  return {
+    leaf,
+    leafHash: tree.levels[0][leafIndex].hash,
+    leafIndex,
+    root: tree.root.hash,
+    proof: getProof(tree, leafIndex),
+    algorithm: 'sha256',
+    leafPrefix: '0x00',
+    nodePrefix: '0x01',
+  };
+}

--- a/frontend/src/lib/soroban-storage-model.ts
+++ b/frontend/src/lib/soroban-storage-model.ts
@@ -1,0 +1,374 @@
+/**
+ * soroban-storage-model.ts — Soroban storage tiers, TTL lifecycles, and rent
+ * arithmetic for the storage visualiser (Issue #1162).
+ *
+ * # The distinction students get wrong
+ *
+ * "Temporary vs Persistent" sounds like a difference of duration. It is not —
+ * both have a TTL and both expire. The difference is **what expiry means**:
+ *
+ *   - A **Temporary** entry that expires is *deleted*. The data is gone. It
+ *     cannot be restored, and reading the key afterwards behaves as if it was
+ *     never written.
+ *   - A **Persistent** entry that expires is *archived*. The data still exists
+ *     and can be brought back with `restore`, at a cost.
+ *
+ * That is why "use Temporary to save money" is only safe for data you can
+ * recompute. Losing a cached price feed is a re-fetch; losing a balance is an
+ * incident.
+ *
+ * **Instance** storage is a third case that behaves differently again: it lives
+ * inside the contract instance entry, so every key shares one TTL. Extending
+ * any of it extends all of it, and if the instance is archived the contract
+ * itself is unreachable until restored.
+ *
+ * # On the numbers
+ *
+ * The fee rates below are network parameters, not constants. They are read from
+ * the ledger config and have changed between protocol versions. They are
+ * exported and overridable so the calculator can be pointed at current values
+ * rather than quietly drifting out of date.
+ */
+
+export type StorageTier = 'instance' | 'temporary' | 'persistent';
+
+/** What happens when an entry's TTL runs out. */
+export type ExpiryBehaviour = 'deleted' | 'archived';
+
+export interface TierProfile {
+  tier: StorageTier;
+  label: string;
+  expiryBehaviour: ExpiryBehaviour;
+  /** Can the data be recovered after expiry? */
+  restorable: boolean;
+  /** Do all keys in this tier share a single TTL? */
+  sharedTtl: boolean;
+  maxTtlLedgers: number;
+  description: string;
+  useWhen: string;
+  avoidWhen: string;
+}
+
+/** ~5 seconds per ledger on Stellar. */
+export const LEDGERS_PER_DAY = 17_280;
+
+/**
+ * Network fee parameters. Defaults approximate Stellar mainnet; override with
+ * live values from the ledger config for a real projection.
+ */
+export interface RentParameters {
+  /** Stroops per byte per ledger for persistent entries. */
+  persistentRentRateStroops: number;
+  /** Stroops per byte per ledger for temporary entries. */
+  temporaryRentRateStroops: number;
+  /** Flat write fee per entry, in stroops. */
+  writeFeeStroops: number;
+  /** Flat cost to restore one archived entry, in stroops. */
+  restoreFeeStroops: number;
+  /** Bytes of overhead the ledger adds to every entry. */
+  entryOverheadBytes: number;
+}
+
+export const DEFAULT_RENT_PARAMETERS: RentParameters = {
+  persistentRentRateStroops: 0.0002,
+  temporaryRentRateStroops: 0.00002,
+  writeFeeStroops: 1_000,
+  restoreFeeStroops: 40_000,
+  entryOverheadBytes: 48,
+};
+
+export const STROOPS_PER_XLM = 10_000_000;
+
+export const TIER_PROFILES: Record<StorageTier, TierProfile> = {
+  instance: {
+    tier: 'instance',
+    label: 'Instance',
+    expiryBehaviour: 'archived',
+    restorable: true,
+    sharedTtl: true,
+    // Instance data shares the contract instance's TTL cap.
+    maxTtlLedgers: LEDGERS_PER_DAY * 30,
+    description:
+      'Stored inside the contract instance entry. Every key shares one TTL, so extending any of it extends all of it.',
+    useWhen: 'Small, global configuration that the contract always needs: admin address, fee settings, a version number.',
+    avoidWhen:
+      'Anything per-user or unbounded. It all shares one entry, so it grows the instance and everyone pays to extend it.',
+  },
+  temporary: {
+    tier: 'temporary',
+    label: 'Temporary',
+    expiryBehaviour: 'deleted',
+    restorable: false,
+    sharedTtl: false,
+    maxTtlLedgers: LEDGERS_PER_DAY * 1,
+    description:
+      'Cheapest tier. When the TTL runs out the entry is deleted outright — there is no restore, and the data is unrecoverable.',
+    useWhen: 'Data you can recompute or re-fetch: price cache, nonce within a session, short-lived rate-limit counters.',
+    avoidWhen:
+      'Anything you cannot reconstruct. Balances, ownership, and history must never live here — expiry is silent data loss.',
+  },
+  persistent: {
+    tier: 'persistent',
+    label: 'Persistent',
+    expiryBehaviour: 'archived',
+    restorable: true,
+    sharedTtl: false,
+    maxTtlLedgers: LEDGERS_PER_DAY * 30,
+    description:
+      'Most expensive tier. On expiry the entry is archived rather than deleted, and can be brought back with restore.',
+    useWhen: 'State of record: balances, ownership, anything whose loss would be a correctness bug.',
+    avoidWhen: 'Large caches you could rebuild — you are paying archival guarantees for data that does not need them.',
+  },
+};
+
+export interface StorageEntry {
+  id: string;
+  key: string;
+  tier: StorageTier;
+  /** Payload size, excluding ledger overhead. */
+  sizeBytes: number;
+  /** Ledger at which the entry was created or last extended. */
+  createdAtLedger: number;
+  /** Ledger at which it expires. */
+  expiresAtLedger: number;
+}
+
+export type EntryState = 'live' | 'expired-archived' | 'expired-deleted';
+
+/** Billable size: payload plus the ledger's per-entry overhead. */
+export function billableBytes(entry: Pick<StorageEntry, 'sizeBytes'>, params = DEFAULT_RENT_PARAMETERS): number {
+  return entry.sizeBytes + params.entryOverheadBytes;
+}
+
+/** Ledgers remaining before expiry; never negative. */
+export function ledgersRemaining(entry: StorageEntry, currentLedger: number): number {
+  return Math.max(0, entry.expiresAtLedger - currentLedger);
+}
+
+/**
+ * What has happened to this entry at `currentLedger`.
+ *
+ * The tier determines the *kind* of expiry, which is the whole lesson — the
+ * same elapsed time deletes a temporary entry and archives a persistent one.
+ */
+export function entryState(entry: StorageEntry, currentLedger: number): EntryState {
+  if (currentLedger < entry.expiresAtLedger) return 'live';
+  return TIER_PROFILES[entry.tier].expiryBehaviour === 'deleted'
+    ? 'expired-deleted'
+    : 'expired-archived';
+}
+
+export interface RentQuote {
+  billableBytes: number;
+  ledgers: number;
+  ratePerBytePerLedger: number;
+  rentStroops: number;
+  writeStroops: number;
+  totalStroops: number;
+  totalXlm: number;
+}
+
+/**
+ * Cost of holding an entry for `ledgers`.
+ *
+ * Instance entries are billed at the persistent rate — they are archived, not
+ * deleted, and priced accordingly. The saving from instance storage is that one
+ * entry covers many keys, not a cheaper rate.
+ */
+export function quoteRent(
+  sizeBytes: number,
+  tier: StorageTier,
+  ledgers: number,
+  params: RentParameters = DEFAULT_RENT_PARAMETERS
+): RentQuote {
+  const bytes = sizeBytes + params.entryOverheadBytes;
+  const rate =
+    tier === 'temporary' ? params.temporaryRentRateStroops : params.persistentRentRateStroops;
+
+  const rentStroops = bytes * rate * Math.max(0, ledgers);
+  const writeStroops = params.writeFeeStroops;
+  const totalStroops = rentStroops + writeStroops;
+
+  return {
+    billableBytes: bytes,
+    ledgers,
+    ratePerBytePerLedger: rate,
+    rentStroops,
+    writeStroops,
+    totalStroops,
+    totalXlm: totalStroops / STROOPS_PER_XLM,
+  };
+}
+
+/** Convenience wrapper for quoting in days rather than ledgers. */
+export function quoteRentForDays(
+  sizeBytes: number,
+  tier: StorageTier,
+  days: number,
+  params: RentParameters = DEFAULT_RENT_PARAMETERS
+): RentQuote {
+  return quoteRent(sizeBytes, tier, Math.round(days * LEDGERS_PER_DAY), params);
+}
+
+export interface ExtendResult {
+  ok: boolean;
+  reason?: string;
+  entry: StorageEntry;
+  quote?: RentQuote;
+}
+
+/**
+ * `extend_ttl` — push the expiry further out.
+ *
+ * Two rules that surprise people, both modelled here:
+ *
+ * 1. Extension is measured **from the current ledger**, not added to whatever
+ *    remains. Calling it repeatedly does not stack.
+ * 2. It cannot rescue an entry that has already expired. A temporary entry is
+ *    gone; a persistent one must be `restore`d first. Extending is not a
+ *    substitute for restoring, and treating it as one is the bug that turns a
+ *    missed extension into an outage.
+ */
+export function extendTtl(
+  entry: StorageEntry,
+  currentLedger: number,
+  extendToLedgers: number,
+  params: RentParameters = DEFAULT_RENT_PARAMETERS
+): ExtendResult {
+  const state = entryState(entry, currentLedger);
+
+  if (state === 'expired-deleted') {
+    return { ok: false, reason: 'Entry was deleted at expiry; temporary storage cannot be restored.', entry };
+  }
+  if (state === 'expired-archived') {
+    return { ok: false, reason: 'Entry is archived. Call restore before extending.', entry };
+  }
+
+  const profile = TIER_PROFILES[entry.tier];
+  const capped = Math.min(extendToLedgers, profile.maxTtlLedgers);
+  const newExpiry = currentLedger + capped;
+
+  // Never shorten a TTL: extend_ttl is a floor, not an assignment.
+  if (newExpiry <= entry.expiresAtLedger) {
+    return {
+      ok: true,
+      reason: 'Already live beyond the requested TTL; extend_ttl is a no-op.',
+      entry,
+      quote: quoteRent(entry.sizeBytes, entry.tier, 0, params),
+    };
+  }
+
+  const additionalLedgers = newExpiry - entry.expiresAtLedger;
+
+  return {
+    ok: true,
+    entry: { ...entry, expiresAtLedger: newExpiry },
+    quote: quoteRent(entry.sizeBytes, entry.tier, additionalLedgers, params),
+  };
+}
+
+export interface RestoreResult {
+  ok: boolean;
+  reason?: string;
+  entry: StorageEntry;
+  costStroops?: number;
+  costXlm?: number;
+}
+
+/**
+ * `restore` — bring an archived entry back.
+ *
+ * Only meaningful for tiers that archive. A temporary entry that expired was
+ * deleted, and no amount of fee brings it back — which is the single most
+ * important consequence of choosing that tier.
+ */
+export function restoreEntry(
+  entry: StorageEntry,
+  currentLedger: number,
+  restoreForLedgers: number,
+  params: RentParameters = DEFAULT_RENT_PARAMETERS
+): RestoreResult {
+  const state = entryState(entry, currentLedger);
+
+  if (state === 'live') {
+    return { ok: false, reason: 'Entry is live; nothing to restore.', entry };
+  }
+  if (state === 'expired-deleted') {
+    return { ok: false, reason: 'Temporary entries are deleted at expiry and cannot be restored.', entry };
+  }
+
+  const rent = quoteRent(entry.sizeBytes, entry.tier, restoreForLedgers, params);
+  const totalStroops = rent.rentStroops + params.restoreFeeStroops;
+
+  return {
+    ok: true,
+    entry: { ...entry, createdAtLedger: currentLedger, expiresAtLedger: currentLedger + restoreForLedgers },
+    costStroops: totalStroops,
+    costXlm: totalStroops / STROOPS_PER_XLM,
+  };
+}
+
+/**
+ * Compare what the same data costs in each tier over the same window.
+ *
+ * The comparison is the point: temporary looks dramatically cheaper until you
+ * account for what expiry does, which is why the result carries the behaviour
+ * alongside the number.
+ */
+export function compareTiers(
+  sizeBytes: number,
+  ledgers: number,
+  params: RentParameters = DEFAULT_RENT_PARAMETERS
+): Array<{ tier: StorageTier; quote: RentQuote; expiryBehaviour: ExpiryBehaviour; restorable: boolean }> {
+  return (Object.keys(TIER_PROFILES) as StorageTier[]).map((tier) => ({
+    tier,
+    quote: quoteRent(sizeBytes, tier, ledgers, params),
+    expiryBehaviour: TIER_PROFILES[tier].expiryBehaviour,
+    restorable: TIER_PROFILES[tier].restorable,
+  }));
+}
+
+/** Advance a whole entry set to a ledger, reporting each entry's fate. */
+export function simulateToLedger(
+  entries: StorageEntry[],
+  targetLedger: number
+): Array<{ entry: StorageEntry; state: EntryState; ledgersRemaining: number }> {
+  return entries.map((entry) => ({
+    entry,
+    state: entryState(entry, targetLedger),
+    ledgersRemaining: ledgersRemaining(entry, targetLedger),
+  }));
+}
+
+/** Worked `extend_ttl` / `restore` snippets, shown alongside the diagram. */
+export const CODE_EXAMPLES: Record<StorageTier, { extend: string; note: string }> = {
+  instance: {
+    extend: `// Instance storage shares ONE TTL across every key it holds.
+// Extending here extends all of it - and if the instance is
+// archived, the contract itself is unreachable until restored.
+env.storage()
+    .instance()
+    .extend_ttl(THRESHOLD_LEDGERS, EXTEND_TO_LEDGERS);`,
+    note: 'Bump the instance on entry points that are called regularly, so an active contract never drifts toward archival.',
+  },
+  temporary: {
+    extend: `// Temporary entries are DELETED at expiry - there is no restore.
+// Only put data here that you can recompute.
+env.storage()
+    .temporary()
+    .extend_ttl(&key, THRESHOLD_LEDGERS, EXTEND_TO_LEDGERS);`,
+    note: 'If losing this entry would be a correctness bug rather than a cache miss, it is in the wrong tier.',
+  },
+  persistent: {
+    extend: `// Extend when the remaining TTL drops below the threshold.
+// extend_ttl is a no-op if the entry is already live beyond
+// the target, so this is cheap to call on every access.
+env.storage()
+    .persistent()
+    .extend_ttl(&key, THRESHOLD_LEDGERS, EXTEND_TO_LEDGERS);
+
+// Already archived? extend_ttl will not help - restore first.
+// (Restoration is submitted as a separate operation.)`,
+    note: 'The common bug: extending only on write. A read-heavy entry that is never written will archive while in active use.',
+  },
+};

--- a/frontend/src/lib/xdr-inspector.ts
+++ b/frontend/src/lib/xdr-inspector.ts
@@ -1,0 +1,329 @@
+/**
+ * xdr-inspector.ts — transaction assembly and XDR envelope decoding for the
+ * builder/inspector (Issue #1161).
+ *
+ * # Why a wrapper rather than calling the SDK from the component
+ *
+ * The lesson of the tool is that a Stellar transaction is a *structure* — a
+ * source account, a sequence number, a fee, and an ordered list of operations —
+ * and that Base64 XDR is only that structure serialised. Keeping build and
+ * decode in one module means the round trip can be asserted directly:
+ * `decode(build(spec))` must reproduce `spec`. If a student edits the JSON and
+ * the XDR stops matching, that is a real finding rather than a UI bug.
+ *
+ * Everything here is pure and offline. Network calls (simulate, submit) belong
+ * to the page, so this module stays testable without a testnet.
+ */
+
+import {
+  Account,
+  Asset,
+  BASE_FEE,
+  Keypair,
+  Memo,
+  Networks,
+  Operation,
+  TransactionBuilder,
+  xdr,
+  Transaction,
+} from '@stellar/stellar-sdk';
+
+export type SupportedOperation =
+  | 'payment'
+  | 'createAccount'
+  | 'manageData'
+  | 'invokeHostFunction';
+
+export interface OperationSpec {
+  id: string;
+  type: SupportedOperation;
+  /** Operation-level source, if it differs from the transaction source. */
+  source?: string;
+  // payment
+  destination?: string;
+  amount?: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  // createAccount
+  startingBalance?: string;
+  // manageData
+  name?: string;
+  value?: string;
+  // invokeHostFunction
+  contractId?: string;
+  functionName?: string;
+}
+
+export interface TransactionSpec {
+  sourceAccount: string;
+  sequence: string;
+  fee: string;
+  networkPassphrase: string;
+  memo?: { type: 'none' | 'text' | 'id'; value?: string };
+  timeoutSeconds?: number;
+  operations: OperationSpec[];
+}
+
+export interface BuildResult {
+  ok: boolean;
+  xdr?: string;
+  error?: string;
+  /** Fee actually charged: base fee per operation. */
+  totalFee?: string;
+  operationCount?: number;
+}
+
+export const NETWORKS = {
+  testnet: Networks.TESTNET,
+  public: Networks.PUBLIC,
+} as const;
+
+/** A funded testnet account students can build against without a wallet. */
+export function randomKeypair(): { publicKey: string; secret: string } {
+  const kp = Keypair.random();
+  return { publicKey: kp.publicKey(), secret: kp.secret() };
+}
+
+export function emptySpec(sourceAccount = ''): TransactionSpec {
+  return {
+    sourceAccount,
+    sequence: '0',
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+    memo: { type: 'none' },
+    timeoutSeconds: 180,
+    operations: [],
+  };
+}
+
+function buildAsset(code?: string, issuer?: string): Asset {
+  // No code, or an explicit XLM with no issuer, is the native asset. Passing an
+  // issuer for XLM is a common mistake and produces a different asset entirely.
+  if (!code || code.toUpperCase() === 'XLM') return Asset.native();
+  if (!issuer) throw new Error(`Asset ${code} requires an issuer`);
+  return new Asset(code, issuer);
+}
+
+function buildOperation(spec: OperationSpec): xdr.Operation {
+  const withSource = spec.source ? { source: spec.source } : {};
+
+  switch (spec.type) {
+    case 'payment':
+      if (!spec.destination) throw new Error('payment requires a destination');
+      if (!spec.amount) throw new Error('payment requires an amount');
+      return Operation.payment({
+        destination: spec.destination,
+        asset: buildAsset(spec.assetCode, spec.assetIssuer),
+        amount: spec.amount,
+        ...withSource,
+      });
+
+    case 'createAccount':
+      if (!spec.destination) throw new Error('createAccount requires a destination');
+      if (!spec.startingBalance) throw new Error('createAccount requires a startingBalance');
+      return Operation.createAccount({
+        destination: spec.destination,
+        startingBalance: spec.startingBalance,
+        ...withSource,
+      });
+
+    case 'manageData':
+      if (!spec.name) throw new Error('manageData requires a name');
+      // A null value deletes the entry — distinct from an empty string, which
+      // stores a zero-length value. The distinction matters and is easy to miss.
+      return Operation.manageData({
+        name: spec.name,
+        value: spec.value === undefined || spec.value === '' ? null : spec.value,
+        ...withSource,
+      });
+
+    case 'invokeHostFunction': {
+      if (!spec.contractId) throw new Error('invokeHostFunction requires a contractId');
+      if (!spec.functionName) throw new Error('invokeHostFunction requires a functionName');
+      // Built with no arguments: the point here is to show the envelope shape
+      // of a Soroban invocation, and encoding arbitrary ScVals from free text
+      // would be a type editor rather than an XDR lesson.
+      return Operation.invokeContractFunction({
+        contract: spec.contractId,
+        function: spec.functionName,
+        args: [],
+        ...withSource,
+      });
+    }
+
+    default:
+      throw new Error(`Unsupported operation type: ${spec.type as string}`);
+  }
+}
+
+function buildMemo(memo?: TransactionSpec['memo']): Memo {
+  if (!memo || memo.type === 'none' || !memo.value) return Memo.none();
+  return memo.type === 'id' ? Memo.id(memo.value) : Memo.text(memo.value);
+}
+
+/**
+ * Assemble a spec into a signed-or-unsigned Base64 XDR envelope.
+ *
+ * Errors are returned rather than thrown: every field is student-editable, so
+ * invalid input is the normal case and deserves a readable message next to the
+ * field rather than a crashed render.
+ */
+export function buildTransactionXdr(spec: TransactionSpec, signWith?: string): BuildResult {
+  try {
+    if (!spec.sourceAccount) return { ok: false, error: 'A source account is required' };
+    if (spec.operations.length === 0) {
+      return { ok: false, error: 'A transaction needs at least one operation' };
+    }
+
+    const account = new Account(spec.sourceAccount, spec.sequence);
+    const builder = new TransactionBuilder(account, {
+      fee: spec.fee || BASE_FEE,
+      networkPassphrase: spec.networkPassphrase,
+    });
+
+    for (const operation of spec.operations) {
+      builder.addOperation(buildOperation(operation));
+    }
+
+    builder.addMemo(buildMemo(spec.memo));
+    builder.setTimeout(spec.timeoutSeconds ?? 180);
+
+    const tx = builder.build();
+
+    if (signWith) {
+      tx.sign(Keypair.fromSecret(signWith));
+    }
+
+    return {
+      ok: true,
+      xdr: tx.toEnvelope().toXDR('base64'),
+      // The fee on the envelope is the total: base fee multiplied by the
+      // operation count, not the per-operation figure that was entered.
+      totalFee: tx.fee,
+      operationCount: spec.operations.length,
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export interface DecodedOperation {
+  index: number;
+  type: string;
+  source?: string;
+  details: Record<string, string>;
+}
+
+export interface DecodedEnvelope {
+  ok: boolean;
+  error?: string;
+  sourceAccount?: string;
+  sequence?: string;
+  fee?: string;
+  memo?: { type: string; value: string };
+  timeBounds?: { minTime: string; maxTime: string } | null;
+  signatureCount?: number;
+  operations?: DecodedOperation[];
+  /** Hash the signatures cover — network-specific, which is the trap below. */
+  transactionHash?: string;
+}
+
+function describeOperation(op: Operation, index: number): DecodedOperation {
+  const details: Record<string, string> = {};
+
+  switch (op.type) {
+    case 'payment':
+      details.destination = op.destination;
+      details.amount = op.amount;
+      details.asset = op.asset.isNative() ? 'XLM (native)' : `${op.asset.getCode()}:${op.asset.getIssuer()}`;
+      break;
+    case 'createAccount':
+      details.destination = op.destination;
+      details.startingBalance = op.startingBalance;
+      break;
+    case 'manageData':
+      details.name = op.name;
+      details.value = op.value ? op.value.toString('utf8') : '(deleted)';
+      break;
+    case 'invokeHostFunction':
+      details.function = 'invokeHostFunction';
+      break;
+    default:
+      break;
+  }
+
+  return { index, type: op.type, source: op.source, details };
+}
+
+/**
+ * Decode a Base64 XDR envelope back into readable fields.
+ *
+ * The network passphrase is required, not optional: signatures commit to a hash
+ * that includes it, so the same envelope decodes to a *different* transaction
+ * hash on testnet and mainnet. That is the mechanism preventing a testnet
+ * transaction from being replayed on the public network, and it is worth
+ * surfacing rather than hiding behind a default.
+ */
+export function decodeEnvelope(base64: string, networkPassphrase: string): DecodedEnvelope {
+  try {
+    if (!base64.trim()) return { ok: false, error: 'Paste a Base64 XDR envelope to decode' };
+
+    const tx = new Transaction(base64.trim(), networkPassphrase);
+
+    const memoValue =
+      tx.memo.value === undefined || tx.memo.value === null
+        ? ''
+        : Buffer.isBuffer(tx.memo.value)
+          ? tx.memo.value.toString('utf8')
+          : String(tx.memo.value);
+
+    return {
+      ok: true,
+      sourceAccount: tx.source,
+      sequence: tx.sequence,
+      fee: tx.fee,
+      memo: { type: tx.memo.type, value: memoValue },
+      timeBounds: tx.timeBounds
+        ? { minTime: String(tx.timeBounds.minTime), maxTime: String(tx.timeBounds.maxTime) }
+        : null,
+      signatureCount: tx.signatures.length,
+      operations: tx.operations.map((op, i) => describeOperation(op as Operation, i)),
+      transactionHash: tx.hash().toString('hex'),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? `Could not decode envelope: ${error.message}`
+          : 'Could not decode envelope',
+    };
+  }
+}
+
+/**
+ * Round-trip check: does building this spec and decoding the result reproduce
+ * the same source, sequence, and operation list?
+ *
+ * Used by the UI to prove the JSON and XDR views are two spellings of one
+ * thing, which is the claim the whole page rests on.
+ */
+export function verifyRoundTrip(spec: TransactionSpec): { ok: boolean; detail: string } {
+  const built = buildTransactionXdr(spec);
+  if (!built.ok || !built.xdr) return { ok: false, detail: built.error ?? 'build failed' };
+
+  const decoded = decodeEnvelope(built.xdr, spec.networkPassphrase);
+  if (!decoded.ok) return { ok: false, detail: decoded.error ?? 'decode failed' };
+
+  if (decoded.sourceAccount !== spec.sourceAccount) {
+    return { ok: false, detail: 'source account did not survive the round trip' };
+  }
+  if (decoded.operations?.length !== spec.operations.length) {
+    return { ok: false, detail: 'operation count changed across the round trip' };
+  }
+
+  return {
+    ok: true,
+    detail: `${decoded.operations.length} operation(s) round-tripped; envelope hash ${decoded.transactionHash?.slice(0, 16)}…`,
+  };
+}


### PR DESCRIPTION
Closes #1159
Closes #1161
Closes #1162
Closes #1163

Four simulators. Each is a **pure library plus a page**, so the teaching logic is testable without rendering — and in three of the four the library is where the actual lesson lives.

| Issue | Route | Library |
|---|---|---|
| #1159 | `/merkle-simulator` | `lib/merkle-sha256.ts` |
| #1161 | `/xdr-inspector` | `lib/xdr-inspector.ts` |
| #1162 | `/storage-model` | `lib/soroban-storage-model.ts` |
| #1163 | `/consensus-simulator` | `lib/consensus-simulator.ts` |

## #1159 — Merkle visualiser

**Not built on the existing `merkle-tree-builder.ts`, deliberately.** That module hashes with `stableHash`, which is FNV-1a: a 32-bit, non-cryptographic hash. It is fine for the airdrop demo it backs, where the hash is only an identifier. It is the wrong primitive for a tool whose entire lesson is cryptographic immutability — a student could find an FNV collision by hand, and the tamper demo would be teaching that Merkle roots are forgeable. The existing `/merkle-tree` route is untouched.

`lib/merkle-sha256.ts` uses real SHA-256 via Web Crypto, with two properties worth calling out:

- **Domain separation.** Leaves are hashed `SHA256(0x00 ‖ value)` and nodes `SHA256(0x01 ‖ left ‖ right)`. Without it, an internal node's preimage is 64 bytes and could be presented as a leaf in a tree built over 64-byte leaves — the standard second-preimage attack. RFC 6962 uses the same construction.
- **Unpaired nodes are promoted, not duplicated.** Duplicating the odd node — the Bitcoin approach — admits CVE-2012-2459, where two distinct trees produce the same root. There is a test asserting our root differs from the duplicate-style root.

The page does what the issue asks: student-supplied leaves, audit path with siblings highlighted separately from the path itself, step-by-step reconstruction showing the exact bytes hashed at each level, tamper simulation with the cascade highlighted, and JSON export. The exported bundle records `algorithm`, `leafPrefix` and `nodePrefix` — a vector that omits the scheme is not reproducible by a contract.

## #1161 — Transaction builder & XDR inspector

Builds Payment, CreateAccount, ManageData and InvokeHostFunction (Soroban), converts between the structured view and Base64 XDR, and decodes envelopes back.

**The decoded panel parses the envelope rather than echoing form state.** That is the whole claim of the page — the JSON and the XDR are one object in two spellings — and `verifyRoundTrip` asserts it on every edit, so a disagreement is visible rather than hidden.

Three things the tool surfaces that are easy to get wrong:

- The **fee on an envelope is the total** (base × operation count), not the per-operation figure entered.
- A **`manageData` with no value deletes the entry**, which is not the same as storing an empty string.
- The **transaction hash is network-specific**. Signatures commit to a hash that includes the network passphrase, so flipping the network selector changes the hash without the envelope changing at all — that is the mechanism preventing testnet replay on the public network.

Submission funds the account via Friendbot, re-reads the live sequence (the form's sequence is for teaching; the network wants exactly next), simulates via Soroban RPC first, and only then submits — so authorization and precondition failures cost nothing. Submission is restricted to testnet.

## #1162 — Storage model visualiser

The distinction students get wrong is that Temporary and Persistent sound like "short" and "long". They are not — both expire. They differ in **what expiry does**:

- Temporary expiry **deletes**. Unrecoverable, no restore.
- Persistent expiry **archives**. Recoverable via `restore`, at a cost.

So "use Temporary to save money" is only safe for data you can recompute. The page makes this concrete: advance past the TTL, press `restore` on the temporary cache entry and it refuses; press it on the persistent balance at the same moment and it succeeds.

Also modelled: Instance storage shares **one TTL across every key**, `extend_ttl` measures from the current ledger (repeated calls do not stack) and never shortens a TTL, and neither `extend_ttl` nor `restore` can revive a deleted entry. Rent calculator shows all three tiers side by side with the expiry behaviour in the same row, because price alone makes Temporary look like the obvious choice.

The fee rates are network parameters, not constants — they are exported and overridable, and the page says so rather than presenting a projection as a quote.

## #1163 — Reorg & finality simulator

Distinct from the existing `/chain-reorg`, which animates two racing chains with random hashes and declares a winner. This models branches concretely, so **a reorg names the transactions it reverted** — not "reorgs can happen" but "this payment unhappened, and the goods already shipped".

- PoW fork choice by cumulative work, recomputed after every block.
- Nakamoto gambler's-ruin reversal probability `(q/p)^depth`, which returns 1 at ≥50% — no confirmation count is safe, which is what "51% attack" actually means.
- A 51% double-spend that forks *below* the block holding the payment (forking at the tip can never remove it — an easy modelling error, and one I hit and fixed).
- The SCP contrast: a closed ledger is final, so a competing branch is never adopted however much work it carries. An attacker with enough influence can **halt** the network — a liveness failure, not a reversal.
- Timeline scrubber that replays history through the same fork-choice code, so the scrubbed view and the live view cannot diverge.

A transaction present on **both** branches is correctly not counted as reverted.

## Verification

`npm install` does not produce a working `node_modules` for this repo in my environment, so **I could not run vitest**. Instead I exercised each library directly with Node's native TypeScript stripping, against independent references where one exists — **147 assertions, all passing**:

| Library | Assertions | Verified against |
|---|---|---|
| `merkle-sha256` | 45 | `node:crypto` SHA-256 computed independently — leaf/node hashes, roots, and the promotion-vs-duplication root all cross-checked |
| `soroban-storage-model` | 32 | rent arithmetic, every lifecycle transition, extend/restore refusals |
| `consensus-simulator` | 37 | reorg depth and reverted-tx lists, `(q/p)^depth` closed form, SCP invariants |
| `xdr-inspector` | 33 | **the real `@stellar/stellar-sdk` v14** — installed separately to confirm the API surface and round-trip actual envelopes |

The four vitest files mirror those assertions and are written in the repo's existing convention (`vitest`, `src/lib/__tests__/`), but have not been executed here — worth a CI run.

The pages themselves are not type-checked, for the same missing-toolchain reason. I verified the SDK method names I depend on (`Operation.invokeContractFunction`, `StrKey.encodeContract`, etc.) against the installed v14 package rather than assuming them.
