### PR TITLE
feat: address validator, session monitor, workspace RLS, SSE notifications

### DIFF
--- a/backend/src/auth/sessionMonitor.ts
+++ b/backend/src/auth/sessionMonitor.ts
@@ -1,0 +1,184 @@
+import { redisConnection as redis } from '../utils/redis.js';
+import { revokeAllUserTokens } from './token.service.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Session Activity Monitor (#1116).
+ *
+ * Protects shared university lab terminals by tracking per-user session
+ * activity and enforcing inactivity lockouts:
+ *
+ *  - `touchSession(userId)`   — called on mouse/keyboard/touch activity
+ *  - `getSessionStatus`       — idle duration, locked state, thresholds
+ *  - `lockSession`            — blur the UI immediately (manual or auto)
+ *  - `unlockSession`          — re-authentication challenge gate
+ *  - `purgeSession`           — extended idle (30m): revoke tokens, purge
+ *    memory credentials, and terminate WebSocket channels
+ *
+ * State is stored in Redis with a TTL so stale entries expire naturally and
+ * the monitor works across multiple backend instances. In test mode the
+ * shared redis util returns an in-memory client, so this is fully unit
+ * testable without a live Redis.
+ */
+
+export const SESSION_ACTIVITY_KEY = (userId: string): string =>
+  `session:activity:${userId}`;
+export const SESSION_LOCK_KEY = (userId: string): string =>
+  `session:lock:${userId}`;
+
+/** Default idle threshold before the UI locks (15 minutes). */
+export const DEFAULT_IDLE_LOCK_MS = 15 * 60 * 1000;
+/** Extended idle before credentials are purged and sessions revoked (30m). */
+export const DEFAULT_EXTENDED_IDLE_MS = 30 * 60 * 1000;
+/** Activity entries expire after 24h so stale keys never accumulate. */
+const ACTIVITY_TTL_SECONDS = 24 * 60 * 60;
+
+export interface SessionStatus {
+  userId: string;
+  locked: boolean;
+  lastActivityAt: number;
+  idleMs: number;
+  idleLockThresholdMs: number;
+  extendedIdleThresholdMs: number;
+  /** True when the session is in the extended-idle purge window. */
+  shouldPurge: boolean;
+}
+
+export interface SessionMonitorConfig {
+  idleLockMs?: number;
+  extendedIdleMs?: number;
+}
+
+const config: Required<SessionMonitorConfig> = {
+  idleLockMs: DEFAULT_IDLE_LOCK_MS,
+  extendedIdleMs: DEFAULT_EXTENDED_IDLE_MS,
+};
+
+/**
+ * Override the inactivity thresholds (used by tests).
+ */
+export function configureSessionMonitor(
+  next: SessionMonitorConfig,
+): void {
+  if (next.idleLockMs !== undefined) {
+    config.idleLockMs = next.idleLockMs;
+  }
+  if (next.extendedIdleMs !== undefined) {
+    config.extendedIdleMs = next.extendedIdleMs;
+  }
+}
+
+/**
+ * Record user activity (mouse / keyboard / touch). Resets the idle clock and
+ * clears the automatic lock state so an active user is never blurred out.
+ */
+export async function touchSession(userId: string): Promise<void> {
+  const now = Date.now();
+  try {
+    await redis.setex(SESSION_ACTIVITY_KEY(userId), ACTIVITY_TTL_SECONDS, String(now));
+    // Re-activation clears the lock.
+    await redis.del(SESSION_LOCK_KEY(userId));
+  } catch (err) {
+    logger.warn(`[session-monitor] Failed to record activity for ${userId}:`, err);
+  }
+}
+
+/**
+ * Read the current session status for a user.
+ */
+export async function getSessionStatus(
+  userId: string,
+  now: number = Date.now(),
+): Promise<SessionStatus> {
+  const [activityRaw, lockRaw] = await Promise.all([
+    redis.get(SESSION_ACTIVITY_KEY(userId)),
+    redis.get(SESSION_LOCK_KEY(userId)),
+  ]);
+
+  const lastActivityAt = activityRaw ? Number(activityRaw) : now;
+  const idleMs = Math.max(0, now - lastActivityAt);
+  const locked = lockRaw !== null;
+
+  return {
+    userId,
+    locked,
+    lastActivityAt,
+    idleMs,
+    idleLockThresholdMs: config.idleLockMs,
+    extendedIdleThresholdMs: config.extendedIdleMs,
+    shouldPurge: idleMs >= config.extendedIdleMs,
+  };
+}
+
+/**
+ * Lock a session immediately (manual lock or automatic idle trigger).
+ * While locked, the frontend must blur sensitive views and require
+ * re-authentication before the active session is usable again.
+ */
+export async function lockSession(userId: string): Promise<void> {
+  try {
+    await redis.setex(SESSION_LOCK_KEY(userId), ACTIVITY_TTL_SECONDS, String(Date.now()));
+  } catch (err) {
+    logger.warn(`[session-monitor] Failed to lock session for ${userId}:`, err);
+  }
+}
+
+/**
+ * Unlock a session after a successful re-authentication challenge
+ * (biometric / PIN verified by the caller). Fails with `false` when the
+ * session has already been purged by extended idle — the client must then do
+ * a full login instead of resuming.
+ */
+export async function unlockSession(userId: string): Promise<boolean> {
+  try {
+    const status = await getSessionStatus(userId);
+    if (status.shouldPurge) {
+      return false;
+    }
+    await redis.del(SESSION_LOCK_KEY(userId));
+    return true;
+  } catch (err) {
+    logger.warn(`[session-monitor] Failed to unlock session for ${userId}:`, err);
+    return false;
+  }
+}
+
+/**
+ * Purge an extended-idle session: revoke all refresh tokens (invalidating the
+ * session server-side), remove the activity/lock state, and terminate the
+ * user's WebSocket channels (via the gateway hook, if registered).
+ */
+export async function purgeSession(userId: string): Promise<void> {
+  logger.info(`[session-monitor] Purging extended-idle session for ${userId}`);
+  try {
+    await revokeAllUserTokens(userId);
+  } catch (err) {
+    logger.warn(`[session-monitor] Token revocation failed for ${userId}:`, err);
+  }
+  try {
+    await redis.del(SESSION_ACTIVITY_KEY(userId), SESSION_LOCK_KEY(userId));
+  } catch (err) {
+    logger.warn(`[session-monitor] Failed to clear session state for ${userId}:`, err);
+  }
+  try {
+    await terminateWebSocketChannels(userId);
+  } catch (err) {
+    logger.warn(`[session-monitor] Failed to terminate WebSocket channels for ${userId}:`, err);
+  }
+}
+
+/**
+ * Hook invoked by `purgeSession` to drop the user's WebSocket channels.
+ * The gateway registers a callback at startup; when absent (e.g. unit tests,
+ * or the gateway not initialized) this is a no-op.
+ */
+let terminateWebSocketChannels: (userId: string) => Promise<void> = async () => undefined;
+
+/**
+ * Register the WebSocket-termination callback (called by the gateway).
+ */
+export function registerWebSocketTerminator(
+  fn: (userId: string) => Promise<void>,
+): void {
+  terminateWebSocketChannels = fn;
+}

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -4,26 +4,12 @@ import { getWorkspaceId } from '../middleware/WorkspaceContext.js';
 import { getDatabaseRoleForOperation } from './requestContext.js';
 import logger from '../utils/logger.js';
 import { encryptionMiddleware } from '../middleware/prismaEncryption.js';
+import { workspaceModels } from './workspaceModels.js';
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
   readPrisma: PrismaClient | undefined;
 };
-
-const workspaceModels = new Set([
-  'Student',
-  'Course',
-  'Certificate',
-  'CertificateVerificationEvent',
-  'Enrollment',
-  'Feedback',
-  'LearningProgress',
-  'AuditLog',
-  'Canvas',
-  'WebhookSubscription',
-  'TranslationEntry',
-  'VestingSchedule',
-]);
 
 import { PrismaPg } from '@prisma/adapter-pg';
 // @ts-ignore

--- a/backend/src/db/workspaceModels.ts
+++ b/backend/src/db/workspaceModels.ts
@@ -1,0 +1,24 @@
+/**
+ * Models carrying a `workspaceId` column — the set the workspace-isolation
+ * extension filters. Kept in sync with the Prisma schema; every model with a
+ * `workspaceId` must appear here (#1119).
+ */
+export const workspaceModels = new Set([
+  'Student',
+  'Course',
+  'Certificate',
+  'CertificateVerificationEvent',
+  'ContributorProof',
+  'DecentralizedAsset',
+  'Enrollment',
+  'Feedback',
+  'Idea',
+  'LearningProgress',
+  'AuditLog',
+  'Canvas',
+  'NotificationPreferences',
+  'P2PNode',
+  'WebhookSubscription',
+  'TranslationEntry',
+  'VestingSchedule',
+]);

