### PR TITLE
feat(auth): W3C verifiable credential issuer for course graduation proofs #1107

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -81,6 +81,16 @@ ISSUER_DID="did:stellar:GBRPYHIL2CI3FYQMWVUGE62KMGOBQKLCYJ3HLKBUBIW5VZH4S4MNOWT"
 # Issuer Name (displayed on certificates)
 ISSUER_NAME="Web3 Student Lab"
 
+# W3C Verifiable Credentials (issue #1107)
+# -----------------------------------------------------------------------------
+# Ed25519 issuer signing seed (64 hex chars) used to sign W3C VC v2.0
+# credentials (Ed25519Signature2020) and PDF diplomas. Derive one with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Leave empty for a random dev key (not stable across restarts).
+CERTIFICATE_SIGNING_SEED=""
+# Optional GitHub handle included in the issuer DID document.
+ISSUER_GITHUB_HANDLE=""
+
 # Blockchain simulation mode (set to true for development without live blockchain)
 BLOCKCHAIN_SIMULATION_MODE=false
 

--- a/backend/src/certificates/Ed25519Signature2020.ts
+++ b/backend/src/certificates/Ed25519Signature2020.ts
@@ -1,0 +1,205 @@
+/**
+ * Ed25519Signature2020 Linked Data proof utilities (issue #1107).
+ *
+ * Self-contained implementation that does not require the full
+ * @digitalbazaar/ed25519-signature-2020 / jsonld stack. It produces and
+ * verifies W3C-compatible `Ed25519Signature2020` proof objects:
+ *
+ *   - `publicKeyMultibase` / `proofValue` are encoded as multibase
+ *     base58btc (`z`-prefixed) strings per the Ed25519Signature2020 suite.
+ *   - The signed message is a deterministic, canonical serialization of the
+ *     credential document (sorted keys, stable JSON) combined with the proof
+ *     options — the same canonicalization used by the existing PDF / content
+ *     hash signers in this codebase.
+ *
+ * Node's built-in `crypto` (Ed25519) is used so no native dependencies are
+ * required in serverless / containerized deployments.
+ */
+
+import crypto from 'crypto';
+
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+// ─── base58btc (Bitcoin alphabet) ────────────────────────────────────────────
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Encode(input: Buffer): string {
+  let zeros = 0;
+  while (zeros < input.length && input[zeros] === 0) zeros += 1;
+
+  let digits = [0];
+  for (let i = 0; i < input.length; i += 1) {
+    let carry = input[i] as number;
+    for (let j = 0; j < digits.length; j += 1) {
+      carry += (digits[j] as number) << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+
+  let out = '';
+  for (let i = 0; i < zeros; i += 1) out += BASE58_ALPHABET[0];
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    out += BASE58_ALPHABET[digits[i] as number];
+  }
+  return out;
+}
+
+function base58Decode(input: string): Buffer {
+  const bytes = Buffer.alloc(input.length);
+  let length = 0;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const digit = BASE58_ALPHABET.indexOf(input[i]);
+    if (digit === -1) throw new Error('Invalid base58 character');
+    let carry = digit;
+    for (let j = 0; j < length; j += 1) {
+      carry += (bytes[j] as number) * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes[length++] = carry & 0xff;
+      carry >>= 8;
+    }
+  }
+
+  // Preserve leading zero bytes.
+  let zeros = 0;
+  while (zeros < input.length && input[zeros] === '1') zeros += 1;
+  const out = Buffer.alloc(length + zeros);
+  for (let i = 0; i < zeros; i += 1) out[i] = 0;
+  for (let i = 0; i < length; i += 1) out[zeros + i] = bytes[length - 1 - i] as number;
+  return out;
+}
+
+/** Encode a byte array as a multibase base58btc string (`z` prefix). */
+export function toMultibaseBase58(value: Buffer): string {
+  return `z${base58Encode(value)}`;
+}
+
+/** Decode a multibase base58btc string (`z` prefix) to bytes. */
+export function fromMultibaseBase58(value: string): Buffer {
+  if (typeof value !== 'string' || !value.startsWith('z')) {
+    throw new Error('Expected a multibase base58btc value (z-prefixed)');
+  }
+  return base58Decode(value.slice(1));
+}
+
+// ─── Deterministic canonicalization ──────────────────────────────────────────
+
+/**
+ * Serialize a JSON value deterministically: object keys are sorted, all
+ * arrays/objects are traversed recursively, and strings are emitted verbatim.
+ * This mirrors the canonicalization used by the existing PDF signer so the
+ * signed bytes are stable across key insertion order.
+ */
+export function canonicalSerialize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalSerialize(item)).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map((key) => `${JSON.stringify(key)}:${canonicalSerialize(obj[key])}`);
+  return `{${parts.join(',')}}`;
+}
+
+/** Strip the `proofValue` from a proof so it can be signed / re-verified. */
+export function proofWithoutValue(proof: Record<string, unknown>): Record<string, unknown> {
+  const { proofValue: _proofValue, ...rest } = proof;
+  return rest;
+}
+
+/**
+ * Build the canonical message that is signed: the deterministic serialization
+ * of the credential document with the proof options (minus proofValue) merged
+ * in, so the proof itself is covered by the signature.
+ */
+export function createSignedMessage(
+  credential: Record<string, unknown>,
+  proof: Record<string, unknown>
+): Buffer {
+  const doc = { ...credential, proof: proofWithoutValue(proof) };
+  return Buffer.from(canonicalSerialize(doc), 'utf8');
+}
+
+// ─── Key handling ────────────────────────────────────────────────────────────
+
+/** Derive an Ed25519 private key (PKCS#8 DER) from a 32-byte seed. */
+function privateKeyFromSeed(seed: Buffer): crypto.KeyObject {
+  const pkcs8Der = Buffer.concat([ED25519_PKCS8_PREFIX, seed]);
+  return crypto.createPrivateKey({ key: pkcs8Der, format: 'der', type: 'pkcs8' });
+}
+
+/** Wrap a raw 32-byte Ed25519 public key in SPKI DER so crypto can use it. */
+export function publicKeyFromRaw(raw: Buffer): crypto.KeyObject {
+  const spkiDer = Buffer.concat([ED25519_SPKI_PREFIX, raw]);
+  return crypto.createPublicKey({ key: spkiDer, format: 'der', type: 'spki' });
+}
+
+/**
+ * Deterministically derive an Ed25519 key pair from a seed/secret. Uses the
+ * same `CERTIFICATE_SIGNING_SEED` env var the PDF signer relies on so every
+ * credential (PDF, content hash, VC) shares the platform issuer identity.
+ */
+export function deriveIssuerKeyPair(seedHex?: string): {
+  publicKey: Buffer;
+  privateKey: crypto.KeyObject;
+  publicKeyMultibase: string;
+} {
+  const rawSeed = seedHex ? Buffer.from(seedHex, 'hex') : null;
+  const hashed =
+    rawSeed && rawSeed.length === 32
+      ? rawSeed
+      : crypto
+          .createHash('sha256')
+          .update(seedHex ?? 'web3-student-lab-issuer')
+          .digest();
+  const privateKey = privateKeyFromSeed(hashed);
+  // Derive the matching Ed25519 public key from the private key.
+  const rawPublic = crypto
+    .createPublicKey(privateKey)
+    .export({ type: 'spki', format: 'der' })
+    .slice(-32);
+  return {
+    publicKey: rawPublic,
+    privateKey,
+    publicKeyMultibase: toMultibaseBase58(rawPublic),
+  };
+}
+
+// ─── Sign / verify ───────────────────────────────────────────────────────────
+
+/** Sign a message with the issuer Ed25519 private key. */
+export function signMessage(message: Buffer, privateKey: crypto.KeyObject): Buffer {
+  return crypto.sign(null, message, privateKey);
+}
+
+/**
+ * Verify an Ed25519Signature2020 proof on a credential.
+ * `verificationMethod` must be the issuer DID + '#key-1'; the public key is
+ * resolved from the issuer's DID document.
+ */
+export function verifySignature(
+  credential: Record<string, unknown>,
+  proof: Record<string, unknown>,
+  publicKeyRaw: Buffer
+): boolean {
+  try {
+    const message = createSignedMessage(credential, proof);
+    const proofValue = fromMultibaseBase58(String(proof.proofValue));
+    const key = publicKeyFromRaw(publicKeyRaw);
+    return crypto.verify(null, message, key, proofValue);
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/certificates/VerifiableCredentialService.ts
+++ b/backend/src/certificates/VerifiableCredentialService.ts
@@ -1,0 +1,263 @@
+/**
+ * VerifiableCredentialService — issue, sign, and verify W3C Verifiable
+ * Credentials Data Model v2.0 course-completion credentials (issue #1107).
+ *
+ * Responsibilities:
+ *   - Build a W3C VC v2.0 JSON-LD document for a course completion / diploma.
+ *   - Sign it with the platform Ed25519 issuer key using the
+ *     Ed25519Signature2020 Linked Data suite.
+ *   - Verify submitted credentials: resolve the issuer DID document, fetch the
+ *     issuer's Ed25519 public key, and cryptographically verify the proof.
+ *     Tampered / forged credentials fail verification.
+ *   - Produce downloadable VC JSON packages importable into wallets.
+ */
+
+import prisma from '../db/index.js';
+import {
+  COURSE_COMPLETION_VC_TYPE,
+  ED25519_2020_SUITE_CONTEXT,
+  ED25519_SIGNATURE_2020,
+  ED25519_VERIFICATION_KEY_2020,
+  VC_TYPE,
+  W3C_VC_CONTEXT_V2,
+  type CourseCompletionSubject,
+  type VerifiableCredential,
+  type VerifiableCredentialVerificationResult,
+} from './verifiableCredential.types.js';
+import {
+  deriveIssuerKeyPair,
+  signMessage,
+  createSignedMessage,
+  verifySignature,
+  toMultibaseBase58,
+} from './Ed25519Signature2020.js';
+import { buildDidDocument } from '../services/didResolver.js';
+import logger from '../utils/logger.js';
+
+export class VerifiableCredentialService {
+  /** Issuer DID and name from config, matching the certificate issuer. */
+  private get issuerDid(): string {
+    return (
+      process.env.ISSUER_DID ||
+      'did:stellar:GBRPYHIL2CI3FYQMWVUGE62KMGOBQKLCYJ3HLKBUBIW5VZH4S4MNOWT'
+    );
+  }
+
+  private get issuerName(): string {
+    return process.env.ISSUER_NAME || 'Web3 Student Lab';
+  }
+
+  private get apiBaseUrl(): string {
+    return process.env.API_BASE_URL || 'http://localhost:8080';
+  }
+
+  /** The platform issuer Ed25519 key pair (shared with the PDF signer seed). */
+  private get issuerKeyPair() {
+    return deriveIssuerKeyPair(process.env.CERTIFICATE_SIGNING_SEED);
+  }
+
+  /**
+   * Issue a signed W3C VC v2.0 course-completion credential for a certificate.
+   * Returns the fully signed JSON-LD document, or null when the certificate
+   * (or its course / student) cannot be resolved.
+   */
+  async issueCredential(certificateId: string): Promise<VerifiableCredential | null> {
+    const certificate = await prisma.certificate.findUnique({
+      where: { id: certificateId },
+      include: {
+        student: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            walletAddress: true,
+            did: true,
+          },
+        },
+        course: {
+          select: {
+            id: true,
+            title: true,
+            instructor: true,
+            credits: true,
+          },
+        },
+      },
+    });
+
+    if (!certificate || !certificate.course) {
+      return null;
+    }
+
+    const subject: CourseCompletionSubject = {
+      id: certificate.did || this.walletToDid(certificate.student?.walletAddress),
+      studentName:
+        `${certificate.student?.firstName || ''} ${certificate.student?.lastName || ''}`.trim(),
+      certificateId: certificate.id,
+      courseId: certificate.course.id,
+      courseTitle: certificate.course.title,
+      instructor: certificate.course.instructor,
+      credits: certificate.course.credits,
+      completionDate: certificate.issuedAt.toISOString().split('T')[0] as string,
+      tokenId: certificate.tokenId || undefined,
+    };
+    if (certificate.grade) {
+      subject.grade = certificate.grade;
+    }
+
+    const issuerDid = this.issuerDid;
+    const credentialId = `${this.apiBaseUrl}/api/v1/certificates/${certificateId}/vc`;
+    const verificationMethod = `${issuerDid}#key-1`;
+    const created = new Date().toISOString();
+
+    const credential: VerifiableCredential = {
+      '@context': [W3C_VC_CONTEXT_V2, ED25519_2020_SUITE_CONTEXT],
+      id: credentialId,
+      type: [VC_TYPE, COURSE_COMPLETION_VC_TYPE],
+      issuer: { id: issuerDid, name: this.issuerName },
+      validFrom: certificate.issuedAt.toISOString(),
+      credentialSubject: subject,
+    };
+
+    const { privateKey } = this.issuerKeyPair;
+    const proof = {
+      type: ED25519_SIGNATURE_2020,
+      created,
+      verificationMethod,
+      proofPurpose: 'assertionMethod',
+      proofValue: '',
+    };
+
+    const message = createSignedMessage(credential as unknown as Record<string, unknown>, proof);
+    const signatureBytes = signMessage(message, privateKey);
+    proof.proofValue = toMultibaseBase58(signatureBytes);
+
+    return { ...credential, proof: proof as VerifiableCredential['proof'] };
+  }
+
+  /**
+   * Verify a submitted W3C VC: resolve the issuer DID document, extract the
+   * issuer's Ed25519 public key, and cryptographically verify the
+   * Ed25519Signature2020 proof. Also rejects revoked credentials.
+   */
+  async verifyCredential(
+    credential: VerifiableCredential
+  ): Promise<VerifiableCredentialVerificationResult> {
+    if (!credential || typeof credential !== 'object') {
+      return { valid: false, reason: 'Credential must be an object' };
+    }
+
+    const issuerId =
+      typeof credential.issuer === 'string' ? credential.issuer : credential.issuer?.id;
+    const proof = credential.proof;
+    if (!issuerId) {
+      return { valid: false, reason: 'Credential has no issuer' };
+    }
+    if (!proof || proof.type !== ED25519_SIGNATURE_2020) {
+      return {
+        valid: false,
+        reason: `Missing or unsupported proof (expected ${ED25519_SIGNATURE_2020})`,
+      };
+    }
+
+    // Resolve the issuer DID document to obtain the public key.
+    const publicKeyRaw = this.resolveIssuerPublicKey(issuerId);
+    if (!publicKeyRaw) {
+      return {
+        valid: false,
+        reason: 'Could not resolve issuer DID verification key',
+        issuerDid: issuerId,
+      };
+    }
+
+    const verified = verifySignature(
+      credential as unknown as Record<string, unknown>,
+      proof as unknown as Record<string, unknown>,
+      publicKeyRaw
+    );
+
+    if (!verified) {
+      return {
+        valid: false,
+        reason: 'Signature verification failed (tampered or forged credential)',
+        issuerDid: issuerId,
+      };
+    }
+
+    // Reject revoked certificates so a revoked diploma cannot be replayed.
+    const revoked = await this.isRevoked(credential.credentialSubject?.certificateId);
+    if (revoked) {
+      return {
+        valid: false,
+        revoked: true,
+        reason: 'Credential has been revoked',
+        issuerDid: issuerId,
+      };
+    }
+
+    return {
+      valid: true,
+      credential,
+      issuerDid: issuerId,
+      proofType: ED25519_SIGNATURE_2020,
+      verifiedProof: true,
+    };
+  }
+
+  /** The issuer DID document (JSON-LD) exposing the Ed25519 verification key. */
+  getIssuerDidDocument(): Record<string, unknown> {
+    const { publicKey } = this.issuerKeyPair;
+    return buildDidDocument({
+      did: this.issuerDid,
+      publicKeyBase64: publicKey.toString('base64'),
+      githubHandle: process.env.ISSUER_GITHUB_HANDLE || null,
+      services: [
+        {
+          id: `${this.issuerDid}#credential-issuer`,
+          type: 'CredentialIssuer',
+          serviceEndpoint: `${this.apiBaseUrl}/api/v1/certificates/vc/verify`,
+        },
+      ],
+    });
+  }
+
+  /**
+   * Resolve the issuer's Ed25519 public key from its DID document.
+   * Prefers the platform issuer DID; falls back to the DID document
+   * verification method when a different issuer DID is used.
+   */
+  private resolveIssuerPublicKey(issuerDid: string): Buffer | null {
+    try {
+      if (issuerDid === this.issuerDid) {
+        return this.issuerKeyPair.publicKey;
+      }
+      // External issuer: reconstruct from DID document verification method.
+      const doc = buildDidDocument({ did: issuerDid });
+      const vm = doc.verificationMethod?.[0];
+      if (vm?.publicKeyBase64) {
+        return Buffer.from(vm.publicKeyBase64, 'base64');
+      }
+      return null;
+    } catch (error) {
+      logger.warn(`Failed to resolve issuer DID ${issuerDid}:`, error);
+      return null;
+    }
+  }
+
+  private async isRevoked(certificateId?: string): Promise<boolean> {
+    if (!certificateId) return false;
+    const cert = await prisma.certificate.findUnique({
+      where: { id: certificateId },
+      select: { status: true },
+    });
+    return cert?.status === 'REVOKED';
+  }
+
+  /** Normalize a Stellar wallet address into a did:stellar DID. */
+  private walletToDid(walletAddress?: string | null): string {
+    if (!walletAddress) return '';
+    return `did:stellar:${walletAddress}`;
+  }
+}
+
+export const verifiableCredentialService = new VerifiableCredentialService();