--- a/backend/src/middleware/workspaceMembership.ts
+++ b/backend/src/middleware/workspaceMembership.ts
@@ -1,0 +1,96 @@
+import { NextFunction, Request, Response } from 'express';
+import prisma from '../db/index.js';
+import { logAudit } from '../utils/audit.js';
+import { getWorkspaceId } from './WorkspaceContext.js';
+
+/**
+ * Multi-tenant workspace membership guard (#1119).
+ *
+ * Validates the active workspace (from the `x-workspace-id` header, captured
+ * by `optionalWorkspaceMiddleware` into AsyncLocalStorage) against the
+ * organizations the authenticated student is enrolled in:
+ *
+ *  1. The student's own `Student.workspaceId`, or
+ *  2. A workspace they hold an active `Enrollment` in.
+ *
+ * Admins bypass the check (they manage all workspaces).
+ *
+ * On violation the request is rejected with **403 Forbidden** and the attempt
+ * is written to the security audit stream (`WORKSPACE_ACCESS_DENIED`).
+ *
+ * Must run AFTER `authenticate` (needs `req.user`). Requests without an
+ * authenticated user, or without a workspace context, pass through — public
+ * endpoints and unscoped requests are governed by the Prisma extension's
+ * per-query filtering instead.
+ */
+export const validateWorkspaceMembership = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const workspaceId = getWorkspaceId();
+  const user = (req as Request & { user?: { id: string; role?: string } }).user;
+
+  if (!workspaceId || !user) {
+    next();
+    return;
+  }
+
+  // Admins manage all workspaces.
+  if (user.role === 'admin') {
+    next();
+    return;
+  }
+
+  try {
+    const student = await prisma.student.findUnique({
+      where: { id: user.id },
+      select: { workspaceId: true },
+    });
+
+    if (student?.workspaceId === workspaceId) {
+      next();
+      return;
+    }
+
+    const enrollment = await prisma.enrollment.findFirst({
+      where: { studentId: user.id, workspaceId, status: 'active' },
+      select: { id: true },
+    });
+
+    if (enrollment) {
+      next();
+      return;
+    }
+
+    await logAudit({
+      userId: user.id,
+      action: 'WORKSPACE_ACCESS_DENIED',
+      entity: 'Workspace',
+      entityId: workspaceId,
+      details: {
+        reason: 'user is not enrolled in workspace',
+        path: req.path,
+        method: req.method,
+      },
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent'),
+    });
+
+    res.status(403).json({
+      error: 'Forbidden: you do not belong to this workspace',
+    });
+  } catch (error) {
+    // Fail closed on lookup errors: never leak cross-tenant data.
+    await logAudit({
+      userId: user.id,
+      action: 'WORKSPACE_ACCESS_DENIED',
+      entity: 'Workspace',
+      entityId: workspaceId,
+      details: { reason: 'membership check failed', error: String(error) },
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent'),
+    });
+    res.status(403).json({ error: 'Forbidden: workspace membership could not be verified' });
+  }
+};

--- a/backend/src/notifications/notification.routes.ts
+++ b/backend/src/notifications/notification.routes.ts
@@ -1,4 +1,10 @@
 import { Router, Request, Response } from 'express';
+import { verifyToken } from '../auth/auth.service.js';
+import { sseSessionManager } from '../sse/SseSessionManager.js';
+import {
+  replayMissedEvents,
+  startNotificationStreamBridge,
+} from '../sse/notificationStream.js';
 import {
   getNotifications,
   markAsRead,
@@ -7,6 +13,10 @@ import {
 import { NotificationListResponse } from './notification.types.js';
 
 const router: ReturnType<typeof Router> = Router();
+
+// Ensure the Redis Pub/Sub bridge is forwarding course notifications to SSE
+// clients. Idempotent — safe to call on every request.
+startNotificationStreamBridge();
 
 /** Query string accepted by `GET /api/notifications`. */
 interface ListNotificationsQuery {
@@ -36,6 +46,60 @@ interface MarkAsReadResponse {
 interface MarkAllAsReadResponse extends MarkAsReadResponse {
   updatedCount: number;
 }
+
+/**
+ * GET /api/notifications/stream
+ *
+ * Server-Sent Events stream for real-time course notifications (#1122).
+ *
+ * Auth: `Authorization: Bearer <jwt>` header or `?access_token=` query param.
+ * Headers:
+ *   - `Last-Event-ID` — optional; replays notifications missed since this id.
+ *
+ * Events:
+ *   - `notification`  — a course notification (targeted or broadcast)
+ *   - `: keep-alive`  — heartbeat comment every 25s
+ */
+router.get('/stream', (req, res) => {
+  const authHeader = req.headers.authorization;
+  const headerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+  const queryToken =
+    typeof req.query.access_token === 'string' ? req.query.access_token : undefined;
+  const token = headerToken || queryToken;
+
+  if (!token) {
+    return res.status(401).json({ error: 'Authorization token required' });
+  }
+
+  let userId: string;
+  try {
+    userId = verifyToken(token).userId;
+  } catch {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  if (typeof res.flushHeaders === 'function') {
+    res.flushHeaders();
+  }
+
+  // Reconnection recovery (#1122): replay what the client missed.
+  const lastEventId =
+    typeof req.headers['last-event-id'] === 'string'
+      ? req.headers['last-event-id']
+      : null;
+  replayMissedEvents(userId, lastEventId, res);
+
+  res.write('retry: 5000\n\n');
+  const clientId = sseSessionManager.addClient(userId, res);
+
+  req.on('close', () => {
+    sseSessionManager.removeClient(userId, clientId);
+  });
+});
 
 /**
  * GET /api/notifications

--- a/backend/src/routes/auth/auth.routes.ts
+++ b/backend/src/routes/auth/auth.routes.ts
@@ -1,6 +1,13 @@
 import { Request, Response, Router } from 'express';
 import { authenticate } from '../../auth/auth.middleware.js';
 import { getProfileStatusByWallet, login, register } from '../../auth/auth.service.js';
+import {
+  getSessionStatus,
+  lockSession,
+  purgeSession,
+  touchSession,
+  unlockSession,
+} from '../../auth/sessionMonitor.js';
 import { blacklistAccessToken, rotateRefreshToken, revokeAllUserTokens, verifyRefreshToken } from '../../auth/token.service.js';
 import { LoginRequest } from '../../auth/types.js';
 import { loginSchema, registerSchema, web3VerifySchema } from '../../auth/validation.schemas.js';
@@ -575,6 +582,118 @@ router.post(
     console.error('Signature verification error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
+});
+
+/**
+ * @openapi
+ * /api/v1/auth/session/activity:
+ *   post:
+ *     summary: Record session activity (mouse/keyboard/touch) and reset idle
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: Activity recorded }
+ *       401: { description: Unauthorized }
+ */
+router.post('/session/activity', authenticate, async (req: Request, res: Response) => {
+  const userId = (req as unknown as { user?: { id: string } }).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  await touchSession(userId);
+  res.json({ ok: true });
+});
+
+/**
+ * @openapi
+ * /api/v1/auth/session/status:
+ *   get:
+ *     summary: Get session idle/lock status
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: SessionStatus }
+ *       401: { description: Unauthorized }
+ */
+router.get('/session/status', authenticate, async (req: Request, res: Response) => {
+  const userId = (req as unknown as { user?: { id: string } }).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const status = await getSessionStatus(userId);
+  res.json(status);
+});
+
+/**
+ * @openapi
+ * /api/v1/auth/session/lock:
+ *   post:
+ *     summary: Lock the session (blur UI, require re-auth)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: Session locked }
+ *       401: { description: Unauthorized }
+ */
+router.post('/session/lock', authenticate, async (req: Request, res: Response) => {
+  const userId = (req as unknown as { user?: { id: string } }).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  await lockSession(userId);
+  res.json({ ok: true });
+});
+
+/**
+ * @openapi
+ * /api/v1/auth/session/unlock:
+ *   post:
+ *     summary: Unlock after re-authentication challenge
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: Session unlocked }
+ *       401: { description: Unauthorized }
+ *       423: { description: Session purged by extended idle; full login required }
+ */
+router.post('/session/unlock', authenticate, async (req: Request, res: Response) => {
+  const userId = (req as unknown as { user?: { id: string } }).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const unlocked = await unlockSession(userId);
+  if (!unlocked) {
+    res.status(423).json({
+      error: 'Session expired from extended inactivity; please sign in again',
+    });
+    return;
+  }
+  res.json({ ok: true });
+});
+
+/**
+ * @openapi
+ * /api/v1/auth/session/purge:
+ *   post:
+ *     summary: Purge extended-idle session (revoke tokens, terminate WebSockets)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: Session purged }
+ *       401: { description: Unauthorized }
+ */
+router.post('/session/purge', authenticate, async (req: Request, res: Response) => {
+  const userId = (req as unknown as { user?: { id: string } }).user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  await purgeSession(userId);
+  res.json({ ok: true });
 });
 
 export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,4 +1,6 @@
 import { Router } from 'express';
+import { optionalWorkspaceMiddleware } from '../middleware/WorkspaceContext.js';
+import { validateWorkspaceMembership } from '../middleware/workspaceMembership.js';
 import dashboardRoutes from '../dashboard/dashboard.routes.js';
 import activityLogRouter from '../dashboard/activityLog.routes.js';
 import feedbackRouter from '../feedback/feedback.routes.js';
@@ -48,17 +50,30 @@ import storageRouter from './storage.routes.js';
 
 const router: ReturnType<typeof Router> = Router();
 
+// Populate the AsyncLocalStorage workspace context from the `x-workspace-id`
+// header (or `workspaceId` query param) so the Prisma workspace-isolation
+// extension filters every query automatically (#1119). Optional: requests
+// without a workspace header pass through unscoped.
+router.use(optionalWorkspaceMiddleware);
+
 router.use('/health', healthRouter);
 router.use('/analytics', analyticsRouter);
 router.use('/students', studentsRouter);
-router.use('/certificates', certificatesRouter);
-router.use('/courses', coursesRouter);
-router.use('/enrollments', enrollmentsRouter);
+
+// Cross-tenant data lives in courses, submissions (enrollments), certificates
+// and learning progress — enforce workspace membership on those groups
+// (#1119). Runs after the workspace context is populated above; requests
+// without an authenticated user or workspace header pass through, while
+// the Prisma extension still applies per-query tenant filtering.
+router.use('/certificates', validateWorkspaceMembership, certificatesRouter);
+router.use('/courses', validateWorkspaceMembership, coursesRouter);
+router.use('/enrollments', validateWorkspaceMembership, enrollmentsRouter);
+router.use('/feedback', validateWorkspaceMembership, feedbackRouter);
+router.use('/learning', validateWorkspaceMembership, learningRoutes);
+
 router.use('/dashboard', dashboardRoutes);
 router.use('/dashboard/activity-log', activityLogRouter);
-router.use('/feedback', feedbackRouter);
 router.use('/auth', authRoutes);
-router.use('/learning', learningRoutes);
 router.use('/search', curriculumSearchRouter);
 router.use('/contracts', contractRouter);
 router.use('/notifications', notificationRouter);

--- a/backend/src/sse/SseSessionManager.ts
+++ b/backend/src/sse/SseSessionManager.ts
@@ -49,13 +49,13 @@ export class SseSessionManager {
     }
   }
 
-  emitToUser(userId: string, event: string, payload: unknown): void {
+  emitToUser(userId: string, event: string, payload: unknown, eventId?: string): void {
     const clients = this.sessions.get(userId);
     if (!clients || clients.size === 0) {
       return;
     }
 
-    const message = this.formatEvent(event, payload);
+    const message = this.formatEvent(event, payload, eventId);
 
     for (const [clientId, client] of clients.entries()) {
       const success = this.writeRaw(client.res, message);
@@ -65,8 +65,26 @@ export class SseSessionManager {
     }
   }
 
-  private formatEvent(event: string, payload: unknown): string {
-    return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+  /**
+   * Broadcast an event to every connected client (all sessions).
+   * Used for broadcast (non-targeted) notifications (#1122).
+   */
+  emitToAll(event: string, payload: unknown, eventId?: string): void {
+    const message = this.formatEvent(event, payload, eventId);
+    for (const [sessionId, clients] of this.sessions.entries()) {
+      for (const [clientId, client] of clients.entries()) {
+        const success = this.writeRaw(client.res, message);
+        if (!success) {
+          this.removeClient(sessionId, clientId);
+        }
+      }
+    }
+  }
+
+  private formatEvent(event: string, payload: unknown, eventId?: string): string {
+    // `id:` enables Last-Event-ID reconnection recovery (#1122).
+    const idLine = eventId ? `id: ${eventId}\n` : '';
+    return `${idLine}event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
   }
 
   private writeRaw(res: Response, chunk: string): boolean {

--- a/backend/src/sse/notificationStream.ts
+++ b/backend/src/sse/notificationStream.ts
@@ -1,0 +1,185 @@
+import { Response } from 'express';
+import redisClient from '../cache/RedisClient.js';
+import logger from '../utils/logger.js';
+import { sseSessionManager } from './SseSessionManager.js';
+
+/**
+ * Real-time course notification SSE bridge (#1122).
+ *
+ * Subscribes to the `course_notifications` Redis Pub/Sub channel (the same
+ * channel `NotificationService.createNotification` publishes to) and relays
+ * each event to the connected SSE clients of the targeted user, or to all
+ * clients when the notification is a broadcast (no `userId`).
+ *
+ * Reconnection recovery: every delivered event carries an `id:` line. The
+ * bridge keeps a small per-user ring buffer of recently delivered events so
+ * a client that reconnects with a `Last-Event-ID` header can be replayed the
+ * events it missed while disconnected.
+ */
+
+export const NOTIFICATIONS_CHANNEL = 'course_notifications';
+
+/** Max events kept per user for `Last-Event-ID` replay. */
+export const RECENT_EVENTS_PER_USER = 100;
+
+interface RecentNotification {
+  id: string;
+  event: string;
+  data: string;
+}
+
+const recentByUser = new Map<string, RecentNotification[]>();
+
+let bridgeStarted = false;
+
+/**
+ * Remember a delivered notification for `Last-Event-ID` replay. Broadcasts
+ * (no userId) are remembered under the `__broadcast__` key.
+ */
+function remember(userId: string | undefined, entry: RecentNotification): void {
+  const key = userId ?? '__broadcast__';
+  const list = recentByUser.get(key) ?? [];
+  list.push(entry);
+  while (list.length > RECENT_EVENTS_PER_USER) {
+    list.shift();
+  }
+  recentByUser.set(key, list);
+}
+
+function parseNotification(raw: string): RecentNotification | null {
+  try {
+    const parsed = JSON.parse(raw) as { id?: string; type?: string };
+    if (!parsed.id) {
+      return null;
+    }
+    return {
+      id: parsed.id,
+      event: parsed.type ?? 'notification',
+      data: raw,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a `course_notifications` Redis message, remember it for replay, and
+ * forward it to the connected SSE clients (targeted or broadcast).
+ *
+ * Exported separately so the emit/remember logic can be unit-tested without
+ * a live Redis connection.
+ */
+export function forwardNotification(rawMessage: string): boolean {
+  const entry = parseNotification(rawMessage);
+  if (!entry) {
+    return false;
+  }
+
+  let userId: string | undefined;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawMessage);
+    userId = (payload as { userId?: string }).userId;
+  } catch {
+    payload = rawMessage;
+  }
+
+  remember(userId, entry);
+  if (userId) {
+    sseSessionManager.emitToUser(userId, entry.event, payload, entry.id);
+  } else {
+    // Broadcast to every connected client (#1122).
+    sseSessionManager.emitToAll(entry.event, payload, entry.id);
+  }
+  return true;
+}
+
+/**
+ * Subscribe to the notifications channel and forward events to connected SSE
+ * clients. Idempotent: safe to call from multiple modules / during tests.
+ *
+ * Returns an unsubscribe function.
+ */
+export function startNotificationStreamBridge(): () => void {
+  const subClient = redisClient.getSubClient();
+
+  if (!subClient) {
+    logger.warn(
+      '[notification-stream] Redis unavailable — SSE notifications will not be bridged',
+    );
+    return () => undefined;
+  }
+
+  if (bridgeStarted) {
+    return () => undefined;
+  }
+  bridgeStarted = true;
+
+  const onMessage = (channel: string, message: string): void => {
+    if (channel !== NOTIFICATIONS_CHANNEL) {
+      return;
+    }
+    forwardNotification(message);
+  };
+
+  subClient.subscribe(NOTIFICATIONS_CHANNEL);
+  subClient.on('message', onMessage);
+
+  return () => {
+    subClient.unsubscribe(NOTIFICATIONS_CHANNEL);
+    subClient.removeListener('message', onMessage);
+    bridgeStarted = false;
+  };
+}
+
+/**
+ * Replay notifications the client missed while disconnected.
+ *
+ * The `Last-Event-ID` header tells us the last event id the client processed;
+ * we re-send every remembered event for the user (plus broadcasts) with a
+ * later id. When no `lastEventId` is provided we replay nothing and let the
+ * client receive only fresh events.
+ */
+export function replayMissedEvents(
+  userId: string,
+  lastEventId: string | null,
+  res: Response,
+): void {
+  if (!lastEventId) {
+    return;
+  }
+
+  const userEntries = recentByUser.get(userId) ?? [];
+  const broadcastEntries = recentByUser.get('__broadcast__') ?? [];
+  const all = [...broadcastEntries, ...userEntries].sort((a, b) =>
+    a.id.localeCompare(b.id)
+  );
+
+  for (const entry of all) {
+    // Notification ids are lexicographically sortable (`notif-<ts>-<n>`),
+    // so string comparison is a correct "later than" test.
+    if (entry.id > lastEventId) {
+      writeEvent(res, entry);
+    }
+  }
+}
+
+/**
+ * Write one SSE event with an `id:` line (required for Last-Event-ID
+ * reconciliation) followed by `event:`/`data:` payload.
+ */
+function writeEvent(res: Response, entry: RecentNotification): void {
+  res.write(`id: ${entry.id}\n`);
+  res.write(`event: ${entry.event}\n`);
+  res.write(`data: ${entry.data}\n\n`);
+}
+
+/** Exposed for tests. */
+export function _clearRecentEvents(): void {
+  recentByUser.clear();
+}
+
+/** Exposed for tests. */
+export function _recentCount(userId: string | undefined): number {
+  return (recentByUser.get(userId ?? '__broadcast__') ?? []).length;
+}

--- a/backend/src/utils/stellarAddressValidator.ts
+++ b/backend/src/utils/stellarAddressValidator.ts
@@ -1,0 +1,282 @@
+/**
+ * Universal Stellar Public Key Checksum & Address Validator (#1114).
+ *
+ * Validates every Stellar address flavour before transaction construction:
+ *
+ *  - `G...` ed25519 public keys (StrKey CRC16-XDR checksum)
+ *  - `S...` ed25519 secret seeds
+ *  - `C...` Soroban contract addresses
+ *  - `M...` muxed (multiplexed) addresses, decoding the 64-bit memo id
+ *  - Federation handles (`username*domain.com`) resolved via SEP-0010
+ *
+ * Also provides a deterministic identicon generator so UIs can render a
+ * stable avatar from any valid public key.
+ */
+
+import { StrKey } from '@stellar/stellar-sdk';
+import { createHash } from 'crypto';
+
+export type StellarAddressKind =
+  | 'public'
+  | 'secret'
+  | 'contract'
+  | 'muxed'
+  | 'federation'
+  | 'invalid';
+
+export interface StellarAddressValidation {
+  valid: boolean;
+  kind: StellarAddressKind;
+  /** Human-readable reason when `valid` is false. */
+  reason?: string;
+  /** Decoded base address for muxed addresses (`M...` -> `G...`). */
+  baseAddress?: string;
+  /** Decoded 64-bit memo id for muxed addresses. */
+  memoId?: string;
+  /** Normalized address (hex uppercase for muxed, input otherwise). */
+  normalized?: string;
+}
+
+const FEDERATION_HANDLE_REGEX = /^[a-zA-Z0-9._-]+\*[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+/**
+ * Validate a single Stellar address string.
+ *
+ * @example
+ * validateStellarAddress('GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+ * // => { valid: true, kind: 'public' }
+ */
+export function validateStellarAddress(input: string): StellarAddressValidation {
+  const value = input?.trim() ?? '';
+
+  if (!value) {
+    return { valid: false, kind: 'invalid', reason: 'Address is empty' };
+  }
+
+  // Federation handles look like `alice*example.com` — no StrKey checksum.
+  if (FEDERATION_HANDLE_REGEX.test(value)) {
+    return { valid: true, kind: 'federation', normalized: value };
+  }
+
+  const prefix = value[0];
+
+  try {
+    switch (prefix) {
+      case 'G':
+        if (!StrKey.isValidEd25519PublicKey(value)) {
+          return {
+            valid: false,
+            kind: 'invalid',
+            reason: 'Invalid CRC16-XDR checksum for G... public key',
+          };
+        }
+        return { valid: true, kind: 'public', normalized: value };
+
+      case 'S':
+        if (!StrKey.isValidEd25519SecretSeed(value)) {
+          return {
+            valid: false,
+            kind: 'invalid',
+            reason: 'Invalid CRC16-XDR checksum for S... secret seed',
+          };
+        }
+        return { valid: true, kind: 'secret', normalized: value };
+
+      case 'C':
+        if (!StrKey.isValidContract(value)) {
+          return {
+            valid: false,
+            kind: 'invalid',
+            reason: 'Invalid CRC16-XDR checksum for C... contract address',
+          };
+        }
+        return { valid: true, kind: 'contract', normalized: value };
+
+      case 'M':
+        return decodeMuxedAddress(value);
+
+      default:
+        return {
+          valid: false,
+          kind: 'invalid',
+          reason: `Unsupported address prefix "${prefix}". Expected G..., S..., C..., M... or a federation handle`,
+        };
+    }
+  } catch {
+    return { valid: false, kind: 'invalid', reason: 'Malformed Stellar address' };
+  }
+}
+
+/**
+ * Decode a multiplexed (`M...`) Stellar address into its base `G...` account
+ * and 64-bit memo id (SEP-0023). Used for exchange / memo compliance.
+ */
+export function decodeMuxedAddress(input: string): StellarAddressValidation {
+  const value = input.trim();
+
+  if (!StrKey.isValidMed25519PublicKey(value)) {
+    return {
+      valid: false,
+      kind: 'invalid',
+      reason: 'Invalid CRC16-XDR checksum for M... muxed address',
+    };
+  }
+
+  try {
+    const decoded = StrKey.decodeMed25519PublicKey(value);
+    const baseAddress = StrKey.encodeEd25519PublicKey(decoded.ed25519);
+    return {
+      valid: true,
+      kind: 'muxed',
+      baseAddress,
+      memoId: decoded.id.toString(),
+      normalized: value,
+    };
+  } catch {
+    return {
+      valid: false,
+      kind: 'invalid',
+      reason: 'Failed to decode muxed address payload',
+    };
+  }
+}
+
+/**
+ * Resolve a Stellar federation handle (`username*domain.com`) to an account
+ * address following SEP-0010:
+ *
+ *  1. Fetch `https://<domain>/.well-known/stellar.toml` (HTTPS only)
+ *  2. Read the `FEDERATION_SERVER` entry
+ *  3. Query `<server>?type=name&q=<username*domain>` and return `account.id`
+ *
+ * Returns `null` when the handle cannot be resolved, the domain refuses
+ * HTTPS, or no federation server is advertised.
+ */
+export async function resolveFederationHandle(
+  handle: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  const trimmed = handle.trim();
+
+  if (!FEDERATION_HANDLE_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  const [, domain] = trimmed.split('*');
+  const tomlUrl = `https://${domain}/.well-known/stellar.toml`;
+
+  let toml: string;
+  try {
+    const res = await fetchImpl(tomlUrl, {
+      headers: { Accept: 'text/plain' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      return null;
+    }
+    toml = await res.text();
+  } catch {
+    // HTTPS failed — federation servers are required to serve over HTTPS,
+    // so we deliberately do NOT fall back to plain HTTP (DNS rebinding
+    // protection). Return null to signal an unresolved handle.
+    return null;
+  }
+
+  const federationServer = parseFederationServer(toml);
+  if (!federationServer) {
+    return null;
+  }
+
+  try {
+    const url = new URL(federationServer);
+    url.searchParams.set('type', 'name');
+    url.searchParams.set('q', trimmed);
+
+    const res = await fetchImpl(url.toString(), {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      return null;
+    }
+
+    const body = (await res.json()) as { account?: { id?: string } };
+    const accountId = body?.account?.id;
+
+    if (!accountId || !StrKey.isValidEd25519PublicKey(accountId)) {
+      return null;
+    }
+    return accountId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the `FEDERATION_SERVER` value from a stellar.toml document.
+ * Accepts both `FEDERATION_SERVER = "https://..."` and the raw URL form.
+ */
+export function parseFederationServer(toml: string): string | null {
+  const match = toml.match(/^\s*FEDERATION_SERVER\s*=\s*["']?([^"'\s]+)["']?\s*$/m);
+  const server = match?.[1];
+
+  if (!server || !server.startsWith('https://')) {
+    return null;
+  }
+  return server;
+}
+
+// ─── Identicon ─────────────────────────────────────────────────────────────
+
+const IDENTICON_COLORS = [
+  '#2563eb',
+  '#7c3aed',
+  '#db2777',
+  '#ea580c',
+  '#16a34a',
+  '#0891b2',
+  '#4f46e5',
+  '#c026d3',
+];
+
+/**
+ * Render a deterministic identicon (5x5 grid, 8 colors) from a Stellar
+ * public key. The same key always produces the same grid; the hash is
+ * derived from the raw ed25519 bytes so the visual is stable across
+ * sessions and renderers.
+ *
+ * Returns `null` for invalid public keys.
+ */
+export function identiconFromPublicKey(publicKey: string): string[] | null {
+  const trimmed = publicKey.trim();
+
+  if (!StrKey.isValidEd25519PublicKey(trimmed) && !StrKey.isValidMed25519PublicKey(trimmed)) {
+    return null;
+  }
+
+  let raw: Buffer;
+  try {
+    raw = StrKey.isValidMed25519PublicKey(trimmed)
+      ? Buffer.from(StrKey.decodeMed25519PublicKey(trimmed).ed25519)
+      : Buffer.from(StrKey.decodeEd25519PublicKey(trimmed));
+  } catch {
+    return null;
+  }
+
+  const digest = createHash('sha256').update(raw).digest();
+
+  // 5x5 symmetric grid: only 15 cells are derived, mirrored for the rest.
+  const cells: string[] = new Array(25).fill(IDENTICON_COLORS[0]);
+  for (let row = 0; row < 5; row++) {
+    for (let col = 0; col < 3; col++) {
+      const idx = row * 5 + col;
+      const byte = digest[idx % digest.length];
+      cells[idx] = IDENTICON_COLORS[byte % IDENTICON_COLORS.length];
+      // Mirror horizontally: col 4 mirrors col 0, col 3 mirrors col 1.
+      cells[row * 5 + (4 - col)] = cells[idx];
+    }
+  }
+  return cells;
+}
+
+export default validateStellarAddress;

--- a/backend/src/websocket/gateway.ts
+++ b/backend/src/websocket/gateway.ts
@@ -1,11 +1,21 @@
 import { Server, Socket } from 'socket.io';
 import { verifyToken } from '../auth/auth.service.js';
+import { registerWebSocketTerminator } from '../auth/sessionMonitor.js';
 import redisClient from '../cache/RedisClient.js';
 import { sseSessionManager } from '../sse/SseSessionManager.js';
 import logger from '../utils/logger.js';
 
 export const initWebSocketGateway = (io: Server) => {
   logger.info('Initializing WebSocket Gateway...');
+
+  // Extended-idle sessions (30m) have their WebSocket channels terminated by
+  // the session monitor (#1116) — drop every socket belonging to the user.
+  registerWebSocketTerminator(async (userId: string) => {
+    const sockets = await io.in(`user:${userId}`).fetchSockets();
+    for (const socket of sockets) {
+      socket.disconnect(true);
+    }
+  });
 
   // JWT Authentication Middleware
   io.use((socket, next) => {

--- a/backend/tests/notificationStream.test.ts
+++ b/backend/tests/notificationStream.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { Response } from 'express';
+import { SseSessionManager } from '../src/sse/SseSessionManager.js';
+import {
+  _clearRecentEvents,
+  _recentCount,
+  forwardNotification,
+  NOTIFICATIONS_CHANNEL,
+  replayMissedEvents,
+  RECENT_EVENTS_PER_USER,
+} from '../src/sse/notificationStream.js';
+
+const createMockResponse = (): Response => {
+  const chunks: string[] = [];
+  const res = {
+    write: jest.fn((chunk: string) => {
+      chunks.push(String(chunk));
+      return true;
+    }),
+    _chunks: chunks,
+  } as unknown as Response & { _chunks: string[] };
+  return res;
+};
+
+const notifMessage = (id: string, title: string, userId?: string): string =>
+  JSON.stringify({
+    id,
+    type: 'announcement',
+    ...(userId ? { userId } : {}),
+    title,
+    message: title,
+    read: false,
+    createdAt: new Date().toISOString(),
+  });
+
+describe('SSE Notification Stream (#1122)', () => {
+  beforeEach(() => {
+    _clearRecentEvents();
+  });
+
+  it('exposes the course_notifications Redis channel', () => {
+    expect(NOTIFICATIONS_CHANNEL).toBe('course_notifications');
+  });
+
+  it('forwards targeted events to the session of the recipient user only', () => {
+    const manager = new SseSessionManager(60000);
+    const aliceRes = createMockResponse();
+    const bobRes = createMockResponse();
+
+    const aliceClient = manager.addClient('alice', aliceRes);
+    const bobClient = manager.addClient('bob', bobRes);
+
+    forwardNotification(notifMessage('notif-1', 'For Alice', 'alice'));
+
+    expect(aliceRes.write).toHaveBeenCalledWith(expect.stringContaining('event: announcement'));
+    expect(aliceRes.write).toHaveBeenCalledWith(expect.stringContaining('"title":"For Alice"'));
+    expect(bobRes.write).not.toHaveBeenCalled();
+
+    manager.removeClient('alice', aliceClient);
+    manager.removeClient('bob', bobClient);
+  });
+
+  it('includes an id: line when an event id is provided (Last-Event-ID support)', () => {
+    const manager = new SseSessionManager(60000);
+    const res = createMockResponse();
+    const clientId = manager.addClient('alice', res);
+
+    forwardNotification(notifMessage('notif-42', 'Hi', 'alice'));
+
+    expect(res.write).toHaveBeenCalledWith(expect.stringContaining('id: notif-42'));
+    expect(res.write).toHaveBeenCalledWith(expect.stringContaining('event: announcement'));
+
+    manager.removeClient('alice', clientId);
+  });
+
+  it('broadcasts to all connected clients when no userId is targeted', () => {
+    const manager = new SseSessionManager(60000);
+    const aliceRes = createMockResponse();
+    const bobRes = createMockResponse();
+
+    const aliceClient = manager.addClient('alice', aliceRes);
+    const bobClient = manager.addClient('bob', bobRes);
+
+    forwardNotification(notifMessage('notif-broadcast', 'Global announcement'));
+
+    expect(aliceRes.write).toHaveBeenCalledWith(
+      expect.stringContaining('"title":"Global announcement"')
+    );
+    expect(bobRes.write).toHaveBeenCalledWith(
+      expect.stringContaining('"title":"Global announcement"')
+    );
+
+    manager.removeClient('alice', aliceClient);
+    manager.removeClient('bob', bobClient);
+  });
+
+  it('remembers recent events per user for reconnection replay', () => {
+    const manager = new SseSessionManager(60000);
+    const res = createMockResponse();
+    const clientId = manager.addClient('alice', res);
+
+    // Targeted
+    forwardNotification(notifMessage('notif-1', 'A', 'alice'));
+    // Broadcast
+    forwardNotification(notifMessage('notif-2', 'B'));
+
+    expect(_recentCount('alice')).toBeGreaterThanOrEqual(1);
+    expect(_recentCount(undefined)).toBeGreaterThanOrEqual(1);
+
+    manager.removeClient('alice', clientId);
+  });
+
+  it('replays only events with an id newer than Last-Event-ID', () => {
+    const manager = new SseSessionManager(60000);
+    const res = createMockResponse();
+    const clientId = manager.addClient('alice', res);
+
+    forwardNotification(notifMessage('notif-1', 'Old', 'alice'));
+    forwardNotification(notifMessage('notif-2', 'Mid', 'alice'));
+    forwardNotification(notifMessage('notif-3', 'New', 'alice'));
+
+    const replayRes = createMockResponse();
+    replayMissedEvents('alice', 'notif-2', replayRes);
+
+    const allWrites = (replayRes.write as unknown as jest.Mock).mock.calls
+      .map((call) => String(call[0]))
+      .join('');
+    expect(allWrites).toContain('notif-3');
+    expect(allWrites).not.toContain('notif-1');
+    expect(allWrites).not.toContain('notif-2');
+
+    manager.removeClient('alice', clientId);
+  });
+
+  it('replays nothing when no Last-Event-ID is provided', () => {
+    const manager = new SseSessionManager(60000);
+    const res = createMockResponse();
+    const clientId = manager.addClient('alice', res);
+    forwardNotification(notifMessage('notif-1', 'A', 'alice'));
+
+    const replayRes = createMockResponse();
+    replayMissedEvents('alice', null, replayRes);
+    expect(replayRes.write).not.toHaveBeenCalled();
+
+    manager.removeClient('alice', clientId);
+  });
+
+  it('caps the per-user replay buffer', () => {
+    const manager = new SseSessionManager(60000);
+    const res = createMockResponse();
+    const clientId = manager.addClient('alice', res);
+
+    for (let i = 0; i < RECENT_EVENTS_PER_USER + 50; i++) {
+      forwardNotification(notifMessage(`notif-${i}`, `N${i}`, 'alice'));
+    }
+
+    const replayRes = createMockResponse();
+    replayMissedEvents('alice', 'notif-0', replayRes);
+    // Buffer is bounded — not all 150 events survive.
+    const allWrites = (replayRes.write as unknown as jest.Mock).mock.calls
+      .map((call) => String(call[0]))
+      .join('');
+    expect(allWrites).toContain('notif-149');
+    expect(allWrites).not.toContain('notif-0');
+
+    manager.removeClient('alice', clientId);
+  });
+
+  it('ignores malformed messages', () => {
+    expect(forwardNotification('not json')).toBe(false);
+    expect(forwardNotification(JSON.stringify({ type: 'announcement' }))).toBe(false);
+  });
+});

--- a/backend/tests/sessionMonitor.test.ts
+++ b/backend/tests/sessionMonitor.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import {
+  configureSessionMonitor,
+  DEFAULT_EXTENDED_IDLE_MS,
+  DEFAULT_IDLE_LOCK_MS,
+  getSessionStatus,
+  lockSession,
+  purgeSession,
+  registerWebSocketTerminator,
+  touchSession,
+  unlockSession,
+} from '../src/auth/sessionMonitor.js';
+
+describe('Session Activity Monitor (#1116)', () => {
+  const userId = 'student-42';
+
+  beforeEach(() => {
+    configureSessionMonitor({
+      idleLockMs: DEFAULT_IDLE_LOCK_MS,
+      extendedIdleMs: DEFAULT_EXTENDED_IDLE_MS,
+    });
+  });
+
+  it('starts unlocked with zero idle for an unknown user', async () => {
+    const status = await getSessionStatus(userId, Date.now());
+    expect(status.locked).toBe(false);
+    expect(status.shouldPurge).toBe(false);
+    expect(status.idleLockThresholdMs).toBe(DEFAULT_IDLE_LOCK_MS);
+    expect(status.extendedIdleThresholdMs).toBe(DEFAULT_EXTENDED_IDLE_MS);
+  });
+
+  it('tracks idle time from the last recorded activity', async () => {
+    const now = Date.now();
+    await touchSession(userId);
+    // Simulate 1 minute passing.
+    const status = await getSessionStatus(userId, now + 60_000);
+    expect(status.lastActivityAt).toBeLessThanOrEqual(now);
+    expect(status.idleMs).toBeGreaterThanOrEqual(60_000);
+    expect(status.locked).toBe(false);
+  });
+
+  it('locks the session on demand', async () => {
+    await touchSession(userId);
+    await lockSession(userId);
+    const status = await getSessionStatus(userId);
+    expect(status.locked).toBe(true);
+  });
+
+  it('unlocks a session after re-authentication', async () => {
+    await touchSession(userId);
+    await lockSession(userId);
+    expect(await unlockSession(userId)).toBe(true);
+    const status = await getSessionStatus(userId);
+    expect(status.locked).toBe(false);
+  });
+
+  it('activity after a lock clears it (active user is never blurred)', async () => {
+    await touchSession(userId);
+    await lockSession(userId);
+    await touchSession(userId);
+    const status = await getSessionStatus(userId);
+    expect(status.locked).toBe(false);
+  });
+
+  it('flags extended idle for purge at 30 minutes', async () => {
+    const now = Date.now();
+    await touchSession(userId);
+    const status = await getSessionStatus(userId, now + DEFAULT_EXTENDED_IDLE_MS + 1000);
+    expect(status.shouldPurge).toBe(true);
+  });
+
+  it('refuses to unlock a purged (extended-idle) session', async () => {
+    const now = Date.now();
+    await touchSession(userId);
+    await lockSession(userId);
+    configureSessionMonitor({ idleLockMs: 0, extendedIdleMs: 1 });
+    expect(await unlockSession(userId)).toBe(false);
+    // Restore defaults for subsequent tests.
+    configureSessionMonitor({
+      idleLockMs: DEFAULT_IDLE_LOCK_MS,
+      extendedIdleMs: DEFAULT_EXTENDED_IDLE_MS,
+    });
+  });
+
+  it('purges the session: clears state and revokes tokens', async () => {
+    await touchSession(userId);
+    await lockSession(userId);
+
+    const terminated: string[] = [];
+    registerWebSocketTerminator(async (id: string) => {
+      terminated.push(id);
+    });
+
+    await purgeSession(userId);
+
+    expect(terminated).toContain(userId);
+    const status = await getSessionStatus(userId);
+    expect(status.locked).toBe(false);
+    expect(status.shouldPurge).toBe(false);
+  });
+
+  it('uses a configurable idle lock threshold', async () => {
+    configureSessionMonitor({ idleLockMs: 5 * 60 * 1000 });
+    const now = Date.now();
+    await touchSession(userId);
+    const status = await getSessionStatus(userId, now + 6 * 60 * 1000);
+    expect(status.idleLockThresholdMs).toBe(5 * 60 * 1000);
+    expect(status.idleMs).toBeGreaterThan(status.idleLockThresholdMs);
+  });
+});

--- a/backend/tests/stellarAddressValidator.test.ts
+++ b/backend/tests/stellarAddressValidator.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  decodeMuxedAddress,
+  identiconFromPublicKey,
+  parseFederationServer,
+  resolveFederationHandle,
+  validateStellarAddress,
+} from '../src/utils/stellarAddressValidator.js';
+
+// Verified StrKey test vectors (checksum-valid, from the stellar SDK test suites).
+const VALID_PUBLIC_KEY = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
+const VALID_SECRET_SEED = 'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY';
+const VALID_CONTRACT = 'CA2XT5OG4VUMHG773OQ5LHV57ZW3HZZNNZNBGOOOKMEYNXWXMNHXLWLJ';
+// Muxed address with memo id 0 wrapping VALID_PUBLIC_KEY's base address.
+const VALID_MUXED =
+  'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ';
+const MUXED_BASE_ADDRESS = 'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+
+describe('Stellar Address Validator (#1114)', () => {
+  describe('StrKey CRC16 checksum validation', () => {
+    it('accepts valid G... public keys', () => {
+      expect(validateStellarAddress(VALID_PUBLIC_KEY)).toEqual({
+        valid: true,
+        kind: 'public',
+        normalized: VALID_PUBLIC_KEY,
+      });
+    });
+
+    it('rejects public keys with corrupted checksums', () => {
+      // Flip the final character — CRC16-XDR check must fail.
+      const corrupted = VALID_PUBLIC_KEY.slice(0, -1) + 'X';
+      const result = validateStellarAddress(corrupted);
+      expect(result.valid).toBe(false);
+      expect(result.kind).toBe('invalid');
+      expect(result.reason).toMatch(/checksum/i);
+    });
+
+    it('accepts valid S... secret seeds and rejects bad ones', () => {
+      expect(validateStellarAddress(VALID_SECRET_SEED).kind).toBe('secret');
+      const corrupted = VALID_SECRET_SEED.slice(0, -1) + 'X';
+      expect(validateStellarAddress(corrupted).valid).toBe(false);
+    });
+
+    it('accepts valid C... contract addresses and rejects bad ones', () => {
+      expect(validateStellarAddress(VALID_CONTRACT).kind).toBe('contract');
+      const corrupted = VALID_CONTRACT.slice(0, -1) + 'X';
+      expect(validateStellarAddress(corrupted).valid).toBe(false);
+    });
+
+    it('rejects empty and unsupported input', () => {
+      expect(validateStellarAddress('').valid).toBe(false);
+      expect(validateStellarAddress('  ').valid).toBe(false);
+      expect(validateStellarAddress('X123456789').valid).toBe(false);
+      expect(validateStellarAddress('0xdeadbeef').valid).toBe(false);
+    });
+  });
+
+  describe('Muxed (M...) address decoding', () => {
+    it('recognizes muxed addresses and exposes base address + memo id', () => {
+      const result = validateStellarAddress(VALID_MUXED);
+      expect(result.valid).toBe(true);
+      expect(result.kind).toBe('muxed');
+      expect(result.memoId).toBe('0');
+      expect(result.baseAddress).toBe(MUXED_BASE_ADDRESS);
+    });
+
+    it('exposes the decoded 64-bit memo id via decodeMuxedAddress', () => {
+      const decoded = decodeMuxedAddress(VALID_MUXED);
+      expect(decoded.valid).toBe(true);
+      expect(decoded.memoId).toBe('0');
+      expect(decoded.baseAddress).toMatch(/^G/);
+      expect(decoded.baseAddress).toBe(MUXED_BASE_ADDRESS);
+    });
+
+    it('rejects malformed muxed addresses', () => {
+      const result = decodeMuxedAddress('MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+      expect(result.valid).toBe(false);
+      expect(result.kind).toBe('invalid');
+    });
+  });
+
+  describe('Federation handles (SEP-0010)', () => {
+    it('recognizes username*domain handles as federation kind', () => {
+      const result = validateStellarAddress('alice*example.com');
+      expect(result.valid).toBe(true);
+      expect(result.kind).toBe('federation');
+    });
+
+    it('rejects malformed federation handles', () => {
+      expect(validateStellarAddress('alice*').valid).toBe(false);
+      expect(validateStellarAddress('*example.com').valid).toBe(false);
+      expect(validateStellarAddress('alice@example.com').valid).toBe(false);
+    });
+
+    it('parses FEDERATION_SERVER from a stellar.toml document', () => {
+      const toml = [
+        'NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"',
+        'FEDERATION_SERVER = "https://federation.example.com"',
+        'ACCOUNTS = ["G..."]',
+      ].join('\n');
+      expect(parseFederationServer(toml)).toBe('https://federation.example.com');
+    });
+
+    it('rejects non-HTTPS federation servers', () => {
+      expect(parseFederationServer('FEDERATION_SERVER = "http://federation.example.com"')).toBeNull();
+    });
+
+    it('resolves a handle via the federation server and returns the account id', async () => {
+      const fakeFetch = async (url: string | URL | Request): Promise<Response> => {
+        const href = String(url);
+        if (href.endsWith('/.well-known/stellar.toml')) {
+          return new Response('FEDERATION_SERVER = "https://federation.example.com"', {
+            status: 200,
+          });
+        }
+        return new Response(JSON.stringify({ account: { id: VALID_PUBLIC_KEY } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      };
+
+      const account = await resolveFederationHandle(
+        'alice*example.com',
+        fakeFetch as unknown as typeof fetch,
+      );
+      expect(account).toBe(VALID_PUBLIC_KEY);
+    });
+
+    it('returns null when federation lookup fails', async () => {
+      const failingFetch = async (): Promise<Response> =>
+        new Response('not found', { status: 404 });
+
+      const account = await resolveFederationHandle(
+        'alice*example.com',
+        failingFetch as unknown as typeof fetch,
+      );
+      expect(account).toBeNull();
+    });
+
+    it('returns null for invalid handles without any network call', async () => {
+      const spyFetch = jest.fn();
+      const account = await resolveFederationHandle(
+        'not-a-handle',
+        spyFetch as unknown as typeof fetch,
+      );
+      expect(account).toBeNull();
+      expect(spyFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Deterministic identicon', () => {
+    it('renders a 25-cell symmetric grid from a public key', () => {
+      const grid = identiconFromPublicKey(VALID_PUBLIC_KEY);
+      expect(grid).not.toBeNull();
+      expect(grid).toHaveLength(25);
+      // Symmetry: column 0 mirrors column 4 in every row.
+      expect(grid![0]).toBe(grid![4]);
+      expect(grid![5]).toBe(grid![9]);
+    });
+
+    it('is deterministic for the same key and different for different keys', () => {
+      const first = identiconFromPublicKey(VALID_PUBLIC_KEY);
+      const second = identiconFromPublicKey(VALID_PUBLIC_KEY);
+      expect(first).toEqual(second);
+
+      const otherKey =
+        'GB7KKHHVYLDIZEKYJPAJUOTBE5E3NJAXPSDZK7O6O44WR3EBRO5HRPVT';
+      const other = identiconFromPublicKey(otherKey);
+      expect(other).not.toEqual(first);
+    });
+
+    it('returns null for invalid public keys', () => {
+      expect(identiconFromPublicKey('G123456789')).toBeNull();
+      expect(identiconFromPublicKey('')).toBeNull();
+    });
+  });
+});

--- a/backend/tests/workspaceRls.test.ts
+++ b/backend/tests/workspaceRls.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { NextFunction, Request, Response } from 'express';
+import { workspaceModels } from '../src/db/workspaceModels.js';
+import { validateWorkspaceMembership } from '../src/middleware/workspaceMembership.js';
+import { workspaceContextStorage } from '../src/middleware/WorkspaceContext.js';
+
+// Mock the DB module so the middleware can be tested without a database.
+const mockStudentFindUnique = jest.fn();
+const mockEnrollmentFindFirst = jest.fn();
+const mockLogAudit = jest.fn();
+
+jest.mock('../src/db/index.js', () => ({
+  __esModule: true,
+  default: {
+    student: { findUnique: (...args: unknown[]) => mockStudentFindUnique(...args) },
+    enrollment: { findFirst: (...args: unknown[]) => mockEnrollmentFindFirst(...args) },
+  },
+}));
+
+jest.mock('../src/utils/audit.js', () => ({
+  logAudit: (...args: unknown[]) => mockLogAudit(...args),
+}));
+
+const makeReq = (overrides: Partial<Request> = {}): Request =>
+  ({
+    path: '/api/v1/courses',
+    method: 'GET',
+    ip: '127.0.0.1',
+    get: jest.fn(() => 'jest'),
+    ...overrides,
+  }) as unknown as Request;
+
+const makeRes = (): Response & { statusCode: number; body: unknown } => {
+  const res = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  } as unknown as Response & { statusCode: number; body: unknown };
+  return res;
+};
+
+const runMiddleware = async (req: Request, res: Response): Promise<void> => {
+  await validateWorkspaceMembership(req, res, (() => undefined) as NextFunction);
+};
+
+describe('Workspace RLS (#1119)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspaceContextStorage.disable();
+  });
+
+  describe('workspaceModels coverage', () => {
+    it('includes every Prisma model that carries a workspaceId column', () => {
+      for (const model of [
+        'Student',
+        'Course',
+        'Certificate',
+        'CertificateVerificationEvent',
+        'ContributorProof',
+        'DecentralizedAsset',
+        'Enrollment',
+        'Feedback',
+        'Idea',
+        'LearningProgress',
+        'AuditLog',
+        'Canvas',
+        'NotificationPreferences',
+        'P2PNode',
+        'WebhookSubscription',
+        'TranslationEntry',
+        'VestingSchedule',
+      ]) {
+        expect(workspaceModels.has(model)).toBe(true);
+      }
+    });
+  });
+
+  describe('validateWorkspaceMembership', () => {
+    it('passes through when no workspace context is active', async () => {
+      const req = makeReq({ user: { id: 'user-1' } });
+      const res = makeRes();
+      await runMiddleware(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(mockStudentFindUnique).not.toHaveBeenCalled();
+    });
+
+    it('passes through when no authenticated user is present', async () => {
+      workspaceContextStorage.run('workspace-a', async () => {
+        const req = makeReq();
+        const res = makeRes();
+        await runMiddleware(req, res);
+        expect(res.statusCode).toBe(200);
+        expect(mockStudentFindUnique).not.toHaveBeenCalled();
+      });
+    });
+
+    it('passes for admins without querying the database', async () => {
+      workspaceContextStorage.run('workspace-a', async () => {
+        const req = makeReq({ user: { id: 'admin-1', role: 'admin' } });
+        const res = makeRes();
+        await runMiddleware(req, res);
+        expect(res.statusCode).toBe(200);
+        expect(mockStudentFindUnique).not.toHaveBeenCalled();
+      });
+    });
+
+    it('passes when the student belongs to the workspace', async () => {
+      workspaceContextStorage.run('workspace-a', async () => {
+        mockStudentFindUnique.mockResolvedValueOnce({ workspaceId: 'workspace-a' });
+        const req = makeReq({ user: { id: 'student-1' } });
+        const res = makeRes();
+        await runMiddleware(req, res);
+        expect(res.statusCode).toBe(200);
+        expect(mockEnrollmentFindFirst).not.toHaveBeenCalled();
+      });
+    });
+
+    it('passes when the student holds an active enrollment in the workspace', async () => {
+      workspaceContextStorage.run('workspace-b', async () => {
+        mockStudentFindUnique.mockResolvedValueOnce({ workspaceId: 'workspace-a' });
+        mockEnrollmentFindFirst.mockResolvedValueOnce({ id: 'enr-1' });
+        const req = makeReq({ user: { id: 'student-1' } });
+        const res = makeRes();
+        await runMiddleware(req, res);
+        expect(res.statusCode).toBe(200);
+        expect(mockEnrollmentFindFirst).toHaveBeenCalledWith({
+          where: { studentId: 'student-1', workspaceId: 'workspace-b', status: 'active' },
+          select: { id: true },
+        });
+      });
+    });
+
+    it('rejects with 403 and audits the violation when not enrolled', async () => {
+      workspaceContextStorage.run('workspace-b', async () => {
+        mockStudentFindUnique.mockResolvedValueOnce({ workspaceId: 'workspace-a' });
+        mockEnrollmentFindFirst.mockResolvedValueOnce(null);
+        const req = makeReq({ user: { id: 'student-1' } });
+        const res = makeRes();
+        await runMiddleware(req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({
+          error: 'Forbidden: you do not belong to this workspace',
+        });
+        expect(mockLogAudit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'student-1',
+            action: 'WORKSPACE_ACCESS_DENIED',
+            entity: 'Workspace',
+            entityId: 'workspace-b',
+          })
+        );
+      });
+    });
+
+    it('fails closed with 403 when the membership lookup errors', async () => {
+      workspaceContextStorage.run('workspace-b', async () => {
+        mockStudentFindUnique.mockRejectedValueOnce(new Error('db down'));
+        const req = makeReq({ user: { id: 'student-1' } });
+        const res = makeRes();
+        await runMiddleware(req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(mockLogAudit).toHaveBeenCalledWith(
+          expect.objectContaining({ action: 'WORKSPACE_ACCESS_DENIED' })
+        );
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -1,0 +1,214 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { API_BASE_URL } from '@/lib/api-config';
+
+/**
+ * Shape of a course-notification event pushed over the SSE stream.
+ * Mirrors `CourseNotification` in the backend notifications module.
+ */
+export interface NotificationStreamEvent {
+  id: string;
+  type: string;
+  userId?: string;
+  courseId?: string;
+  courseTitle?: string;
+  title: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+  read: boolean;
+  createdAt: string;
+}
+
+export type NotificationStreamState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected';
+
+export interface UseNotificationStreamOptions {
+  /** Backend base URL (defaults to the shared API_BASE_URL). */
+  url?: string;
+  /** Initial reconnect delay (ms). Default 1s. */
+  initialDelayMs?: number;
+  /** Maximum reconnect delay (ms). Default 30s. */
+  maxDelayMs?: number;
+  /** Reconnect attempts before giving up. Default 10. */
+  maxAttempts?: number;
+  /** Enable/disable auto-reconnect. Default true. */
+  autoReconnect?: boolean;
+  /** Callback for each notification event. */
+  onEvent?: (event: NotificationStreamEvent) => void;
+}
+
+export interface UseNotificationStreamReturn {
+  connectionState: NotificationStreamState;
+  lastEventId: string | null;
+  lastError: string | null;
+  reconnectAttempt: number;
+  /** Force-close the stream and clear state. */
+  close: () => void;
+}
+
+/**
+ * Real-time course notification hook backed by Server-Sent Events (#1122).
+ *
+ * - Connects to `GET /api/v1/notifications/stream` with the JWT as
+ *   `access_token` (EventSource cannot send Authorization headers).
+ * - Reconnects with **bounded exponential backoff + jitter**.
+ * - On reconnect, sends the last received event id via the `Last-Event-ID`
+ *   header, so notifications missed while disconnected are replayed by the
+ *   server instead of being lost forever.
+ */
+export function useNotificationStream(
+  options: UseNotificationStreamOptions = {},
+): UseNotificationStreamReturn {
+  const {
+    url = API_BASE_URL,
+    initialDelayMs = 1000,
+    maxDelayMs = 30_000,
+    maxAttempts = 10,
+    autoReconnect = true,
+    onEvent,
+  } = options;
+
+  const [connectionState, setConnectionState] =
+    useState<NotificationStreamState>('idle');
+  const [lastEventId, setLastEventId] = useState<string | null>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
+
+  const sourceRef = useRef<EventSource | null>(null);
+  const attemptsRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closedRef = useRef(false);
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  const close = useCallback(() => {
+    closedRef.current = true;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    sourceRef.current?.close();
+    sourceRef.current = null;
+    attemptsRef.current = 0;
+    setConnectionState('disconnected');
+  }, []);
+
+  useEffect(() => {
+    const token =
+      localStorage.getItem('token') ?? localStorage.getItem('auth_token');
+
+    if (!token) {
+      setConnectionState('idle');
+      return undefined;
+    }
+
+    closedRef.current = false;
+
+    // Read the persisted last-event id (localStorage survives reloads so
+    // reconnection recovery works across page refreshes, #1122).
+    const lastEventIdRef = {
+      current: localStorage.getItem('notif_last_event_id'),
+    };
+    setLastEventId(lastEventIdRef.current);
+
+    const connect = (): void => {
+      if (closedRef.current) {
+        return;
+      }
+
+      const streamUrl = new URL(`${url}/notifications/stream`);
+      streamUrl.searchParams.set('access_token', token);
+      // Last-Event-ID recovery (#1122): only send when we have seen events.
+      if (lastEventIdRef.current) {
+        streamUrl.searchParams.set('lastEventId', lastEventIdRef.current);
+      }
+
+      setConnectionState(
+        attemptsRef.current === 0 ? 'connecting' : 'reconnecting',
+      );
+
+      const source = new EventSource(streamUrl.toString());
+      sourceRef.current = source;
+
+      source.addEventListener('open', () => {
+        if (closedRef.current) {
+          source.close();
+          return;
+        }
+        attemptsRef.current = 0;
+        setReconnectAttempt(0);
+        setLastError(null);
+        setConnectionState('connected');
+      });
+
+      // Named `notification` event from the backend bridge.
+      source.addEventListener('notification', (raw) => {
+        const event = raw as MessageEvent<string>;
+        try {
+          const parsed = JSON.parse(event.data) as NotificationStreamEvent;
+          if (event.lastEventId) {
+            lastEventIdRef.current = event.lastEventId;
+            setLastEventId(event.lastEventId);
+          } else if (parsed.id) {
+            lastEventIdRef.current = parsed.id;
+            setLastEventId(parsed.id);
+          }
+          onEventRef.current?.(parsed);
+        } catch {
+          // Ignore malformed payloads.
+        }
+      });
+
+      source.onerror = () => {
+        source.close();
+        sourceRef.current = null;
+
+        if (closedRef.current || !autoReconnect) {
+          setConnectionState('disconnected');
+          return;
+        }
+
+        attemptsRef.current += 1;
+        setReconnectAttempt(attemptsRef.current);
+
+        if (attemptsRef.current > maxAttempts) {
+          setLastError('Reconnect attempts exhausted');
+          setConnectionState('disconnected');
+          return;
+        }
+
+        // Bounded exponential backoff with jitter (full jitter).
+        const cap = Math.min(
+          maxDelayMs,
+          initialDelayMs * 2 ** (attemptsRef.current - 1),
+        );
+        const delay = Math.floor(cap * (0.5 + Math.random() * 0.5));
+        timerRef.current = setTimeout(connect, delay);
+      };
+    };
+
+    connect();
+
+    return () => {
+      closedRef.current = true;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      sourceRef.current?.close();
+      sourceRef.current = null;
+      // Persist for the next mount so reconnection recovery works across
+      // reloads (#1122).
+      if (lastEventIdRef.current) {
+        localStorage.setItem('notif_last_event_id', lastEventIdRef.current);
+      }
+    };
+  }, [url, initialDelayMs, maxDelayMs, maxAttempts, autoReconnect]);
+
+  return { connectionState, lastEventId, lastError, reconnectAttempt, close };
+}

--- a/frontend/src/hooks/useSessionActivityMonitor.ts
+++ b/frontend/src/hooks/useSessionActivityMonitor.ts
@@ -1,0 +1,211 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { API_BASE_URL } from '@/lib/api-config';
+
+/**
+ * Session Activity Monitor hook (#1116).
+ *
+ * Protects shared lab terminals:
+ *
+ *  - Monitors mouse / keyboard / touch activity and reports it to the
+ *    backend (`POST /api/v1/auth/session/activity`) so idle time is tracked
+ *    server-side and survives reloads.
+ *  - After `idleLockMs` (default 15m) of inactivity the UI is blurred and a
+ *    re-authentication challenge is required to resume — without logging out.
+ *  - After `extendedIdleMs` (default 30m) the backend purges the session
+ *    (revokes tokens, terminates WebSocket channels); the hook then performs
+ *    a full logout so memory credentials are cleared.
+ *
+ * Usage:
+ * ```tsx
+ * const { locked, blur, reauthenticate, remainingIdleMs } =
+ *   useSessionActivityMonitor({ onPurged: logout });
+ * ```
+ */
+
+const DEFAULT_IDLE_LOCK_MS = 15 * 60 * 1000;
+const DEFAULT_EXTENDED_IDLE_MS = 30 * 60 * 1000;
+/** How often the client re-checks idle state while no events fire. */
+const CHECK_INTERVAL_MS = 30_000;
+/** Throttle activity POSTs so a burst of events is one request. */
+const ACTIVITY_POST_THROTTLE_MS = 60_000;
+
+export interface UseSessionActivityMonitorOptions {
+  idleLockMs?: number;
+  extendedIdleMs?: number;
+  /** Called when the session is purged by extended idle (full logout). */
+  onPurged?: () => void;
+  /** Called when the session is locked (blur UI, show re-auth). */
+  onLocked?: () => void;
+  /** Called when the session is unlocked after re-auth. */
+  onUnlocked?: () => void;
+  /** API base URL (defaults to shared API_BASE_URL). */
+  url?: string;
+}
+
+export interface UseSessionActivityMonitorReturn {
+  /** True while the session is locked (UI should blur sensitive views). */
+  locked: boolean;
+  /** Milliseconds remaining until the idle lock, null when unknown. */
+  remainingIdleMs: number | null;
+  /** Report activity manually (also wired to DOM events automatically). */
+  reportActivity: () => void;
+  /** Re-authenticate and unlock (call after PIN/biometric succeeds). */
+  reauthenticate: () => Promise<boolean>;
+  /** Lock the session immediately. */
+  lock: () => Promise<void>;
+  /** Full logout (purge memory credentials). */
+  purgeAndLogout: () => void;
+}
+
+export function useSessionActivityMonitor(
+  options: UseSessionActivityMonitorOptions = {},
+): UseSessionActivityMonitorReturn {
+  const {
+    idleLockMs = DEFAULT_IDLE_LOCK_MS,
+    extendedIdleMs = DEFAULT_EXTENDED_IDLE_MS,
+    onPurged,
+    onLocked,
+    onUnlocked,
+    url = API_BASE_URL,
+  } = options;
+
+  const [locked, setLocked] = useState(false);
+  const [remainingIdleMs, setRemainingIdleMs] = useState<number | null>(null);
+
+  const lastActivityRef = useRef<number>(Date.now());
+  const lastPostRef = useRef<number>(0);
+  const lockedRef = useRef(false);
+  const callbacksRef = useRef({ onPurged, onLocked, onUnlocked });
+  callbacksRef.current = { onPurged, onLocked, onUnlocked };
+
+  const getToken = (): string | null =>
+    localStorage.getItem('token') ?? localStorage.getItem('auth_token');
+
+  const reportActivity = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    if (lockedRef.current) {
+      return; // Locked sessions are only resumed via re-authentication.
+    }
+    setRemainingIdleMs(idleLockMs);
+
+    const token = getToken();
+    if (!token) {
+      return;
+    }
+    // Throttle network writes.
+    const now = Date.now();
+    if (now - lastPostRef.current < ACTIVITY_POST_THROTTLE_MS) {
+      return;
+    }
+    lastPostRef.current = now;
+    fetch(`${url}/auth/session/activity`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    }).catch(() => {
+      // Non-fatal: the client-side timer still protects the terminal.
+    });
+  }, [idleLockMs, url]);
+
+  const lock = useCallback(async () => {
+    lockedRef.current = true;
+    setLocked(true);
+    callbacksRef.current.onLocked?.();
+    const token = getToken();
+    if (token) {
+      fetch(`${url}/auth/session/lock`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }).catch(() => undefined);
+    }
+  }, [url]);
+
+  const reauthenticate = useCallback(async (): Promise<boolean> => {
+    const token = getToken();
+    if (!token) {
+      return false;
+    }
+    try {
+      const res = await fetch(`${url}/auth/session/unlock`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        // 423 = purged by extended idle — the session is gone.
+        callbacksRef.current.onPurged?.();
+        return false;
+      }
+      lockedRef.current = false;
+      setLocked(false);
+      lastActivityRef.current = Date.now();
+      callbacksRef.current.onUnlocked?.();
+      return true;
+    } catch {
+      return false;
+    }
+  }, [url]);
+
+  const purgeAndLogout = useCallback(() => {
+    const token = getToken();
+    if (token) {
+      fetch(`${url}/auth/session/purge`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }).catch(() => undefined);
+    }
+    // Clear memory credentials and any sensitive state.
+    localStorage.removeItem('token');
+    localStorage.removeItem('auth_token');
+    localStorage.removeItem('user');
+    sessionStorage.clear();
+    callbacksRef.current.onPurged?.();
+  }, [url]);
+
+  useEffect(() => {
+    // DOM activity listeners.
+    const events: (keyof WindowEventMap)[] = [
+      'mousemove',
+      'mousedown',
+      'keydown',
+      'touchstart',
+      'wheel',
+      'pointerdown',
+    ];
+    const handler = (): void => reportActivity();
+    for (const event of events) {
+      window.addEventListener(event, handler, { passive: true });
+    }
+
+    // Idle watchdog: lock after `idleLockMs`, purge after `extendedIdleMs`.
+    const interval = setInterval(() => {
+      const idle = Date.now() - lastActivityRef.current;
+      setRemainingIdleMs(Math.max(0, idleLockMs - idle));
+
+      if (!lockedRef.current && idle >= idleLockMs) {
+        void lock();
+      } else if (lockedRef.current && idle >= extendedIdleMs) {
+        purgeAndLogout();
+      }
+    }, CHECK_INTERVAL_MS);
+
+    return () => {
+      for (const event of events) {
+        window.removeEventListener(event, handler);
+      }
+      clearInterval(interval);
+    };
+  }, [reportActivity, lock, purgeAndLogout, idleLockMs, extendedIdleMs]);
+
+  return {
+    locked,
+    remainingIdleMs,
+    reportActivity,
+    reauthenticate,
+    lock,
+    purgeAndLogout,
+  };
+}


### PR DESCRIPTION
## Summary

Four Stellar Wave issues in one wave branch, one commit each:

- **#1114** — Universal Stellar address validator: StrKey CRC16-XDR checksums for `G`/`S`/`C`, `M` muxed decoding with 64-bit memo ids, SEP-0010 federation resolution over HTTPS, deterministic identicon renderer.
- **#1116** — Session activity monitor: Redis-backed idle tracking, 15m lock (blur + re-auth), 30m purge that revokes tokens and terminates WebSocket channels. Endpoints under `/api/v1/auth/session/*` plus a `useSessionActivityMonitor` hook.
- **#1119** — Multi-tenant workspace RLS: completes the `workspaceModels` set (5 missing models), mounts the workspace-context middleware so the Prisma extension actually filters, and adds `validateWorkspaceMembership` returning 403 + `WORKSPACE_ACCESS_DENIED` audit on cross-tenant attempts.
- **#1122** — SSE stream for course notifications: `GET /api/v1/notifications/stream` bridged over Redis Pub/Sub, heartbeats, `id:` lines and `Last-Event-ID` replay, plus a `useNotificationStream` hook with bounded exponential backoff.

Written by inspection (no deps installed, no tests run) following existing repo conventions; unit tests added alongside each change.

Closes #1114
Closes #1116
Closes #1119
Closes #1122