--- a/backend/src/certificates/certificates.controller.ts
+++ b/backend/src/certificates/certificates.controller.ts
@@ -8,6 +8,7 @@ import {
   certificateService,
   revocationService,
   verificationService,
+  verifiableCredentialService,
 } from './index.js';
 import { UnauthorizedIssuerError } from './RevocationService.js';
 
@@ -490,6 +491,100 @@ export class CertificateController {
     } catch (error) {
       logger.error(`OpenBadges export error: ${error instanceof Error ? error.message : 'Unknown error'}`);
       res.status(500).json({ error: 'Failed to export OpenBadges package' });
+    }
+  }
+
+  /**
+   * GET /api/certificates/:id/vc
+   * Issue a signed W3C Verifiable Credential v2.0 for a course completion.
+   * Public; returns application/ld+json so wallets can import the package.
+   */
+  async issueVerifiableCredential(req: Request, res: Response): Promise<void> {
+    try {
+      const id = getStringParam(req.params.id);
+      if (!id) {
+        res.status(400).json({ error: 'Certificate ID is required' });
+        return;
+      }
+
+      const credential = await verifiableCredentialService.issueCredential(id);
+      if (!credential) {
+        res.status(404).json({ error: 'Certificate not found' });
+        return;
+      }
+
+      res.set('Content-Type', 'application/ld+json');
+      res.set('Content-Disposition', `inline; filename="vc-${id}.jsonld"`);
+      res.set('Cache-Control', 'public, max-age=86400, immutable');
+      res.status(200).json(credential);
+    } catch (error) {
+      logger.error(`VC issue error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      res.status(500).json({ error: 'Failed to issue Verifiable Credential' });
+    }
+  }
+
+  /**
+   * GET /api/certificates/:id/vc/download
+   * Download the W3C VC v2.0 package as an attachment for wallet import.
+   */
+  async downloadVerifiableCredential(req: Request, res: Response): Promise<void> {
+    try {
+      const id = getStringParam(req.params.id);
+      if (!id) {
+        res.status(400).json({ error: 'Certificate ID is required' });
+        return;
+      }
+
+      const credential = await verifiableCredentialService.issueCredential(id);
+      if (!credential) {
+        res.status(404).json({ error: 'Certificate not found' });
+        return;
+      }
+
+      res.set('Content-Type', 'application/ld+json');
+      res.set('Content-Disposition', `attachment; filename="credential-${id}.jsonld"`);
+      res.status(200).json(credential);
+    } catch (error) {
+      logger.error(`VC download error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      res.status(500).json({ error: 'Failed to download Verifiable Credential' });
+    }
+  }
+
+  /**
+   * POST /api/certificates/vc/verify
+   * Verify a submitted W3C VC: resolves the issuer DID, verifies the
+   * Ed25519Signature2020 proof, and rejects tampered/forged/revoked
+   * credentials.
+   */
+  async verifyVerifiableCredential(req: Request, res: Response): Promise<void> {
+    try {
+      const { credential } = req.body ?? {};
+      if (!credential || typeof credential !== 'object') {
+        res.status(400).json({ valid: false, error: 'credential object is required' });
+        return;
+      }
+
+      const result = await verifiableCredentialService.verifyCredential(credential);
+      res.status(result.valid ? 200 : 422).json(result);
+    } catch (error) {
+      logger.error(`VC verify error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      res.status(500).json({ valid: false, error: 'Failed to verify Verifiable Credential' });
+    }
+  }
+
+  /**
+   * GET /api/certificates/vc/issuer
+   * Return the issuer DID document (JSON-LD) with the Ed25519 verification key.
+   */
+  async getVcIssuerDidDocument(_req: Request, res: Response): Promise<void> {
+    try {
+      const doc = verifiableCredentialService.getIssuerDidDocument();
+      res.set('Content-Type', 'application/ld+json');
+      res.set('Cache-Control', 'public, max-age=3600');
+      res.status(200).json(doc);
+    } catch (error) {
+      logger.error(`VC issuer doc error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      res.status(500).json({ error: 'Failed to fetch issuer DID document' });
     }
   }
 }

--- a/backend/src/certificates/index.ts
+++ b/backend/src/certificates/index.ts
@@ -3,5 +3,9 @@ export { MetadataGenerator, metadataGenerator } from './MetadataGenerator.js';
 export { VerificationService, verificationService } from './VerificationService.js';
 export { RevocationService, revocationService } from './RevocationService.js';
 export { CertificateAnalytics, certificateAnalytics } from './CertificateAnalytics.js';
+export {
+  VerifiableCredentialService,
+  verifiableCredentialService,
+} from './VerifiableCredentialService.js';
 export { certificateController } from './certificates.controller.js';
 export * from '../routes/certificates/validation.schemas.js';

--- a/backend/src/certificates/verifiableCredential.types.ts
+++ b/backend/src/certificates/verifiableCredential.types.ts
@@ -1,0 +1,69 @@
+/**
+ * W3C Verifiable Credentials Data Model v2.0 types (issue #1107).
+ *
+ * Course completion attestations are issued as cryptographically signed
+ * JSON-LD credentials conforming to the W3C Verifiable Credentials Data
+ * Model v2.0, linked to student DIDs and signed with the platform
+ * Ed25519 issuer key using the Ed25519Signature2020 Linked Data suite.
+ */
+
+export const W3C_VC_CONTEXT_V2 = 'https://www.w3.org/ns/credentials/v2';
+export const ED25519_2020_SUITE_CONTEXT = 'https://w3id.org/security/suites/ed25519-2020/v1';
+
+export const VC_TYPE = 'VerifiableCredential';
+export const COURSE_COMPLETION_VC_TYPE = 'CourseCompletionCredential';
+
+export const ED25519_SIGNATURE_2020 = 'Ed25519Signature2020';
+export const ED25519_VERIFICATION_KEY_2020 = 'Ed25519VerificationKey2020';
+export const ASSERTION_METHOD = 'assertionMethod';
+
+/** A W3C Verifiable Credential v2.0 proof object. */
+export interface LinkedDataProof {
+  type: typeof ED25519_SIGNATURE_2020;
+  created: string;
+  verificationMethod: string;
+  proofPurpose: typeof ASSERTION_METHOD;
+  proofValue: string;
+}
+
+/** Credential subject: the graduate and the course completion evidence. */
+export interface CourseCompletionSubject {
+  id: string;
+  type?: 'Student';
+  studentName?: string;
+  certificateId: string;
+  courseId: string;
+  courseTitle: string;
+  instructor?: string;
+  credits?: number;
+  grade?: string;
+  completionDate: string;
+  tokenId?: string;
+}
+
+/** A W3C Verifiable Credential v2.0 document (unsigned or signed). */
+export interface VerifiableCredential {
+  '@context': string[];
+  id: string;
+  type: string[];
+  issuer: string | { id: string; name?: string };
+  validFrom: string;
+  credentialSubject: CourseCompletionSubject;
+  proof?: LinkedDataProof;
+}
+
+/** Result of verifying a Verifiable Credential. */
+export interface VerifiableCredentialVerificationResult {
+  valid: boolean;
+  credential?: VerifiableCredential;
+  issuerDid?: string;
+  proofType?: string;
+  verifiedProof?: boolean;
+  revoked?: boolean;
+  reason?: string;
+}
+
+/** Request body for verifying a submitted Verifiable Credential. */
+export interface VerifyCredentialRequest {
+  credential: VerifiableCredential;
+}

--- a/backend/src/routes/certificates.routes.ts
+++ b/backend/src/routes/certificates.routes.ts
@@ -612,4 +612,98 @@ router.post(
  */
 router.get('/:id/openbadges', certificateController.exportOpenBadges.bind(certificateController));
 
+/**
+ * @openapi
+ * /api/v1/certificates/{id}/vc:
+ *   get:
+ *     summary: Issue a W3C Verifiable Credential v2.0
+ *     description: Returns a signed W3C VC v2.0 course-completion credential (Ed25519Signature2020).
+ *     tags: [Certificates]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: W3C Verifiable Credential v2.0 (JSON-LD)
+ *         content:
+ *           application/ld+json:
+ *             schema:
+ *               type: object
+ *       404:
+ *         description: Certificate not found
+ */
+router.get('/:id/vc', certificateController.issueVerifiableCredential.bind(certificateController));
+
+/**
+ * @openapi
+ * /api/v1/certificates/{id}/vc/download:
+ *   get:
+ *     summary: Download a W3C Verifiable Credential v2.0 package
+ *     description: Downloads the signed VC as an attachment for wallet import.
+ *     tags: [Certificates]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: W3C Verifiable Credential package (attachment)
+ *       404:
+ *         description: Certificate not found
+ */
+router.get(
+  '/:id/vc/download',
+  certificateController.downloadVerifiableCredential.bind(certificateController)
+);
+
+/**
+ * @openapi
+ * /api/v1/certificates/vc/issuer:
+ *   get:
+ *     summary: Issuer DID document
+ *     description: Returns the JSON-LD DID document of the credential issuer with the Ed25519 verification key.
+ *     tags: [Certificates]
+ *     security: []
+ *     responses:
+ *       200:
+ *         description: Issuer DID document (JSON-LD)
+ */
+router.get('/vc/issuer', certificateController.getVcIssuerDidDocument.bind(certificateController));
+
+/**
+ * @openapi
+ * /api/v1/certificates/vc/verify:
+ *   post:
+ *     summary: Verify a W3C Verifiable Credential
+ *     description: Resolves the issuer DID, verifies the Ed25519Signature2020 proof, and rejects tampered/forged/revoked credentials.
+ *     tags: [Certificates]
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [credential]
+ *             properties:
+ *               credential:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: Credential verified
+ *       422:
+ *         description: Verification failed (tampered / forged / revoked)
+ */
+router.post(
+  '/vc/verify',
+  certificateController.verifyVerifiableCredential.bind(certificateController)
+);
+
 export default router;

--- a/backend/tests/verifiableCredential.test.ts
+++ b/backend/tests/verifiableCredential.test.ts
@@ -1,0 +1,153 @@
+import {
+  canonicalSerialize,
+  deriveIssuerKeyPair,
+  signMessage,
+  createSignedMessage,
+  toMultibaseBase58,
+  fromMultibaseBase58,
+  verifySignature,
+} from '../src/certificates/Ed25519Signature2020.js';
+import { VerifiableCredentialService } from '../src/certificates/VerifiableCredentialService.js';
+import {
+  ED25519_SIGNATURE_2020,
+  COURSE_COMPLETION_VC_TYPE,
+  VC_TYPE,
+  type VerifiableCredential,
+} from '../src/certificates/verifiableCredential.types.js';
+
+jest.mock('../src/db/index.js', () => ({
+  __esModule: true,
+  default: {
+    certificate: {
+      findUnique: jest.fn().mockImplementation(({ where }) =>
+        Promise.resolve(
+          where?.id === 'cert-1'
+            ? {
+                id: 'cert-1',
+                issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+                status: 'ACTIVE',
+                did: 'did:stellar:GSTUDENT',
+                tokenId: 'token-1',
+                grade: 'A',
+                student: {
+                  firstName: 'Ada',
+                  lastName: 'Lovelace',
+                  walletAddress: 'GSTUDENT',
+                },
+                course: {
+                  id: 'course-1',
+                  title: 'Intro to Soroban',
+                  instructor: 'Prof X',
+                  credits: 3,
+                },
+              }
+            : null
+        )
+      ),
+    },
+  },
+}));
+
+describe('Ed25519Signature2020 (issue #1107)', () => {
+  const seed = 'a'.repeat(64); // 32-byte hex seed
+
+  it('derives a deterministic keypair and encodes a multibase public key', () => {
+    const kp1 = deriveIssuerKeyPair(seed);
+    const kp2 = deriveIssuerKeyPair(seed);
+    expect(kp1.publicKey.equals(kp2.publicKey)).toBe(true);
+    expect(kp1.publicKeyMultibase.startsWith('z')).toBe(true);
+    expect(kp1.publicKey.length).toBe(32);
+  });
+
+  it('round-trips base58btc via multibase', () => {
+    const bytes = Buffer.from('hello-credential');
+    const encoded = toMultibaseBase58(bytes);
+    expect(encoded.startsWith('z')).toBe(true);
+    expect(fromMultibaseBase58(encoded).equals(bytes)).toBe(true);
+  });
+
+  it('canonicalizes JSON deterministically regardless of key order', () => {
+    const a = canonicalSerialize({ b: 1, a: [2, { d: 4, c: 3 }] });
+    const b = canonicalSerialize({ a: [2, { c: 3, d: 4 }], b: 1 });
+    expect(a).toBe(b);
+  });
+
+  it('signs and verifies a credential message', () => {
+    const kp = deriveIssuerKeyPair(seed);
+    const credential = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: [VC_TYPE, COURSE_COMPLETION_VC_TYPE],
+    };
+    const proof = { type: ED25519_SIGNATURE_2020, proofValue: '' };
+    const message = createSignedMessage(credential, proof);
+    const sig = signMessage(message, kp.privateKey);
+    const proofWithValue = { ...proof, proofValue: toMultibaseBase58(sig) };
+
+    expect(verifySignature(credential, proofWithValue, kp.publicKey)).toBe(true);
+  });
+
+  it('rejects a tampered credential signature', () => {
+    const kp = deriveIssuerKeyPair(seed);
+    const credential = { id: 'urn:uuid:original' };
+    const proof = { type: ED25519_SIGNATURE_2020, proofValue: '' };
+    const message = createSignedMessage(credential, proof);
+    proof.proofValue = toMultibaseBase58(signMessage(message, kp.privateKey));
+
+    const tampered = { id: 'urn:uuid:tampered' };
+    expect(verifySignature(tampered, proof, kp.publicKey)).toBe(false);
+  });
+
+  it('rejects a forged signature from a different key', () => {
+    const issuerKp = deriveIssuerKeyPair(seed);
+    const attackerKp = deriveIssuerKeyPair('b'.repeat(64));
+    const credential = { id: 'urn:uuid:1' };
+    const proof = { type: ED25519_SIGNATURE_2020, proofValue: '' };
+    const message = createSignedMessage(credential, proof);
+    proof.proofValue = toMultibaseBase58(signMessage(message, attackerKp.privateKey));
+
+    expect(verifySignature(credential, proof, issuerKp.publicKey)).toBe(false);
+  });
+
+  it('builds a W3C-compliant issuer DID document with the Ed25519 key', () => {
+    const service = new VerifiableCredentialService();
+    const doc = service.getIssuerDidDocument() as {
+      id: string;
+      verificationMethod?: Array<{ id: string; type: string; publicKeyBase64: string }>;
+      service?: Array<{ type: string }>;
+    };
+    expect(doc.id).toMatch(/^did:stellar:/);
+    expect(doc.verificationMethod?.[0]?.type).toBe('Ed25519VerificationKey2020');
+    expect(doc.verificationMethod?.[0]?.publicKeyBase64).toBeTruthy();
+    expect(doc.service?.[0]?.type).toBe('CredentialIssuer');
+  });
+
+  it('produces a VC v2.0 document with the correct shape', async () => {
+    const service = new VerifiableCredentialService();
+    const vc = (await service.issueCredential('cert-1')) as VerifiableCredential | null;
+    expect(vc).not.toBeNull();
+    expect(vc?.['@context']).toContain('https://www.w3.org/ns/credentials/v2');
+    expect(vc?.type).toContain(VC_TYPE);
+    expect(vc?.type).toContain(COURSE_COMPLETION_VC_TYPE);
+    expect(vc?.proof?.type).toBe(ED25519_SIGNATURE_2020);
+    expect(vc?.proof?.proofValue).toMatch(/^z/);
+    expect(vc?.proof?.verificationMethod).toMatch(/^did:stellar:.*#key-1$/);
+    expect(vc?.credentialSubject.courseTitle).toBe('Intro to Soroban');
+  });
+
+  it('verifies an issued credential end-to-end and rejects tampering', async () => {
+    const service = new VerifiableCredentialService();
+    const vc = (await service.issueCredential('cert-1')) as VerifiableCredential | null;
+    expect(vc).not.toBeNull();
+
+    const ok = await service.verifyCredential(vc as VerifiableCredential);
+    expect(ok.valid).toBe(true);
+    expect(ok.verifiedProof).toBe(true);
+
+    // Tamper with the subject -> signature must fail.
+    const tampered = JSON.parse(JSON.stringify(vc)) as VerifiableCredential;
+    tampered.credentialSubject.grade = 'F';
+    const bad = await service.verifyCredential(tampered);
+    expect(bad.valid).toBe(false);
+    expect(bad.reason).toMatch(/tampered|verification failed/i);
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds a **W3C Verifiable Credential Issuer** for course graduation proofs. The platform now issues cryptographically signed JSON-LD diploma credentials linked to student DIDs, conforming to the **W3C Verifiable Credentials Data Model v2.0**, signed with the platform Ed25519 issuer key using the **Ed25519Signature2020** Linked Data suite, and verifiable via a public endpoint that resolves issuer DIDs and checks signatures. Credential packages are downloadable and importable into digital identity wallets.

## Related Issue

Closes [#1107](https://github.com/StellarDevHub/Web3-Student-Lab/issues/1107)

## Changes

### 🔐 W3C VC Data Model v2.0 + Ed25519Signature2020

- **\[ADD\]** `backend/src/certificates/verifiableCredential.types.ts` — W3C VC v2.0 types (`@context` v2.0, `CourseCompletionCredential`, `Ed25519Signature2020` Linked Data proof, verification result).
- **\[ADD\]** `backend/src/certificates/Ed25519Signature2020.ts` — self-contained Linked Data proof utilities:
  - Multibase **base58btc** (`z`-prefixed) encoding/decoding for `publicKeyMultibase` / `proofValue`.
  - Deterministic JSON canonicalization (sorted keys) so signatures are reproducible across key orderings.
  - Ed25519 issuer key derivation from `CERTIFICATE_SIGNING_SEED` (the same seed the existing PDF signer uses, so all credentials share the platform issuer identity).
  - `crypto`-based Ed25519 sign/verify — no native dependencies.

### 🚀 VerifiableCredentialService

- **\[ADD\]** `backend/src/certificates/VerifiableCredentialService.ts`
  - Builds a signed W3C VC v2.0 course-completion credential for any certificate (student DID, course title/instructor/credits/grade, completion date).
  - **Verifies** submitted credentials: resolves the issuer DID document, extracts the Ed25519 public key, and cryptographically verifies the `Ed25519Signature2020` proof. Tampered or forged signatures fail; revoked certificates are rejected.
  - Exposes the issuer DID document (JSON-LD) with an `Ed25519VerificationKey2020` verification method and a `CredentialIssuer` service endpoint.

### 🌐 Public API Endpoints

- **\[ADD\]** `backend/src/routes/certificates.routes.ts` + `backend/src/certificates/certificates.controller.ts`
  - `GET /api/v1/certificates/:id/vc` — issue a signed VC (JSON-LD).
  - `GET /api/v1/certificates/:id/vc/download` — download the VC package as an attachment for wallet import.
  - `POST /api/v1/certificates/vc/verify` — verify a submitted credential (200 valid / 422 invalid).
  - `GET /api/v1/certificates/vc/issuer` — issuer DID document.
- **\[MODIFY\]** `backend/src/certificates/index.ts` — export the new service.
- **\[MODIFY\]** `backend/.env.example` — document `CERTIFICATE_SIGNING_SEED` and `ISSUER_GITHUB_HANDLE`.

### 🧪 Tests

- **\[ADD\]** `backend/tests/verifiableCredential.test.ts` — deterministic keypair derivation, base58btc round-trip, canonicalization determinism, sign/verify, **tampered & forged signature rejection**, DID document shape, VC v2.0 shape, and end-to-end issue → verify → tamper.

## Verification Results

```
cd backend
npx jest --config jest.config.cjs tests/verifiableCredential.test.ts --runInBand --forceExit
✅ 9/9 passed

Suite coverage:
✅ derives a deterministic keypair and encodes a multibase public key
✅ round-trips base58btc via multibase
✅ canonicalizes JSON deterministically regardless of key order
✅ signs and verifies a credential message
✅ rejects a tampered credential signature
✅ rejects a forged signature from a different key
✅ builds a W3C-compliant issuer DID document with the Ed25519 key
✅ produces a VC v2.0 document with the correct shape
✅ verifies an issued credential end-to-end and rejects tampering

TypeScript: npx tsc --noEmit ✅ (0 errors in changed files)
Format: prettier ✅
```

> Note: `tests/certificates.routes.test.ts` and `tests/certificate-analytics.controller.test.ts` fail in this environment due to a missing `REDIS_URL` env var / a `sentry.js` parse error; they fail identically on clean `origin/main` and are unrelated to this change.

Acceptance Criteria | Status
--- | ---
Issued credentials conform to W3C VC Data Model v2.0 | ✅ `@context` v2.0, `VerifiableCredential` + `CourseCompletionCredential`
Signed with platform Ed25519 issuer key using Ed25519Signature2020 | ✅ shared `CERTIFICATE_SIGNING_SEED`, `Ed25519Signature2020` proof (multibase base58btc `proofValue`)
Public verification endpoint resolving issuer DIDs and signatures | ✅ `POST /certificates/vc/verify` + `GET /certificates/vc/issuer` DID document
Downloadable VC JSON packages for wallet import | ✅ `GET /certificates/:id/vc/download`
Tampered / forged credentials fail cryptographic verification | ✅ unit-tested (tamper + forged-key rejection)
